### PR TITLE
docs: publish generated Maven plugin goal documentation

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "enforce-the-required-jdk-21-build-check-on-main",
-  "branch": "feature/enforce-the-required-jdk-21-build-check-on-main",
+  "feature": "publish-generated-maven-plugin-goal-documentation",
+  "branch": "feature/publish-generated-maven-plugin-goal-documentation",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/enforce-the-required-jdk-21-build-check-on-main/sessions/require-the-existing-jdk-21-build-before-main-merges.md",
+  "last_session": "docs/fluencyloop/features/publish-generated-maven-plugin-goal-documentation/sessions/replace-the-obsolete-plugin-report-provider-and-verify-gener.md",
   "base_ref": "feature/shadow-mode-validator",
   "updated": "2026-07-20"
 }

--- a/blastradius-maven-plugin/README.md
+++ b/blastradius-maven-plugin/README.md
@@ -17,6 +17,7 @@ fail, only how many tests get the chance to.
 
 - [How it works](#how-it-works)
 - [Install](#install)
+- [Generated goal reference](#generated-goal-reference)
 - [Configuration reference](#configuration-reference)
 - [What you'll see in the Maven output](#what-youll-see-in-the-maven-output)
 - [The files it writes](#the-files-it-writes)
@@ -79,6 +80,18 @@ the goal only ever narrows *which* tests they run, bound early enough
 Your first build (whichever branch it happens to run on) will be `TRACK` or `FALLBACK`,
 not `SELECT` — there's no index yet. It becomes fast once a `baseRef` build has produced
 one. See [Reading a build's result](#reading-a-builds-result) if it seems stuck there.
+
+## Generated goal reference
+
+The plugin's Maven-generated reference lists every goal and parameter. Generate it from
+the repository root with:
+
+```sh
+mvn -pl blastradius-maven-plugin -am site
+```
+
+Then view `blastradius-maven-plugin/target/site/plugin-info.html`. Maven also generates a
+separate page for each goal, including `help-mojo.html` and `select-mojo.html`.
 
 ## Configuration reference
 

--- a/blastradius-maven-plugin/pom.xml
+++ b/blastradius-maven-plugin/pom.xml
@@ -232,7 +232,7 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-plugin-plugin</artifactId>
+                <artifactId>maven-plugin-report-plugin</artifactId>
                 <version>${maven.plugin-tools.version}</version>
                 <reportSets>
                     <reportSet>

--- a/docs/fluencyloop/features/publish-generated-maven-plugin-goal-documentation/design.md
+++ b/docs/fluencyloop/features/publish-generated-maven-plugin-goal-documentation/design.md
@@ -1,0 +1,59 @@
+# Design: publish generated Maven plugin goal documentation
+
+started: 2026-07-20
+
+## Documentation shape
+
+```mermaid
+classDiagram
+  class PluginAnnotations {
+    @Mojo select
+    @Parameter configuration
+  }
+  class MavenPluginPlugin {
+    descriptor
+    helpmojo
+  }
+  class MavenPluginReportPlugin {
+    report
+  }
+  class PluginDescriptor {
+    plugin.xml
+    help goal
+  }
+  class ConsumerMaven {
+    mvn blastradius:help
+  }
+  class PluginSite {
+    plugin-info.html
+  }
+
+  PluginAnnotations --> MavenPluginPlugin : processed by
+  MavenPluginPlugin --> PluginDescriptor : generates
+  PluginDescriptor --> ConsumerMaven : resolves help goal
+  MavenPluginReportPlugin --> PluginSite : reports goal metadata
+```
+
+## Documentation flow
+
+```mermaid
+sequenceDiagram
+  participant Build as Maven plugin build
+  participant BuildTools as maven-plugin-plugin
+  participant ReportTools as maven-plugin-report-plugin
+  participant Consumer as Consumer Maven
+  participant Site as Maven Site
+
+  Build->>BuildTools: descriptor and helpmojo
+  BuildTools-->>Build: plugin.xml with select and help
+  Consumer->>Build: mvn blastradius:help
+  Build-->>Consumer: goals and parameters
+  Site->>ReportTools: report
+  ReportTools-->>Site: target/site/plugin-info.html
+```
+
+## Key decision
+
+Keep descriptor and `helpmojo` generation in the plugin build, while using the reporting lifecycle
+for `plugin-info.html`. This exposes help to consumers and produces the site on demand without
+making normal `verify` builds pay for site generation.

--- a/docs/fluencyloop/features/publish-generated-maven-plugin-goal-documentation/sessions/replace-the-obsolete-plugin-report-provider-and-verify-gener.md
+++ b/docs/fluencyloop/features/publish-generated-maven-plugin-goal-documentation/sessions/replace-the-obsolete-plugin-report-provider-and-verify-gener.md
@@ -1,0 +1,26 @@
+# Session: replace the obsolete plugin report provider and verify generated docs
+
+- **intent:** replace the obsolete plugin report provider and verify generated docs
+- **started:** 2026-07-20
+
+## Decision: Use the dedicated Maven Plugin Report Plugin for goal documentation
+
+- **where:** `blastradius-maven-plugin/pom.xml reporting section`
+- **why:** The Maven Plugin Plugin generates the descriptor and help mojo, but it has no report goal in the configured version. The dedicated report plugin generates the plugin overview and one page per goal.
+- **alternative:** Keep the report binding on maven-plugin-plugin — rejected because Maven fails: version 3.13.1 does not provide a report goal.
+- **design:** ../design.md#documentation-flow
+- **constitution:** §II
+- **trust:** ✓ verified
+
+## Knowledge transfer
+
+`helpmojo` belongs to the normal plugin build: it adds `blastradius:help` to the generated
+plugin descriptor, so consumers can inspect goals and parameters without browsing source.
+The staged Invoker fixture is the right integration test for this command because its
+`@blastradius.version@` placeholder has already been resolved; the source fixture has not.
+
+Generated HTML documentation is a separate Maven Site concern. The dedicated
+`maven-plugin-report-plugin` reads the plugin metadata and writes
+`target/site/plugin-info.html`, with one `*-mojo.html` page per goal. Keeping it in
+`<reporting>` makes documentation available on demand without adding site generation to
+ordinary `verify` builds.


### PR DESCRIPTION
## Summary

- generate the Maven plugin site reference with `maven-plugin-report-plugin`
- retain build-time descriptor and `blastradius:help` generation
- document how to generate and find the goal pages

## Decision

Use the dedicated reporting plugin because `maven-plugin-plugin:3.13.1` has no `report` goal. This keeps on-demand site generation separate from normal verification builds.

Design: `docs/fluencyloop/features/publish-generated-maven-plugin-goal-documentation/design.md`

## Verification

- `mvn -B --no-transfer-progress -f blastradius-maven-plugin/target/it/track/pom.xml blastradius:help`
- `mvn -B --no-transfer-progress -pl blastradius-maven-plugin -am site -DskipTests -Dinvoker.skip=true`

Addresses #10.