### PR TITLE
fix: restrict Central bundle to Maven plugin

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -2,7 +2,7 @@
   "feature": "prepare-the-0-1-0-maven-central-release",
   "branch": "feature/prepare-the-0-1-0-maven-central-release",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/prepare-the-0-1-0-maven-central-release/sessions/implement-maven-central-release-pipeline.md",
+  "last_session": "docs/fluencyloop/features/prepare-the-0-1-0-maven-central-release/sessions/stabilize-release-verification-and-deployment-boundary.md",
   "base_ref": "feature/shadow-mode-validator",
-  "updated": "2026-07-19"
+  "updated": "2026-07-20"
 }

--- a/docs/fluencyloop/features/prepare-the-0-1-0-maven-central-release/design.md
+++ b/docs/fluencyloop/features/prepare-the-0-1-0-maven-central-release/design.md
@@ -78,6 +78,9 @@ sequenceDiagram
   the published plugin self-contained and keeps a consumer's versions from leaking into the Mojo.
 - Release-only work stays in the `release` profile, so local `test`/`verify` remains quick while
   Central receives its required companion artifacts and signatures.
+- The Central publishing extension stages reactor artifacts independently of Maven's normal deploy
+  skip flag, so its release configuration explicitly excludes the parent, core, and validator;
+  only the shaded plugin enters the public bundle.
 - The Invoker executes Maven fixture projects rather than only testing Mojo classes. That is the
   closest repeatable check of the installed plugin's actual lifecycle behavior.
 - CI can upload only with Central and GPG secrets. Namespace claiming, secret creation, tag

--- a/docs/fluencyloop/features/prepare-the-0-1-0-maven-central-release/sessions/stabilize-release-verification-and-deployment-boundary.md
+++ b/docs/fluencyloop/features/prepare-the-0-1-0-maven-central-release/sessions/stabilize-release-verification-and-deployment-boundary.md
@@ -1,0 +1,32 @@
+# Session: stabilize release verification and deployment boundary
+
+- **intent:** stabilize release verification and deployment boundary
+- **started:** 2026-07-20
+
+## Knowledge transfer
+
+- **Central publishing lifecycle:** The Central extension gathers attached artifacts from each
+  reactor project on `deploy`; `maven.deploy.skip` does not limit that gathering. The release
+  profile must therefore exclude internal artifact IDs directly in the Central configuration.
+  **Status:** documented.
+- **SELECT Invoker fixture:** The hook commits its tracked baseline before it creates `NewTest`,
+  then asserts that `HEAD` and `baseline` remain distinct. This avoids dependence on ignored,
+  unversioned fixture files being copied into a clean Invoker project. **Status:** documented.
+
+## Decision: filter Central artifacts at the publishing boundary
+
+- **where:** `pom.xml release profile`
+- **why:** The Central lifecycle extension collects reactor artifacts independently of Maven deploy-skip, so an explicit artifactId filter is required to keep internal modules out of the public bundle.
+- **alternative:** Rely on maven.deploy.skip alone — rejected: it does not constrain Central's collector and staged the parent and core.
+- **design:** ../design.md
+- **constitution:** §IV
+- **trust:** ✓ verified
+
+## Decision: generate the SELECT fixture's new test in the prebuild hook
+
+- **where:** `blastradius-maven-plugin/src/it/select/prebuild.groovy`
+- **why:** Creating NewTest after the tracked baseline makes the fixture independent of Invoker project-copy behavior and asserts that baseline and HEAD differ before the SELECT run.
+- **alternative:** Rename an ignored template file — rejected: the file is not versioned and is absent from a clean checkout.
+- **design:** ../design.md
+- **constitution:** §I
+- **trust:** ✓ verified

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,14 @@
                             <autoPublish>true</autoPublish>
                             <waitUntil>published</waitUntil>
                             <skipPublishing>${central.skip.publishing}</skipPublishing>
+                            <!-- The Central lifecycle extension stages reactor artifacts independently
+                                 of Maven's maven.deploy.skip property. Keep implementation modules out
+                                 of the public bundle at that collection point. -->
+                            <excludeArtifacts>
+                                <excludeArtifact>blastradius-parent</excludeArtifact>
+                                <excludeArtifact>blastradius-core</excludeArtifact>
+                                <excludeArtifact>blastradius-validator</excludeArtifact>
+                            </excludeArtifacts>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## Summary
- exclude the parent, core, and validator from the Central publishing extension
- retain the shaded plugin as the sole public release artifact
- record the release-boundary rationale

## Verification
- local Central staging probe: bundle contains only the plugin artifacts
- Maven Invoker isolation fixture
- JDK 21 CI

Closes #7.