### PR TITLE
feat: add Gradle TRACK mode

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "gradle-plugin-scaffold-and-select-wiring",
-  "branch": "feature/gradle-plugin-scaffold-and-select-wiring",
+  "feature": "gradle-plugin-track-mode-agent-wiring",
+  "branch": "feature/gradle-plugin-track-mode-agent-wiring",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/gradle-plugin-scaffold-and-select-wiring/sessions/scaffold-the-gradle-adapter-and-prove-select-filtering-in-a.md",
+  "last_session": "docs/fluencyloop/features/gradle-plugin-track-mode-agent-wiring/sessions/attach-a-self-contained-agent-to-gradle-test-workers-and-mer.md",
   "base_ref": "main",
   "updated": "2026-07-20"
 }

--- a/blastradius-core/build.gradle
+++ b/blastradius-core/build.gradle
@@ -2,6 +2,13 @@ plugins {
     id 'java-library'
 }
 
+configurations {
+    agentElements {
+        canBeConsumed = true
+        canBeResolved = false
+    }
+}
+
 java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
@@ -9,6 +16,31 @@ java {
 
 tasks.withType(JavaCompile).configureEach {
     options.release = 21
+}
+
+tasks.register('agentJar', Jar) {
+    archiveClassifier = 'agent'
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    dependsOn configurations.runtimeClasspath
+
+    from sourceSets.main.output
+    from {
+        configurations.runtimeClasspath.collect { dependency ->
+            dependency.isDirectory() ? dependency : zipTree(dependency)
+        }
+    }
+
+    exclude 'META-INF/*.SF', 'META-INF/*.DSA', 'META-INF/*.RSA'
+    manifest {
+        attributes(
+                'Premain-Class': 'io.github.baokhang83.blastradius.core.tracking.DependencyTrackingAgent',
+                'Can-Redefine-Classes': 'true',
+                'Can-Retransform-Classes': 'true')
+    }
+}
+
+artifacts {
+    agentElements tasks.named('agentJar')
 }
 
 dependencies {

--- a/blastradius-gradle-plugin/build.gradle
+++ b/blastradius-gradle-plugin/build.gradle
@@ -21,7 +21,7 @@ gradlePlugin {
 }
 
 dependencies {
-    implementation project(':blastradius-core')
+    implementation project(path: ':blastradius-core', configuration: 'agentElements')
     implementation 'org.eclipse.jgit:org.eclipse.jgit:6.9.0.202403050737-r'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
     implementation 'org.junit.platform:junit-platform-launcher:1.10.2'

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/AgentJarLocator.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/AgentJarLocator.java
@@ -1,0 +1,27 @@
+package io.github.baokhang83.blastradius.gradle;
+
+import io.github.baokhang83.blastradius.core.tracking.DependencyTrackingAgent;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.gradle.api.GradleException;
+
+/** Locates the self-contained core artifact that can be attached as a Java agent. */
+final class AgentJarLocator {
+
+    Path locate() {
+        try {
+            Path agentJar = Path.of(DependencyTrackingAgent.class
+                    .getProtectionDomain()
+                    .getCodeSource()
+                    .getLocation()
+                    .toURI());
+            if (Files.isRegularFile(agentJar)) {
+                return agentJar;
+            }
+        } catch (URISyntaxException | NullPointerException e) {
+            throw new GradleException("could not resolve the blastradius tracking agent", e);
+        }
+        throw new GradleException("the blastradius tracking agent must be packaged as a JAR");
+    }
+}

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusPlugin.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusPlugin.java
@@ -15,6 +15,15 @@ public final class BlastradiusPlugin implements Plugin<Project> {
 
         project.getPluginManager().withPlugin("java", ignored -> project.getTasks()
                 .withType(Test.class)
-                .configureEach(test -> test.doFirst(ignoredTask -> new GradleSelectAction(project, extension).apply(test))));
+                .configureEach(test -> {
+                    GradleTrackAction trackAction = new GradleTrackAction(project, extension);
+                    GradleSelectAction selectAction = new GradleSelectAction(project, extension);
+                    test.doFirst(ignoredTask -> {
+                        if (!trackAction.prepare(test)) {
+                            selectAction.apply(test);
+                        }
+                    });
+                    test.doLast(ignoredTask -> trackAction.complete());
+                }));
     }
 }

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/DependencyIndexWriter.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/DependencyIndexWriter.java
@@ -1,0 +1,24 @@
+package io.github.baokhang83.blastradius.gradle;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Persists the shared dependency index produced by a Gradle TRACK build. */
+final class DependencyIndexWriter {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    void write(Path outputFile, DependencyIndex index) {
+        try {
+            if (outputFile.getParent() != null) {
+                Files.createDirectories(outputFile.getParent());
+            }
+            mapper.writeValue(outputFile.toFile(), index);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to write dependency index to " + outputFile, e);
+        }
+    }
+}

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/GradleSelectAction.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/GradleSelectAction.java
@@ -24,6 +24,7 @@ final class GradleSelectAction {
     private final CurrentChangesResolver currentChangesResolver = new CurrentChangesResolver();
     private final IndexApplicabilityResolver indexApplicabilityResolver = new IndexApplicabilityResolver();
     private final TestDiscoverer testDiscoverer = new TestDiscoverer();
+    private final IndexPathResolver indexPathResolver = new IndexPathResolver();
     GradleSelectAction(Project project, BlastradiusExtension extension) {
         this.project = project;
         this.extension = extension;
@@ -31,7 +32,7 @@ final class GradleSelectAction {
 
     void apply(Test test) {
         Path projectRoot = project.getRootDir().toPath();
-        Path indexPath = resolveIndexPath(projectRoot);
+        Path indexPath = indexPathResolver.resolve(project, extension);
         CurrentChanges changes = currentChangesResolver.resolve(projectRoot, extension.getBaseRef().get());
         IndexApplicability applicability = indexApplicabilityResolver.resolve(indexPath, projectRoot);
         if (changes.baseRefBuild() || applicability.status() != IndexApplicability.Status.APPLICABLE) {
@@ -50,15 +51,6 @@ final class GradleSelectAction {
         } catch (RuntimeException e) {
             project.getLogger().warn("[blastradius] selection failed; running the full test task", e);
         }
-    }
-
-    private Path resolveIndexPath(Path projectRoot) {
-        Path normalizedRoot = projectRoot.normalize();
-        Path resolved = projectRoot.resolve(extension.getIndexPath().get()).normalize();
-        if (!resolved.startsWith(normalizedRoot)) {
-            throw new GradleException("indexPath resolves outside the root project: " + resolved);
-        }
-        return resolved;
     }
 
     private static List<SelectionDecision> computeDecisions(Set<TestIdentity> allTests, DependencyIndex index,

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/GradleTrackAction.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/GradleTrackAction.java
@@ -1,0 +1,79 @@
+package io.github.baokhang83.blastradius.gradle;
+
+import io.github.baokhang83.blastradius.core.tracking.DependencyRecordReader;
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.testing.Test;
+
+/** Attaches the tracking agent to a base-reference {@link Test} task and writes its index. */
+final class GradleTrackAction {
+
+    private final Project project;
+    private final BlastradiusExtension extension;
+    private final CurrentChangesResolver currentChangesResolver = new CurrentChangesResolver();
+    private final IndexPathResolver indexPathResolver = new IndexPathResolver();
+    private final AgentJarLocator agentJarLocator = new AgentJarLocator();
+    private final DependencyRecordReader recordReader = new DependencyRecordReader();
+    private final DependencyIndexWriter indexWriter = new DependencyIndexWriter();
+    private TrackingRun trackingRun;
+
+    GradleTrackAction(Project project, BlastradiusExtension extension) {
+        this.project = project;
+        this.extension = extension;
+    }
+
+    boolean prepare(Test test) {
+        Path projectRoot = project.getRootDir().toPath();
+        CurrentChanges changes = currentChangesResolver.resolve(projectRoot, extension.getBaseRef().get());
+        if (!changes.baseRefBuild()) {
+            return false;
+        }
+
+        Path recordPrefix = createRecordPrefix(test);
+        Path agentJar = agentJarLocator.locate();
+        test.jvmArgs("-javaagent:" + agentJar.toAbsolutePath() + "=" + recordPrefix.toAbsolutePath());
+        trackingRun = new TrackingRun(changes.currentCommit(), indexPathResolver.resolve(project, extension), recordPrefix);
+        project.getLogger().info("[blastradius] TRACK — collecting test dependencies from {}", test.getPath());
+        return true;
+    }
+
+    void complete() {
+        if (trackingRun == null) {
+            return;
+        }
+        try {
+            Map<TestIdentity, Map<String, String>> recorded = recordReader.readAll(trackingRun.recordPrefix());
+            List<DependencyIndex.TestDependencyEntry> entries = recorded.entrySet().stream()
+                    .map(entry -> new DependencyIndex.TestDependencyEntry(entry.getKey(), entry.getValue().keySet()))
+                    .toList();
+            indexWriter.write(
+                    trackingRun.indexPath(), new DependencyIndex(trackingRun.anchorCommit(), Instant.now().toString(), entries));
+            project.getLogger().lifecycle(
+                    "[blastradius] TRACK — {} / {} tests selected", entries.size(), entries.size());
+        } catch (RuntimeException e) {
+            throw new GradleException("failed to create the blastradius dependency index after TRACK", e);
+        }
+    }
+
+    private static Path createRecordPrefix(Test test) {
+        try {
+            Path temporaryDirectory = test.getTemporaryDir().toPath();
+            Files.createDirectories(temporaryDirectory);
+            Path prefix = Files.createTempFile(temporaryDirectory, "blastradius-dependencies-", ".json");
+            Files.deleteIfExists(prefix);
+            return prefix;
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to create a temporary dependency-record path for " + test.getPath(), e);
+        }
+    }
+
+    private record TrackingRun(String anchorCommit, Path indexPath, Path recordPrefix) {}
+}

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/IndexPathResolver.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/IndexPathResolver.java
@@ -1,0 +1,18 @@
+package io.github.baokhang83.blastradius.gradle;
+
+import java.nio.file.Path;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+
+/** Resolves the root-relative shared index path without allowing it to escape the build root. */
+final class IndexPathResolver {
+
+    Path resolve(Project project, BlastradiusExtension extension) {
+        Path root = project.getRootDir().toPath().normalize();
+        Path resolved = root.resolve(extension.getIndexPath().get()).normalize();
+        if (!resolved.startsWith(root)) {
+            throw new GradleException("indexPath resolves outside the root project: " + resolved);
+        }
+        return resolved;
+    }
+}

--- a/blastradius-gradle-plugin/src/test/java/io/github/baokhang83/blastradius/gradle/BlastradiusPluginFunctionalTest.java
+++ b/blastradius-gradle-plugin/src/test/java/io/github/baokhang83/blastradius/gradle/BlastradiusPluginFunctionalTest.java
@@ -18,17 +18,36 @@ class BlastradiusPluginFunctionalTest {
     Path projectDir;
 
     @Test
+    void tracksOnTheBaseReferenceThenSelectsTheChangedTest() throws Exception {
+        writeProject();
+        String baselineCommit = commitBaseline();
+
+        BuildResult trackResult = runGradle("clean", "test");
+
+        Path indexPath = projectDir.resolve(".blastradius/index.json");
+        assertTrue(trackResult.getOutput().contains("[blastradius] TRACK — 2 / 2 tests selected"), trackResult.getOutput());
+        assertTrue(Files.exists(indexPath), "TRACK must create the shared dependency index");
+        assertTrue(Files.readString(indexPath).contains(baselineCommit), "TRACK must anchor the index at the base commit");
+
+        Files.deleteIfExists(projectDir.resolve("build/foo-ran"));
+        Files.deleteIfExists(projectDir.resolve("build/bar-ran"));
+        changeFoo();
+
+        BuildResult selectResult = runGradle("clean", "test");
+
+        assertTrue(selectResult.getOutput().contains("[blastradius] SELECT — 1 / 2 tests selected"), selectResult.getOutput());
+        assertTrue(Files.exists(projectDir.resolve("build/foo-ran")));
+        assertFalse(Files.exists(projectDir.resolve("build/bar-ran")));
+    }
+
+    @Test
     void selectsOnlyTheTestThatDependsOnTheChangedClass() throws Exception {
         writeProject();
         String baselineCommit = commitBaseline();
         changeFoo();
         writeIndex(baselineCommit);
 
-        BuildResult result = GradleRunner.create()
-                .withProjectDir(projectDir.toFile())
-                .withPluginClasspath()
-                .withArguments("test", "--stacktrace", "--info")
-                .build();
+        BuildResult result = runGradle("test");
 
         assertTrue(result.getOutput().contains("[blastradius] SELECT — 1 / 2 tests selected"), result.getOutput());
         assertTrue(Files.exists(projectDir.resolve("build/foo-ran")));
@@ -122,6 +141,17 @@ class BlastradiusPluginFunctionalTest {
                   ]
                 }
                 """.formatted(baselineCommit));
+    }
+
+    private BuildResult runGradle(String... arguments) {
+        String[] argumentsWithLogging = java.util.stream.Stream.concat(
+                        java.util.Arrays.stream(arguments), java.util.stream.Stream.of("--stacktrace", "--info"))
+                .toArray(String[]::new);
+        return GradleRunner.create()
+                .withProjectDir(projectDir.toFile())
+                .withPluginClasspath()
+                .withArguments(argumentsWithLogging)
+                .build();
     }
 
     private void write(String relativePath, String content) throws IOException {

--- a/docs/fluencyloop/features/gradle-plugin-track-mode-agent-wiring/design.md
+++ b/docs/fluencyloop/features/gradle-plugin-track-mode-agent-wiring/design.md
@@ -1,0 +1,92 @@
+# Design: Gradle plugin TRACK mode agent wiring
+
+started: 2026-07-20
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class BlastradiusPlugin {
+    +apply(Project)
+  }
+  class GradleTrackAction {
+    +prepare(Test) boolean
+    +complete()
+  }
+  class GradleSelectAction {
+    +apply(Test)
+  }
+  class CurrentChangesResolver {
+    +resolve(Path, String) CurrentChanges
+  }
+  class AgentJarLocator {
+    +locate() Path
+  }
+  class DependencyTrackingAgent {
+    +premain(String, Instrumentation)
+  }
+  class DependencyRecordReader {
+    +readAll(Path) Map
+  }
+  class DependencyIndexWriter {
+    +write(Path, DependencyIndex)
+  }
+  class Test
+  class agentJar {
+    <<Gradle artifact>>
+  }
+
+  BlastradiusPlugin --> GradleTrackAction : prepares / completes
+  BlastradiusPlugin --> GradleSelectAction : selects non-baseline builds
+  GradleTrackAction --> CurrentChangesResolver : identifies base build
+  GradleTrackAction --> AgentJarLocator : resolves self-contained agent
+  GradleTrackAction --> Test : adds -javaagent before execution
+  GradleTrackAction --> DependencyRecordReader : merges worker records
+  GradleTrackAction --> DependencyIndexWriter : persists shared index
+  AgentJarLocator --> agentJar
+  agentJar --> DependencyTrackingAgent : Premain-Class
+```
+
+## Sequence: base-reference TRACK build
+
+```mermaid
+sequenceDiagram
+  participant G as Gradle
+  participant P as BlastradiusPlugin
+  participant T as Test task
+  participant A as Tracking agent
+  participant R as DependencyRecordReader
+  participant I as .blastradius/index.json
+
+  G->>P: apply plugin
+  P->>T: install doFirst / doLast actions
+  G->>T: execute test on baseRef
+  T->>P: doFirst
+  P->>P: resolve HEAD == baseRef
+  P->>T: add -javaagent:agent.jar=record-prefix
+  T->>A: start test worker JVM
+  A->>A: record classes per active JUnit test
+  A-->>R: write record-prefix.pid at JVM shutdown
+  T->>P: doLast
+  P->>R: merge all worker records
+  R-->>P: test dependencies
+  P->>I: write anchor commit + dependencies
+  Note over I: A later Gradle or Maven SELECT build consumes this format
+```
+
+## Boundaries and decisions
+
+- The existing `blastradius-core` Gradle project will expose a self-contained `agentJar` with
+  the agent manifest and runtime dependencies. The Gradle plugin depends on that artifact, so
+  `DependencyTrackingAgent` resolves to a real, attachable JAR both in a published plugin and
+  in Gradle TestKit. A thin core JAR is not sufficient: `-javaagent` does not automatically
+  bring Jackson, which the shutdown hook needs to write records.
+- `GradleTrackAction` runs in the `Test` task's `doFirst`/`doLast` boundary. `doFirst` is early
+  enough to add JVM arguments before Gradle forks the worker; `doLast` is late enough for every
+  worker shutdown hook to have written its unique record. No nested Gradle build is needed.
+- A base-reference build is TRACK; a non-base build keeps the existing SELECT/fallback path.
+  TRACK never filters tests. Failure to read tracking output fails the TRACK build rather than
+  publishing a partial index.
+- This slice deliberately does not model tracking as cacheable Gradle task inputs or force
+  up-to-date `Test` tasks to rerun; issue #19 owns that compatibility work. The functional
+  proof starts from a clean consumer build, where Gradle executes the test task normally.

--- a/docs/fluencyloop/features/gradle-plugin-track-mode-agent-wiring/sessions/attach-a-self-contained-agent-to-gradle-test-workers-and-mer.md
+++ b/docs/fluencyloop/features/gradle-plugin-track-mode-agent-wiring/sessions/attach-a-self-contained-agent-to-gradle-test-workers-and-mer.md
@@ -1,0 +1,28 @@
+# Session: attach a self-contained agent to Gradle Test workers and merge TRACK records
+
+- **intent:** attach a self-contained agent to Gradle Test workers and merge TRACK records
+- **started:** 2026-07-20
+
+## Knowledge transfer
+
+- `blastradius-core` exposes `agentElements`, whose `agentJar` is an embedded-dependency JAR
+  with the agent manifest. The Gradle plugin consumes that exact variant, so the loaded
+  `DependencyTrackingAgent` has a real JAR code source that can be passed to `-javaagent`.
+- `GradleTrackAction.prepare` only acts when `HEAD` equals `baseRef`; it adds the JVM argument
+  before Gradle executes `Test`. On every other commit, `GradleSelectAction` retains the
+  established SELECT or safe full-suite fallback behavior.
+- The core agent writes one `<prefix>.<pid>` JSON record for each worker JVM. `complete` runs
+  after the task, merges those records through the existing `DependencyRecordReader`, and writes
+  the shared index with the baseline commit as its anchor. A missing record is a TRACK failure,
+  never a partial index.
+- TRACK currently relies on a normally executed `Test` task. Configuration-cache and up-to-date
+  task modelling are deliberately deferred to issue #19.
+
+## Decision: Package tracking as a self-contained core agent artifact
+
+- **where:** `blastradius-core agentJar and GradleTrackAction`
+- **why:** A Java agent receives only its own JAR, so the agent must embed its runtime dependencies before Test.doFirst attaches it; Test.doLast can then safely merge each worker's shutdown record.
+- **alternative:** Attach the ordinary core JAR — rejected because the agent's JSON writer would lack its runtime dependencies.
+- **design:** ../design.md#boundaries-and-decisions
+- **constitution:** §III, §VI
+- **trust:** ✓ verified


### PR DESCRIPTION
## Intent

Enable the Gradle plugin to produce the shared dependency index from a base-reference test build.

## Decision

Chose a self-contained core `agentJar` over attaching the ordinary core JAR, because a Java agent must carry the JSON-writing runtime dependencies it needs. `GradleTrackAction` attaches the agent in `Test.doFirst`, then merges per-worker records and writes the index in `doLast`.

This follows Constitution §§III and VI: a missing tracking record fails TRACK rather than publishing a partial index, and the implementation uses the standard Java Instrumentation API.

Design: `docs/fluencyloop/features/gradle-plugin-track-mode-agent-wiring/design.md`

## Scope boundary

TRACK applies when `HEAD == baseRef`; other builds keep SELECT or safe full-suite fallback behavior. Configuration-cache and up-to-date task modelling remain scoped to #19.

## Verification

- `./gradlew clean :blastradius-gradle-plugin:check --no-daemon --console=plain`
- `mvn -B --no-transfer-progress verify`

Closes #20.