### PR TITLE
Feature/inert file classification

### DIFF
--- a/.fluencyloop/constitution.md
+++ b/.fluencyloop/constitution.md
@@ -1,0 +1,11 @@
+# Constitution
+
+Source of truth: `.specify/memory/constitution.md`
+
+Blastradius keeps its constitution under SpecKit, where it is versioned and carries a Sync
+Impact Report. FluencyLoop features are checked against the principles in that file — this
+pointer exists so the FluencyLoop workflow resolves to the same, single source of truth
+rather than a drifting duplicate.
+
+To change a principle, amend `.specify/memory/constitution.md` in place (bump its version,
+update its Sync Impact Report). Do not add principles here.

--- a/.fluencyloop/features/inert-file-classification/design.md
+++ b/.fluencyloop/features/inert-file-classification/design.md
@@ -1,0 +1,81 @@
+# Design: inert-file classification
+
+started: 2026-07-11
+
+Add a third `FileKind.INERT` for changed files that provably cannot affect any test outcome
+(docs, LICENSE, images). The elegance: **INERT needs no change to the selection logic.** The
+fallback triggers only on `NON_SOURCE`, and dependency-matching contributes only from
+`JAVA_SOURCE`. An `INERT` file is neither — so it triggers no fallback and matches no test,
+and a change that is only inert selects **zero** tests, for free.
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class FileKind {
+    <<enumeration>>
+    JAVA_SOURCE
+    NON_SOURCE
+    INERT
+  }
+  class ChangedFileClassifier {
+    +classify(repo, base, head) List~ChangedFile~
+    -classifyPath(path) ChangedFile
+    -isInert(path) boolean
+  }
+  class ChangedFile {
+    +path
+    +kind FileKind
+    +changedClassName
+  }
+  class FallbackSelector {
+    +shouldFallback(files) boolean
+  }
+  ChangedFileClassifier --> ChangedFile : builds
+  ChangedFile --> FileKind
+  FallbackSelector ..> ChangedFile : triggers on NON_SOURCE only
+```
+
+## Sequence: a README-only change selects zero tests
+
+```mermaid
+sequenceDiagram
+  participant Diff as diff (README.md)
+  participant Cls as ChangedFileClassifier
+  participant Eng as SelectionEngine
+  participant Fb as FallbackSelector
+  Diff->>Cls: classify(base, head)
+  Cls->>Cls: classifyPath("README.md") — isInert? yes
+  Cls-->>Eng: [ChangedFile(README.md, INERT)]
+  Eng->>Fb: shouldFallback? (any NON_SOURCE)
+  Fb-->>Eng: false — INERT is not NON_SOURCE
+  Eng->>Eng: changedClassNames = JAVA_SOURCE only → empty
+  Eng-->>Diff: 0 tests selected
+```
+
+## Constitution check (`.specify/memory/constitution.md`, via the `.fluencyloop` pointer)
+
+- **§III (Sound by default):** the allowlist MUST be conservative — only paths that *provably*
+  cannot affect a test outcome. A false "inert" call skips tests that should run.
+- **§IV (Deterministic core):** a fixed path allowlist, not a probabilistic guess. ✓
+- **§V (Explainability):** the surfaced reason for an inert file is "matched no executable
+  scope (inert path)", not an opaque score. ✓
+
+## Allowlist scope (resolved)
+
+An allowlist, never a blocklist: anything not provably inert stays `NON_SOURCE` (fallback),
+so INERT only ever *narrows* to zero for provably-safe paths. **Anything under
+`**/resources/**` is excluded** — a Markdown/YAML/image there could be test data a test
+loads, and dependency tracking (class loads only) can't see it, so it must fall back.
+
+INERT (and not under `**/resources/**`) when the path matches:
+
+- **Docs:** `*.md`, `*.markdown`, `*.adoc`, `*.rst`; and `README*`, `LICENSE*`, `NOTICE*`,
+  `AUTHORS*`, `CHANGELOG*`, `CONTRIBUTING*`, `CODE_OF_CONDUCT*`, `SECURITY*`; `docs/**`
+- **Media:** `*.png`, `*.jpg`, `*.jpeg`, `*.gif`, `*.svg`, `*.ico`, `*.webp`
+- **VCS/editor/CI/IDE metadata:** `.gitignore`, `.gitattributes`, `.mailmap`, `.editorconfig`,
+  `.github/**`, `.idea/**`, `.vscode/**`, `*.iml`
+
+**Hard boundary — these stay `NON_SOURCE` (can affect a test outcome):** `pom.xml`,
+`*.properties`, non-`.github` `*.yml`/`*.yaml`, `*.sql`, `.mvn/**`, `mvnw`, and everything
+under `**/resources/**`.

--- a/.fluencyloop/features/inert-file-classification/sessions/classify-inert-paths-without-touching-the-selection-engine.md
+++ b/.fluencyloop/features/inert-file-classification/sessions/classify-inert-paths-without-touching-the-selection-engine.md
@@ -1,0 +1,36 @@
+# Session: classify inert paths without touching the selection engine
+
+intent:   classify inert paths without touching the selection engine
+started:  2026-07-11
+
+---
+
+## Decision: model INERT as a third FileKind, changing no selection code
+
+where:        blastradius-core/.../git/FileKind.java, core/selection/SelectionEngine.java
+why:          the fallback rule triggers only on NON_SOURCE and dependency-matching draws
+              class names only from JAVA_SOURCE. An INERT file is neither, so the existing
+              engine already yields "no fallback, no match" — zero tests — for an inert-only
+              change, with no new branch. Inert is safe *by construction*, not by an added rule.
+alternative:  add an explicit "select nothing for inert" branch in SelectionEngine/FallbackSelector
+              — rejected: more code, another branch to keep sound, and it makes it *possible* to
+              accidentally fall back on an inert change; the by-construction approach makes that
+              impossible.
+design:       ../design.md#sequence-a-readme-only-change-selects-zero-tests
+constitution: §III (sound by default) — inert selects zero without weakening the fallback
+trust:        ✓ verified — 45/45 core tests green; existing selection tests pass unchanged, and
+              SelectionEngineTest.inertOnlyChangeSelectsNoTestsAndDoesNotFallback locks the promise.
+
+## Decision: allowlist that excludes anything under resources/
+
+where:        blastradius-core/.../git/ChangedFileClassifier.isInert
+why:          a Markdown/YAML/image under a resources/ directory can be test data a test loads
+              at runtime; class-load tracking only records *class* loads, so that change is
+              invisible to it — exactly why NON_SOURCE→fallback exists. Classifying it INERT
+              would skip tests that depend on it. So isInert returns false for any resources/
+              path, and inert is an allowlist (unmatched → NON_SOURCE), never a blocklist.
+alternative:  blanket extension match (e.g. any *.md → INERT) — rejected: unsound; a `.md`
+              fixture under src/test/resources would wrongly select nothing.
+constitution: §III (a false "inert" call skips tests that should run) and §IV (deterministic
+              path rule, not a probabilistic guess)
+trust:        ✓ verified — guarded by ChangedFileClassifierTest.markdownUnderResourcesIsNonSourceNotInert.

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ target/
 .idea/
 .DS_Store
 dependency-reduced-pom.xml
+
+# FluencyLoop: calibration is per-developer and never committed
+.fluencyloop/**/calibration.md
+.fluencyloop/scripts/
+.fluencyloop/templates/

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,45 +1,28 @@
 <!--
 Sync Impact Report
 ==================
-Version change: 1.0.0 → 2.0.0 (MAJOR — principle removal + principle redefinition)
+Version change: 2.0.0 → 2.1.0 (MINOR — Principle III materially refined)
 Modified principles:
-  - III. Safety Over Speed (NON-NEGOTIABLE) → III. Safety Over Speed
-    (no longer NON-NEGOTIABLE; rationale and body rewritten around a complementary
-    daily full-test-suite-portfolio practice as the safety backstop, replacing the
-    prior "soundness is non-negotiable, speed MUST NOT be traded against it" framing)
-Removed principles:
-  - V. Shadow-Mode Before Gating (NON-NEGOTIABLE) — removed entirely, per explicit
-    user direction (2026-07-09). Shadow-mode validation remains valid, already-
-    completed historical work (see SESSION.md, specs/001-shadow-mode-validator/) but
-    is no longer a constitutionally-mandated prerequisite gate before a selection
-    capability may gate real CI, and is no longer the project's advertised trust
-    mechanism.
-Renumbered principles (following the removal of V):
-  - VI. Explainability → V. Explainability (content unchanged except one internal
-    cross-reference, see below)
-  - VII. Maintainable, Modern Foundations → VI. Maintainable, Modern Foundations
-    (content unchanged)
-Added sections: none
-Removed sections:
-  - Development Workflow & Quality Gates: removed the bullet requiring a shadow-mode
-    validation plan before a feature "may be considered for gating behavior" — that
-    gate no longer exists now that Principle V is removed.
-Other edits:
-  - V. Explainability's rationale previously ended "...which is essential to earning
-    the trust Principle V requires evidence for" — reworded to stand on its own
-    without a dangling reference to the removed principle.
+  - III. Safety Over Speed — added the inert-change carve-out: a change that provably
+    cannot affect any test outcome (documentation, license text, images, and other
+    non-executable files never loaded as classes) MUST NOT trigger the conservative
+    full-scope fallback; the sound selection for it is zero tests. The carve-out stays
+    deterministic and explainable (Principles IV, V) — inert files are recognized by a
+    fixed path classification, not a probabilistic guess — so soundness is not weakened:
+    an inert change has no test that could catch it.
+    Rationale: the current binary classifier (ChangedFileClassifier: JAVA_SOURCE vs
+    NON_SOURCE) routes provably-inert changes such as a README edit to a full-suite run,
+    which is wasteful, not safer.
+Added principles: none
+Removed principles: none
+Added/removed sections: none
 Templates requiring updates:
-  - ✅ .specify/templates/plan-template.md — no changes needed; Constitution Check
-    gate is derived dynamically from this file, no hardcoded principle names found
-  - ✅ .specify/templates/spec-template.md — no hardcoded principle references found
-  - ✅ .specify/templates/tasks-template.md — no hardcoded principle references found
-  - ⚠ specs/002-ci-gating-plugin/ (spec.md, plan.md, research.md) — explicitly frame
-    the feature as satisfying/inheriting Principle V's shadow-mode gate; the user has
-    asked for these to be updated separately, after this amendment lands
-  - ⚠ README.md — advertises shadow-mode as the trust mechanism; the user has asked
-    for this to be updated separately, after this amendment lands
-Follow-up TODOs: none (both flagged follow-ups are being handled directly by the user's
-  request, immediately after this amendment)
+  - ✅ .specify/templates/plan-template.md — Constitution Check derived dynamically from
+    this file, no changes needed
+Follow-up TODOs:
+  - ⚠ Implementation: ChangedFileClassifier needs a third INERT classification (a
+    deterministic inert-path allowlist that selects zero tests) to honor this principle.
+    Tracked as a follow-up feature, not part of this amendment.
 -->
 
 # Blastradius Constitution
@@ -83,7 +66,14 @@ default to running more tests rather than fewer. Changes that fall outside what 
 dependency-tracking mechanism can soundly observe — resource files, `pom.xml` and
 dependency version changes, database migrations, build configuration — MUST still
 trigger a conservative fallback that runs the full affected scope, since that
-mechanism is cheap to keep and doesn't trade away meaningful speed.
+mechanism is cheap to keep and doesn't trade away meaningful speed. This fallback
+applies to unobservable changes that *could* affect a test outcome; a change that
+provably *cannot* affect any test outcome — documentation, license text, images, and
+other non-executable files that are never loaded as classes — MUST NOT trigger a full
+run, since the sound selection for it is zero tests. This carve-out stays deterministic
+and explainable (Principles IV and V): inert files are recognized by a fixed path
+classification, not a probabilistic guess, and the surfaced reason is simply that the
+change matched no executable scope.
 
 This is a strong default, not an absolute, non-negotiable rule: adopting teams are
 expected to run their full test suite portfolio on a regular cadence (recommended:
@@ -195,4 +185,4 @@ gate defined in `.specify/templates/plan-template.md`. Any violation MUST be
 explicitly justified in that plan's Complexity Tracking section or the design MUST
 be simplified until it complies.
 
-**Version**: 2.0.0 | **Ratified**: 2026-07-08 | **Last Amended**: 2026-07-09
+**Version**: 2.1.0 | **Ratified**: 2026-07-08 | **Last Amended**: 2026-07-11

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/ChangedFileClassifier.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/ChangedFileClassifier.java
@@ -3,6 +3,8 @@ package io.github.baokhang83.blastradius.core.git;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.diff.DiffEntry;
 import org.eclipse.jgit.lib.ObjectId;
@@ -61,7 +63,53 @@ public final class ChangedFileClassifier {
         if (className != null) {
             return new ChangedFile(path, FileKind.JAVA_SOURCE, className);
         }
+        if (isInert(path)) {
+            return new ChangedFile(path, FileKind.INERT, null);
+        }
         return new ChangedFile(path, FileKind.NON_SOURCE, null);
+    }
+
+    // Documentation and media extensions that cannot affect a test outcome.
+    private static final Set<String> INERT_EXTENSIONS = Set.of(
+            ".md", ".markdown", ".adoc", ".rst",
+            ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".webp");
+
+    // Root-style documentation files, matched with or without an extension (README, README.md, …).
+    private static final Set<String> INERT_DOC_STEMS = Set.of(
+            "README", "LICENSE", "NOTICE", "AUTHORS", "CHANGELOG", "CONTRIBUTING",
+            "CODE_OF_CONDUCT", "SECURITY");
+
+    // Exact VCS/editor metadata filenames.
+    private static final Set<String> INERT_METADATA_FILES = Set.of(
+            ".gitignore", ".gitattributes", ".mailmap", ".editorconfig");
+
+    /**
+     * True when a changed path provably cannot affect any test outcome (Constitution §III),
+     * so it selects no tests instead of triggering the conservative fallback.
+     *
+     * <p>This is an allowlist, never a blocklist — anything not matched stays {@code NON_SOURCE}.
+     * Nothing under a {@code resources/} directory is ever inert: it may be test data a test
+     * loads, which class-load tracking cannot observe, so it must fall back.
+     */
+    private static boolean isInert(String path) {
+        if (path.startsWith("resources/") || path.contains("/resources/")) {
+            return false;
+        }
+        if (path.startsWith(".github/") || path.startsWith(".idea/") || path.startsWith(".vscode/")
+                || path.startsWith("docs/") || path.contains("/docs/")) {
+            return true;
+        }
+        String fileName = path.substring(path.lastIndexOf('/') + 1);
+        if (INERT_METADATA_FILES.contains(fileName) || fileName.endsWith(".iml")) {
+            return true;
+        }
+        for (String stem : INERT_DOC_STEMS) {
+            if (fileName.equals(stem) || fileName.startsWith(stem + ".")) {
+                return true;
+            }
+        }
+        String lower = fileName.toLowerCase(Locale.ROOT);
+        return INERT_EXTENSIONS.stream().anyMatch(lower::endsWith);
     }
 
     private static String classNameFromPath(String path) {

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/FileKind.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/FileKind.java
@@ -1,10 +1,17 @@
 package io.github.baokhang83.blastradius.core.git;
 
 /**
- * Whether a changed file is Java source (subject to dependency-match selection) or
- * something else (subject to the conservative fallback rule, per FR-006).
+ * How a changed file is treated by selection:
+ * <ul>
+ *   <li>{@link #JAVA_SOURCE} — subject to dependency-match selection;</li>
+ *   <li>{@link #NON_SOURCE} — subject to the conservative fallback rule (FR-006), because it
+ *       may affect a test outcome in a way class-load tracking cannot observe;</li>
+ *   <li>{@link #INERT} — provably cannot affect any test outcome (docs, license, images,
+ *       VCS/editor/CI metadata), so it selects no tests at all (Constitution §III).</li>
+ * </ul>
  */
 public enum FileKind {
     JAVA_SOURCE,
-    NON_SOURCE
+    NON_SOURCE,
+    INERT
 }

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/git/ChangedFileClassifierTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/git/ChangedFileClassifierTest.java
@@ -82,6 +82,58 @@ class ChangedFileClassifierTest {
         assertEquals(2, changed.size());
     }
 
+    @Test
+    void readmeChangeIsClassifiedAsInert(@TempDir Path tempDir) {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(tempDir);
+        String base = fixture.commit("initial");
+        fixture.writeResource("README.md", "# docs edit");
+        String head = fixture.commit("edit readme");
+
+        List<ChangedFile> changed = classifier.classify(tempDir, base, head);
+
+        ChangedFile readme = single(changed, "README.md");
+        assertEquals(FileKind.INERT, readme.kind());
+        assertNull(readme.changedClassName());
+    }
+
+    @Test
+    void ciWorkflowChangeIsClassifiedAsInert(@TempDir Path tempDir) {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(tempDir);
+        String base = fixture.commit("initial");
+        fixture.writeResource(".github/workflows/ci.yml", "name: ci");
+        String head = fixture.commit("edit ci");
+
+        List<ChangedFile> changed = classifier.classify(tempDir, base, head);
+
+        assertEquals(FileKind.INERT, single(changed, ".github/workflows/ci.yml").kind());
+    }
+
+    @Test
+    void docImageChangeIsClassifiedAsInert(@TempDir Path tempDir) {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(tempDir);
+        String base = fixture.commit("initial");
+        fixture.writeResource("docs/logo.png", "fake-png-bytes");
+        String head = fixture.commit("add logo");
+
+        List<ChangedFile> changed = classifier.classify(tempDir, base, head);
+
+        assertEquals(FileKind.INERT, single(changed, "docs/logo.png").kind());
+    }
+
+    @Test
+    void markdownUnderResourcesIsNonSourceNotInert(@TempDir Path tempDir) {
+        // Soundness (§III): a Markdown file under resources/ can be test data a test loads,
+        // and class-load tracking can't see it — so it MUST fall back, never select nothing.
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(tempDir);
+        String base = fixture.commit("initial");
+        fixture.writeResource("src/test/resources/fixture.md", "expected: 42");
+        String head = fixture.commit("edit fixture");
+
+        List<ChangedFile> changed = classifier.classify(tempDir, base, head);
+
+        assertEquals(FileKind.NON_SOURCE, single(changed, "src/test/resources/fixture.md").kind());
+    }
+
     private static ChangedFile single(List<ChangedFile> files, String path) {
         return files.stream()
                 .filter(f -> f.path().equals(path))

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/SelectionEngineTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/SelectionEngineTest.java
@@ -75,4 +75,21 @@ class SelectionEngineTest {
 
         assertEquals(3, decisions.size());
     }
+
+    @Test
+    void inertOnlyChangeSelectsNoTestsAndDoesNotFallback() {
+        // A README-only change: INERT is neither fallback-triggering (NON_SOURCE) nor
+        // match-contributing (JAVA_SOURCE), so every test is unselected — zero tests run.
+        List<ChangedFile> changed = List.of(new ChangedFile("README.md", FileKind.INERT, null));
+
+        List<SelectionDecision> decisions = engine.selectAll(
+                Set.of(MATCHED_TEST, UNRELATED_TEST),
+                Map.of(MATCHED_TEST, Set.of("com.example.Foo")),
+                Set.of(),
+                changed);
+
+        assertTrue(decisions.stream().noneMatch(SelectionDecision::selected));
+        assertTrue(decisions.stream()
+                .noneMatch(d -> d.reason() == SelectionReason.FALLBACK_NON_SOURCE_CHANGE));
+    }
 }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/CommitCheckout.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/CommitCheckout.java
@@ -46,10 +46,23 @@ public final class CommitCheckout implements AutoCloseable {
     /**
      * Checks out {@code commitSha} within the scratch clone (detached HEAD) and returns
      * the working directory now reflecting that commit's tree.
+     *
+     * <p>Also deletes any {@code target/} directory left over from a previous
+     * checkout's build, rather than relying on the next {@code mvn clean test}
+     * invocation to do it. A commit whose {@code pom.xml} fails to resolve (e.g. an
+     * unpublished SNAPSHOT parent — a real case found running against jackson-databind)
+     * fails during Maven's project-model-building phase, before the {@code clean} goal
+     * ever runs, letting a stale {@code target/surefire-reports/TEST-*.xml} from the
+     * prior commit survive. {@code BuildFailureDetector} can only see whether *any*
+     * {@code TEST-*.xml} exists, not whether it's fresh, so a stale one fools it into
+     * treating a genuine build failure as if it had run tests — this cleanup (not
+     * relying on the target project's own `clean` goal succeeding) closes that gap
+     * directly at the source.
      */
     public Path checkoutCommit(String commitSha) {
         try {
             scratchGit.checkout().setName(commitSha).call();
+            deleteRecursively(scratchDir.resolve("target"));
             return scratchDir;
         } catch (Exception e) {
             throw new IllegalStateException("failed to checkout commit " + commitSha, e);

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/git/CommitCheckoutTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/git/CommitCheckoutTest.java
@@ -60,6 +60,42 @@ class CommitCheckoutTest {
         }
     }
 
+    /**
+     * Real bug found running the validator against jackson-databind: a commit whose
+     * {@code pom.xml} fails to resolve (e.g. an unpublished SNAPSHOT parent) fails
+     * during Maven's project-model-building phase, before the {@code clean} goal ever
+     * runs — so a STALE {@code target/surefire-reports/TEST-*.xml} left over from the
+     * *previous* commit's successful build survives into this checkout. {@link
+     * io.github.baokhang83.blastradius.validator.build.BuildFailureDetector} only checks
+     * whether any {@code TEST-*.xml} exists anywhere under the project — it can't tell a
+     * fresh report from a stale one — so it wrongly concluded the (actually failed)
+     * build must have run at least one test, and {@code RunCommand} went on to read
+     * dependency-tracking output that was never produced, crashing the whole run instead
+     * of gracefully excluding the one bad commit.
+     */
+    @Test
+    void checkoutClearsStaleTargetDirectoryFromThePreviousCommit(
+            @TempDir Path targetDir, @TempDir Path scratchParent) throws Exception {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(targetDir);
+        String c1 = fixture.commit("initial");
+        fixture.writeClass("com.example.Foo", "package com.example; class Foo {}");
+        String c2 = fixture.commit("add Foo");
+
+        try (CommitCheckout checkout = CommitCheckout.forTargetProject(targetDir, scratchParent)) {
+            Path atC1 = checkout.checkoutCommit(c1);
+            Path staleReport = atC1.resolve("target/surefire-reports/TEST-com.example.OldTest.xml");
+            Files.createDirectories(staleReport.getParent());
+            Files.writeString(staleReport, "<testsuite/>", StandardCharsets.UTF_8);
+            assertTrue(Files.exists(staleReport), "sanity check: stale report was actually created");
+
+            Path atC2 = checkout.checkoutCommit(c2);
+
+            assertTrue(Files.notExists(atC2.resolve("target/surefire-reports/TEST-com.example.OldTest.xml")),
+                    "a stale test report from the previous commit's build must not survive a checkout "
+                            + "of a different commit");
+        }
+    }
+
     @Test
     void checkingOutMultipleCommitsSequentiallyReusesTheSameScratchClone(
             @TempDir Path targetDir, @TempDir Path scratchParent) throws Exception {


### PR DESCRIPTION
Intent: add FileKind.INERT so provably-inert changes (docs, LICENSE, images, VCS/CI metadata) select zero tests instead of triggering a full-suite fallback. Design: .fluencyloop/features/inert-file-classification/design.md.

Decisions (from the session journal)

1. INERT modeled as a third FileKind, changing no selection code — FileKind.java, SelectionEngine.java. Fallback keys only on NON_SOURCE, matching only on JAVA_SOURCE; INERT is neither, so zero-selection falls out by construction. Chosen over an explicit "select nothing" branch, which would add a way to accidentally fall back on inert. trust: ✓ — 45/45 core tests green, existing selection tests unchanged, plus a lock test (inertOnlyChangeSelectsNoTestsAndDoesNotFallback).
2. Allowlist excludes anything under resources/ — ChangedFileClassifier.isInert. A .md/.yaml/.svg under resources/ can be test data invisible to class-load tracking, so it must fall back. Allowlist, never blocklist. Chosen over blanket extension matching, which is unsound. trust: ✓ — guarded by markdownUnderResourcesIsNonSourceNotInert.

Where a reviewer should look hardest (the honest trust boundaries)
- ⚠ Plugin-level end-to-end not driven. Core proven; blastradius:select on a real README commit not exercised. Relies on the existing "empty selection runs nothing" path.
- ⚠ §V explainability gap. Selection is correct, but the console doesn't yet say "N files inert → 0 tests." Deferred to a separate slice.

Constitution check (.specify/memory/constitution.md v2.1.0, via pointer)
- §III Sound by default ✓ — inert selects zero without weakening the NON_SOURCE fallback; this feature implements the 2.1.0 carve-out.
- §IV Deterministic core ✓ — fixed path allowlist, no ML/probabilistic call.
- §V Explainability ⚠ surfaced, not blocking — the "inert" reason isn't surfaced in output yet.
- §I TDD ✓ — RED→GREEN verified.
