### PR TITLE
Backfill journal: shadow-mode validator (#50)

### DIFF
--- a/docs/fluencyloop/features/shadow-mode-validator/design.md
+++ b/docs/fluencyloop/features/shadow-mode-validator/design.md
@@ -2,11 +2,11 @@
 
 started: 2026-07-12
 
-> ✓ **Backfilled, then reviewed.** `blastradius-validator` shipped from
-> `specs/001-shadow-mode-validator/` without going through the loop. This design was
-> reconstructed from that spec/plan/`research.md`/contracts and the code — not authored live —
-> then confirmed by the maintainer on 2026-07-12. See the session journal for the decisions and
-> their (now ✓) trust markers.
+> ✓ **Backfilled from a real-time record, then reviewed.** `blastradius-validator` was built via
+> the full SpecKit workflow with a contemporaneous development log (`SESSION.md`) — it didn't skip
+> real-time teaching, only FluencyLoop's journal format. This design is reconstructed from
+> `specs/001-shadow-mode-validator/` + `SESSION.md` + the code, then confirmed by the maintainer on
+> 2026-07-12. See the session journal for the decisions and their (now ✓) trust markers.
 
 ## What it is
 

--- a/docs/fluencyloop/features/shadow-mode-validator/design.md
+++ b/docs/fluencyloop/features/shadow-mode-validator/design.md
@@ -1,0 +1,85 @@
+# Design: shadow-mode test-selection validator
+
+started: 2026-07-12
+
+> ✓ **Backfilled, then reviewed.** `blastradius-validator` shipped from
+> `specs/001-shadow-mode-validator/` without going through the loop. This design was
+> reconstructed from that spec/plan/`research.md`/contracts and the code — not authored live —
+> then confirmed by the maintainer on 2026-07-12. See the session journal for the decisions and
+> their (now ✓) trust markers.
+
+## What it is
+
+The validator measures whether the selection engine is *sound* by **replaying real project
+history**: for each commit pair it runs the target's own build to get ground truth, runs the
+engine's selection, and reports any test the engine would have skipped that actually failed
+(a "would-miss"). It never mutates the target repo.
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class RunCommand {
+    +run(RunConfig) int
+  }
+  class CommitWindowResolver
+  class CommitPair
+  class CommitCheckout {
+    +checkoutCommit(sha) Path
+  }
+  class MavenBuildRunner {
+    +run(dir, agentJar, out) BuildResult
+    +runSingleTest(dir, test) BuildResult
+  }
+  class SurefireReportParser
+  class GroundTruthResolver {
+    +resolve(...) GroundTruthResult
+  }
+  class GroundTruthResult
+  class SelectionEngine
+  class VerdictCalculator {
+    +verdict(selected, groundTruth) Verdict
+  }
+  class WouldMissCase
+  class AnalysisReport
+  class ReportWriter {
+    +write(report, path)
+  }
+  class TextSummaryRenderer
+
+  RunCommand --> CommitWindowResolver
+  RunCommand --> CommitCheckout
+  RunCommand --> GroundTruthResolver
+  RunCommand --> VerdictCalculator
+  RunCommand --> ReportWriter
+  CommitWindowResolver --> CommitPair
+  GroundTruthResolver --> MavenBuildRunner
+  GroundTruthResolver --> SurefireReportParser
+  GroundTruthResolver --> GroundTruthResult
+  VerdictCalculator ..> SelectionEngine : compares selection vs
+  VerdictCalculator --> WouldMissCase
+  ReportWriter --> AnalysisReport
+  TextSummaryRenderer ..> AnalysisReport : renders
+```
+
+## Sequence: validating one commit pair
+
+```mermaid
+sequenceDiagram
+  participant Run as RunCommand
+  participant Git as CommitCheckout
+  participant Maven as MavenBuildRunner
+  participant GT as GroundTruthResolver
+  participant Engine as SelectionEngine
+  participant V as VerdictCalculator
+  Run->>Git: checkout base commit (scratch copy, JGit)
+  Run->>Maven: mvn clean test + agent via JAVA_TOOL_OPTIONS
+  Maven-->>GT: Surefire/Failsafe XML + recorded deps
+  GT-->>Run: GroundTruthResult (pass / confirmed-fail / flaky)
+  Run->>Git: checkout head commit
+  Run->>Engine: selectAll(changed files, tracked deps)
+  Engine-->>V: per-test SelectionDecision
+  V->>V: any selected=NO but actually FAILED? -> WouldMissCase
+  V-->>Run: Verdict
+  Run->>Run: aggregate -> AnalysisReport (JSON) + text summary
+```

--- a/docs/fluencyloop/features/shadow-mode-validator/sessions/validator-foundations-build-invocation-ground-truth-git-repl.md
+++ b/docs/fluencyloop/features/shadow-mode-validator/sessions/validator-foundations-build-invocation-ground-truth-git-repl.md
@@ -1,0 +1,107 @@
+# Session: validator foundations: build invocation, ground truth, git replay, report
+
+- **intent:** validator foundations: build invocation, ground truth, git replay, report
+- **started:** 2026-07-12
+
+> ✓ **Backfilled, then reviewed.** `blastradius-validator` shipped from
+> `specs/001-shadow-mode-validator/` without real-time teaching. These decisions were
+> reconstructed from that spec/plan/`research.md`/contracts and the code, then **confirmed by the
+> maintainer on 2026-07-12** — all five upgraded from `⚠` to `✓`. Principle numbers reference the
+> current constitution v2.1.0.
+
+---
+
+## Knowledge transfer
+
+_The ground this backfill makes understandable — the validator's components, roles, and
+conditions. About the work, not any person._
+
+- **RunCommand** — orchestrates one run: resolve the commit window, and for each pair check out,
+  get ground truth, run selection, compute the verdict, and write the report. · status: documented
+- **MavenBuildRunner** — invokes the target's own `mvn -B clean test` as a subprocess (never
+  reimplementing the build); attaches the tracking agent through the `JAVA_TOOL_OPTIONS` env var;
+  `clean` is required because one scratch copy is reused across commits and `target/` is untracked. · status: documented
+- **GroundTruthResolver + SurefireReportParser** — run the full suite once, re-run each failure
+  once to rule out flakiness (FR-013), and read pass/fail from the standard Surefire/Failsafe XML;
+  scans report dirs anywhere under the root so multi-module reactors work. · status: documented
+- **CommitCheckout** — clones the target once into a disposable scratch dir and checks out each
+  commit there via JGit, never touching the target repo's HEAD/branch/worktree. · status: documented
+- **VerdictCalculator + WouldMissCase** — compares the engine's selection against ground truth; a
+  test the engine did *not* select that actually failed is a would-miss (the soundness signal). · status: documented
+- **AnalysisReport / ReportWriter / TextSummaryRenderer** — the run's single JSON source of truth
+  (FR-010); the text summary is a rendering of it, never a second data source. · status: documented
+
+---
+
+## Decision: invoke the target's own `mvn test` as an unmodified subprocess for ground truth
+
+- **where:** `blastradius-validator/.../build/MavenBuildRunner.java`
+- **why:** the validator's whole value is fidelity to the target's *real* build, so it shells out
+  to the project's own `mvn -B clean test` and reads what that build produces — never altering the
+  target or second-guessing its configuration (parallelism, forks, includes/excludes). (research.md §2, plan.md non-destructive constraint)
+- **alternative:** fork/patch the target `pom.xml` to add a plugin (mutates the artifact under
+  test, diverging from its real behaviour); or reimplement execution via the JUnit Platform
+  Launcher (would have to reconstruct the project's classpath + Surefire config, which risks not
+  matching the trusted CI behaviour). Both rejected.
+- **trust:** ✓ verified — maintainer-confirmed on backfill review (2026-07-12)
+
+---
+
+## Decision: attach the tracking agent via `JAVA_TOOL_OPTIONS` (revised from `-DargLine` during T061)
+
+- **where:** `blastradius-validator/.../build/MavenBuildRunner.java` (agent-attach in `execute`)
+- **why:** `JAVA_TOOL_OPTIONS` is read directly by *every* JVM launch (the outer `mvn` and each
+  forked Surefire/Failsafe test JVM), independent of Maven's `argLine` property. The original
+  `-DargLine=-javaagent:...` attach **failed silently** on real projects during T061 validation —
+  jsoup hardcodes a literal `<argLine>` (never interpolated from a CLI property), and JaCoCo's
+  `prepare-agent` goal *overwrites* the `argLine` property after our override (hit via
+  commons-parent). A related fix: with `reuseForks=false` (commons-io) each test class gets a fresh
+  JVM and a single shared output file races, so each JVM writes to a `.<pid>` file, merged on read
+  once the build is done. (research.md §2)
+- **alternative:** keep `-DargLine=...` — rejected: silently defeated by the target's own
+  `argLine` handling, surfacing as empty records rather than an error. *(Strong T061 evidence —
+  confirmed ✓ on review.)*
+- **note:** the class-level Javadoc still describes the old `-DargLine` approach; the code was
+  revised to `JAVA_TOOL_OPTIONS` but that doc comment wasn't updated (stale — worth a follow-up).
+- **trust:** ✓ verified — maintainer-confirmed on backfill review (2026-07-12)
+
+---
+
+## Decision: ground truth from the standard Surefire/Failsafe XML reports
+
+- **where:** `blastradius-validator/.../build/SurefireReportParser.java`, `build/GroundTruthResolver.java`
+- **why:** the `TEST-*.xml` reports are the authoritative, standard output of the exact build just
+  run — reusing them avoids re-deriving results through a second mechanism that could disagree with
+  the real build, and the format is stable and well-documented. (research.md §3)
+- **alternative:** a custom JUnit Platform result listener reporting outcomes directly — rejected as
+  redundant: since the build already runs as a subprocess, the XML is the natural zero-integration
+  output; a listener would be a second, potentially-disagreeing source.
+- **trust:** ✓ verified — maintainer-confirmed on backfill review (2026-07-12)
+
+---
+
+## Decision: JGit in-process for commit-window traversal and non-destructive checkout
+
+- **where:** `blastradius-validator/.../git/CommitCheckout.java`, `git/CommitWindowResolver.java`
+- **why:** JGit walks the commit range and materializes each commit into a disposable scratch clone
+  in-process — testable (no subprocess/output-parsing brittleness), actively maintained, and it
+  never touches the target repo's HEAD/branch/worktree. (research.md §4, plan.md non-destructive)
+- **alternative:** shell out to the `git` CLI via `ProcessBuilder` — rejected: harder to unit test
+  (needs a real git binary + process mocking), output parsing is brittle across git versions, and
+  offers no advantage for these operations.
+- **trust:** ✓ verified — maintainer-confirmed on backfill review (2026-07-12)
+
+---
+
+## Decision: JSON report as the single source of truth + a rendered text summary, no database
+
+- **where:** `blastradius-validator/.../report/AnalysisReport.java`, `report/ReportWriter.java`, `report/TextSummaryRenderer.java`
+- **why:** each run emits one indented-JSON file as the machine-auditable record (FR-010), and the
+  plain-text summary is a *rendering* of it — not a second data source. JSON is dependency-light and
+  satisfies "reproducible from recorded output alone" without a persistence layer the spec puts out
+  of scope. (research.md §6)
+- **alternative:** a relational/embedded database (e.g. SQLite) for run history — rejected as
+  unnecessary infrastructure for a tool that analyses one project per run and needs no cross-run
+  querying.
+- **constitution:** §II (Clean Code & Simplicity — no speculative infrastructure for capability not yet needed).
+- **trust:** ✓ verified — maintainer-confirmed on backfill review (2026-07-12)

--- a/docs/fluencyloop/features/shadow-mode-validator/sessions/validator-foundations-build-invocation-ground-truth-git-repl.md
+++ b/docs/fluencyloop/features/shadow-mode-validator/sessions/validator-foundations-build-invocation-ground-truth-git-repl.md
@@ -3,33 +3,76 @@
 - **intent:** validator foundations: build invocation, ground truth, git replay, report
 - **started:** 2026-07-12
 
-> ✓ **Backfilled, then reviewed.** `blastradius-validator` shipped from
-> `specs/001-shadow-mode-validator/` without real-time teaching. These decisions were
-> reconstructed from that spec/plan/`research.md`/contracts and the code, then **confirmed by the
-> maintainer on 2026-07-12** — all five upgraded from `⚠` to `✓`. Principle numbers reference the
-> current constitution v2.1.0.
+> ✓ **Backfilled from a real-time record, then reviewed.** `blastradius-validator` was built via
+> the full SpecKit workflow *with* a contemporaneous development log
+> (`.claude/worktrees/…/SESSION.md`) — real-time teaching **did** happen; it just wasn't in
+> FluencyLoop's journal format. This session reconstructs that journal from
+> `specs/001-shadow-mode-validator/` + `SESSION.md` + the code, then **confirmed by the maintainer
+> on 2026-07-12** — all five decisions upgraded from `⚠` to `✓`. Because the rationale is backed by
+> a contemporaneous log (not post-hoc memory), these entries carry more weight than a typical
+> blind backfill. Principle numbers reference the current constitution v2.1.0 — the SESSION.md
+> predates it (its Principle VII "Maintainable, Modern Foundations" is now §VI; its Principle V
+> "Shadow-Mode Before Gating" was removed in v2.0.0).
 
 ---
 
 ## Knowledge transfer
 
-_The ground this backfill makes understandable — the validator's components, roles, and
-conditions. About the work, not any person._
+_The ground this backfill makes understandable — the validator's components, roles, conditions,
+and the hard-won mechanism lessons from the real T061 run. About the work, not any person._
 
-- **RunCommand** — orchestrates one run: resolve the commit window, and for each pair check out,
-  get ground truth, run selection, compute the verdict, and write the report. · status: documented
-- **MavenBuildRunner** — invokes the target's own `mvn -B clean test` as a subprocess (never
-  reimplementing the build); attaches the tracking agent through the `JAVA_TOOL_OPTIONS` env var;
-  `clean` is required because one scratch copy is reused across commits and `target/` is untracked. · status: documented
-- **GroundTruthResolver + SurefireReportParser** — run the full suite once, re-run each failure
-  once to rule out flakiness (FR-013), and read pass/fail from the standard Surefire/Failsafe XML;
-  scans report dirs anywhere under the root so multi-module reactors work. · status: documented
-- **CommitCheckout** — clones the target once into a disposable scratch dir and checks out each
-  commit there via JGit, never touching the target repo's HEAD/branch/worktree. · status: documented
-- **VerdictCalculator + WouldMissCase** — compares the engine's selection against ground truth; a
-  test the engine did *not* select that actually failed is a would-miss (the soundness signal). · status: documented
-- **AnalysisReport / ReportWriter / TextSummaryRenderer** — the run's single JSON source of truth
-  (FR-010); the text summary is a rendering of it, never a second data source. · status: documented
+**What it is, in one line:** a *shadow-mode* validator — it always runs the full suite, then
+checks afterward whether dependency-based selection *would have* missed a real failure (must be
+zero) and how much it would have saved. It never skips a real test itself.
+
+### The pipeline (role · conditions)
+
+- **`cli/` — `Main` + `RunConfig` + `RunCommand`** — CLI entry with validated input; `RunCommand`
+  wires the whole pipeline per commit pair. Exit codes: `0` PASS, `1` FAIL (a would-miss), `2`
+  couldn't-run. · status: documented
+- **`git/` — `CommitWindowResolver` + `CommitCheckout` + `CommitPair`** — JGit resolves the N most
+  recent commit pairs, then clones the target **once** into a disposable scratch dir and checks out
+  each commit *within* that clone — the real target repo's HEAD/branch/worktree are never touched
+  (safety-critical; a `/speckit-analyze` CRITICAL gap that was fixed before implementation). · status: documented
+- **`tracking/` — `DependencyTrackingAgent` + `TestBoundaryListener` + `DependencyRecordWriter`/`Reader`**
+  (from core) — a real `-javaagent` SHA-256-checksums each class as it loads and attributes it to
+  the running test via a `ThreadLocal`; records persist as JSON across the subprocess boundary. · status: documented
+- **`build/` — `MavenBuildRunner` + `SurefireReportParser` + `GroundTruthResolver` + `BuildFailureDetector`**
+  — runs the target's own `mvn clean test` as a subprocess (agent via `JAVA_TOOL_OPTIONS`);
+  `clean` is mandatory because one scratch clone is reused across commits and `target/` is
+  untracked. Ground truth is parsed from Surefire/Failsafe XML with the JDK DOM parser (no extra
+  dep), classified `PASSED`/`CONFIRMED_FAILED`/`FLAKY` (failures re-run once, FR-013), scanning
+  report dirs recursively so multi-module reactors just work. **No reports at all ⇒ a build/compile
+  failure, distinct from a test failure** (`BuildFailureDetector`). · status: documented
+- **`selection/` — `SelectionEngine` + the three selectors** (from core) — fallback short-circuits
+  everything; new/modified beats ordinary dependency matching. · status: documented
+- **`verdict/` — `WouldMissComparator` + `VerdictCalculator` + `FlakyFailure`** — a test that was
+  `CONFIRMED_FAILED` **and** not selected is a would-miss; the run is PASS iff there are zero. · status: documented
+- **`report/` — `AnalysisReport` + `SavingsSummaryAggregator` + `ReportWriter` + `TextSummaryRenderer`**
+  — one indented-JSON file is the source of truth (FR-010); savings are bucketed three ways
+  (dependency-matched / fallback-driven / new-or-modified); the text summary is a rendering, never
+  a second source. · status: documented
+
+### Hard-won mechanism conditions (found only by running against real projects — worth keeping)
+
+- **Agent attach must use `JAVA_TOOL_OPTIONS`, not `-DargLine`** — real poms defeat `argLine`:
+  jsoup hardcodes a literal `<argLine>`, and JaCoCo's `prepare-agent` overwrites the property
+  (commons-parent). `-DargLine` failed *silently* (empty record, not an error). See D2. · status: documented
+- **Per-PID dependency file, merged on read** — with `reuseForks=false` (commons-io) Surefire
+  launches one JVM per test class and doesn't wait for a fork to fully exit, so a shared output
+  file races (only 34/251 classes survived). Each JVM writes `<path>.<pid>`, merged after the build
+  (→ 249/251). See D2. · status: documented
+- **`TestIdentity.baselineKey()` strips a trailing `(…)`/`[…]` suffix** — the live JUnit listener
+  reports a parameterized test's plain method name, but Surefire XML reports each invocation under a
+  distinct name (`…(char)[1]`), so the two `TestIdentity` values never `.equals()` and every lookup
+  missed its baseline. The stripped key is used **only** for the baseline lookup — deliberately
+  **not** for the would-miss comparison, which must stay per-invocation so a failing invocation
+  isn't masked behind a passing sibling. (Core selection logic — arguably its own decision.) · status: follow-up
+- **`@BeforeAll`-only class loads are unattributed** — a class loaded solely inside a container-level
+  `@BeforeAll` is never tied to a test, so a later change to it is invisible to selection. Narrow,
+  deterministic, documented in README "Known limitations" — not a correctness time-bomb. · status: documented
+- **Shaded-jar signature stripping** — a signed dependency's leftover `META-INF/*.SF|.DSA|.RSA`
+  survived shading and crashed the agent with `SecurityException`; the shade plugin filters them. · status: documented
 
 ---
 


### PR DESCRIPTION
Reconstructs the FluencyLoop journal for `blastradius-validator`, which shipped from `specs/001-shadow-mode-validator/` without going through the loop. Closes #50.

## What's here
A feature + one session under `docs/fluencyloop/features/shadow-mode-validator/`, capturing five decisions with `where` / `why` / `alternative` / `constitution`, grounded in the spec/`research.md` and the code:

1. **Invoke the target's own `mvn -B clean test` as an unmodified subprocess** for ground truth. Rejected: fork/patch the pom; reimplement via the JUnit Platform Launcher. (§2)
2. **Attach the agent via `JAVA_TOOL_OPTIONS`** (revised from `-DargLine` during T061 — jsoup's hardcoded `<argLine>`, JaCoCo `prepare-agent` overwriting the property; plus per-PID output merged on read for `reuseForks=false`). (§2)
3. **Ground truth from Surefire/Failsafe XML.** Rejected: a custom result listener (redundant). (§3)
4. **JGit in-process, non-destructive scratch checkout.** Rejected: shelling out to the git CLI. (§4)
5. **JSON report as source of truth + rendered text summary, no DB.** (§6, §II)

Also includes a person-neutral (GDPR-safe) **knowledge-transfer** record of the pipeline's components.

## Process
Drafted `trust: ⚠`, reviewed via a rendered fluency briefing (each decision mapped onto the pipeline diagram), and **confirmed decision-by-decision** — all five upgraded to `trust: ✓`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)