### PR TITLE
ci: require JDK 21 build before main merges

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "prepare-the-0-1-0-maven-central-release",
-  "branch": "feature/prepare-the-0-1-0-maven-central-release",
+  "feature": "enforce-the-required-jdk-21-build-check-on-main",
+  "branch": "feature/enforce-the-required-jdk-21-build-check-on-main",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/prepare-the-0-1-0-maven-central-release/sessions/document-gpg-key-distribution-and-ci-secret-provisioning.md",
+  "last_session": "docs/fluencyloop/features/enforce-the-required-jdk-21-build-check-on-main/sessions/require-the-existing-jdk-21-build-before-main-merges.md",
   "base_ref": "feature/shadow-mode-validator",
   "updated": "2026-07-20"
 }

--- a/docs/fluencyloop/features/enforce-the-required-jdk-21-build-check-on-main/design.md
+++ b/docs/fluencyloop/features/enforce-the-required-jdk-21-build-check-on-main/design.md
@@ -1,0 +1,64 @@
+# Design: enforce the required JDK 21 build check on main
+
+started: 2026-07-20
+
+## Protection shape
+
+```mermaid
+classDiagram
+  class PullRequest {
+    +head commit
+    +merge request
+  }
+  class BuildWorkflow {
+    +Maven 3.9.6
+    +JDK 21
+    +clean verify
+  }
+  class StatusCheck {
+    +Maven 3.9.6 / JDK 21
+    +success or failure
+  }
+  class MainBranch {
+    +main
+  }
+  class BranchProtection {
+    +require status check
+    +require current base
+    +enforce for admins
+  }
+
+  PullRequest --> BuildWorkflow : triggers
+  BuildWorkflow --> StatusCheck : reports
+  BranchProtection --> StatusCheck : requires
+  BranchProtection --> MainBranch : protects
+  PullRequest --> MainBranch : merges only when allowed
+```
+
+## Merge flow
+
+```mermaid
+sequenceDiagram
+  participant Dev as Developer
+  participant PR as Pull request
+  participant CI as Build workflow
+  participant Check as Required status check
+  participant Main as main protection
+
+  Dev->>PR: push change
+  PR->>CI: trigger push and PR builds
+  CI->>CI: Maven 3.9.6, JDK 21, clean verify
+  CI->>Check: report Maven 3.9.6 / JDK 21
+  PR->>Main: request merge
+  alt check succeeds and is current
+    Main-->>PR: permit merge
+  else check fails, is missing, or is stale
+    Main-->>PR: block merge
+  end
+```
+
+## Key decision
+
+Require the existing `Maven 3.9.6 / JDK 21` check with strict freshness and admin
+enforcement. This protects the same full-suite build already used by the repository without
+introducing a second workflow or weakening the gate for administrators.

--- a/docs/fluencyloop/features/enforce-the-required-jdk-21-build-check-on-main/sessions/require-the-existing-jdk-21-build-before-main-merges.md
+++ b/docs/fluencyloop/features/enforce-the-required-jdk-21-build-check-on-main/sessions/require-the-existing-jdk-21-build-before-main-merges.md
@@ -1,0 +1,22 @@
+# Session: require the existing JDK 21 build before main merges
+
+- **intent:** require the existing JDK 21 build before main merges
+- **started:** 2026-07-20
+
+## Knowledge transfer
+
+- **Required status check:** GitHub matches the check by both the displayed name and its GitHub
+  Actions app identity. `strict: true` makes a result stale when the target branch moves, forcing
+  a rerun before merge. **Status:** documented.
+- **Administrative enforcement:** `enforce_admins: true` applies the same required check to
+  repository administrators; force-pushes and branch deletion remain disabled. **Status:**
+  documented.
+
+## Decision: require the current JDK 21 build before main merges
+
+- **where:** `GitHub repository settings: main branch protection`
+- **why:** The existing full-suite Maven 3.9.6 / JDK 21 check is required with strict freshness and administrator enforcement, so missing, failed, or stale results block a merge.
+- **alternative:** Keep CI advisory or permit administrator bypasses — rejected: a failing check would not reliably protect main.
+- **design:** ../design.md#merge-flow
+- **constitution:** §III
+- **trust:** ✓ verified


### PR DESCRIPTION
## Summary

- Require the existing full-suite `Maven 3.9.6 / JDK 21` check for merges into `main`.
- Require the check to be current and enforce the gate for administrators.
- Record the protection behavior and verification in the FluencyLoop design and session.

## Verification

- GitHub branch-protection API confirms the required GitHub Actions check, strict freshness, administrator enforcement, and disabled force-pushes/deletions.
- No unjournaled drift.