### PR TITLE
Verify tracking agent on JDK 25

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "gradle-configuration-cache-and-up-to-date-compatibility",
-  "branch": "feature/gradle-configuration-cache-and-up-to-date-compatibility",
+  "feature": "verify-java-25-tracking-agent-support",
+  "branch": "feature/verify-java-25-tracking-agent-support",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/gradle-configuration-cache-and-up-to-date-compatibility/sessions/model-gradle-selection-inputs-and-isolate-test-execution-act.md",
+  "last_session": "docs/fluencyloop/features/verify-java-25-tracking-agent-support/sessions/track-jdk-25-virtual-and-hidden-class-loads.md",
   "base_ref": "main",
   "updated": "2026-07-20"
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
@@ -6,19 +6,29 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.ProtectionDomain;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * A {@code -javaagent} that observes every class loaded in the JVM it's attached to,
  * attributes each load to the currently-executing test (via the injected supplier — in
- * production, {@link TestBoundaryListener#currentTest()}), and records a SHA-256
- * checksum of the loaded bytecode. Bytecode is never modified — {@link #transform}
- * always returns {@code null}. Classes loaded while no test is running (JVM/Surefire
- * bootstrap, etc.) are not attributable to anything and are not recorded.
+ * production, {@link TestBoundaryListener#currentTest()}), and records the class name with a
+ * SHA-256 checksum of the loaded bytecode. Bytecode is never modified — {@link #transform}
+ * always returns {@code null}. Classes loaded while no test is running (JVM/Surefire bootstrap,
+ * etc.) are not attributable to anything and are not recorded. Hidden classes are not class-loader
+ * definitions, so the listener uses the agent's loaded-class list at test boundaries to record
+ * their stable source name. The persisted selection index consumes class names only.
  */
 public final class DependencyTrackingAgent implements ClassFileTransformer {
+
+    private static final String HIDDEN_CLASS_CHECKSUM = "hidden-class-bytecode-unavailable";
+
+    private static volatile DependencyTrackingAgent installedAgent;
+    private static volatile Instrumentation instrumentation;
 
     private final Supplier<TestIdentity> currentTestSupplier;
     private final Map<TestIdentity, Map<String, String>> checksumsByTest = new ConcurrentHashMap<>();
@@ -53,6 +63,8 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
      */
     public static void premain(String agentArgs, Instrumentation inst) {
         DependencyTrackingAgent agent = new DependencyTrackingAgent();
+        installedAgent = agent;
+        instrumentation = inst;
         inst.addTransformer(agent);
         if (agentArgs != null && !agentArgs.isBlank()) {
             Path outputFile = Path.of(agentArgs + "." + ProcessHandle.current().pid());
@@ -79,11 +91,43 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
         return null;
     }
 
-    /** An immutable snapshot of {@code test -> {className -> SHA-256 hex checksum}} recorded so far. */
+    /** An immutable snapshot of {@code test -> {className -> tracking token}} recorded so far. */
     public Map<TestIdentity, Map<String, String>> recordedDependencies() {
         return checksumsByTest.entrySet().stream()
                 .collect(java.util.stream.Collectors.toUnmodifiableMap(
                         Map.Entry::getKey, e -> Map.copyOf(e.getValue())));
+    }
+
+    static Set<Class<?>> loadedClasses() {
+        Instrumentation currentInstrumentation = instrumentation;
+        if (currentInstrumentation == null) {
+            return Set.of();
+        }
+        return Arrays.stream(currentInstrumentation.getAllLoadedClasses())
+                .<Class<?>>map(loadedClass -> loadedClass)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    static void recordHiddenClassesLoadedSince(TestIdentity test, Set<Class<?>> classesAtTestStart) {
+        DependencyTrackingAgent currentAgent = installedAgent;
+        Instrumentation currentInstrumentation = instrumentation;
+        if (currentAgent != null && currentInstrumentation != null) {
+            currentAgent.recordNewHiddenClasses(test, classesAtTestStart, currentInstrumentation.getAllLoadedClasses());
+        }
+    }
+
+    void recordNewHiddenClasses(TestIdentity test, Set<Class<?>> classesAtTestStart, Class<?>[] allLoadedClasses) {
+        Set<Class<?>> baseline = classesAtTestStart == null ? Set.of() : classesAtTestStart;
+        for (Class<?> loadedClass : allLoadedClasses) {
+            if (loadedClass.isHidden() && !baseline.contains(loadedClass)) {
+                String sourceClassName = sourceClassName(loadedClass);
+                if (sourceClassName != null) {
+                    checksumsByTest
+                            .computeIfAbsent(test, ignored -> new ConcurrentHashMap<>())
+                            .putIfAbsent(sourceClassName, HIDDEN_CLASS_CHECKSUM);
+                }
+            }
+        }
     }
 
     private static String sha256Hex(byte[] bytes) {
@@ -97,5 +141,11 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 is a required JDK algorithm", e);
         }
+    }
+
+    private static String sourceClassName(Class<?> hiddenClass) {
+        String hiddenName = hiddenClass.getName();
+        int suffixSeparator = hiddenName.lastIndexOf('/');
+        return suffixSeparator > 0 ? hiddenName.substring(0, suffixSeparator) : null;
     }
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/TestBoundaryListener.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/TestBoundaryListener.java
@@ -1,5 +1,6 @@
 package io.github.baokhang83.blastradius.core.tracking;
 
+import java.util.Set;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.TestExecutionListener;
@@ -7,16 +8,17 @@ import org.junit.platform.launcher.TestIdentifier;
 
 /**
  * A JUnit 5 {@link TestExecutionListener} that marks the currently-executing test via a
- * {@link ThreadLocal}, so {@link DependencyTrackingAgent}'s class-load observations can be
- * attributed to the test that triggered them.
+ * {@link InheritableThreadLocal}, so {@link DependencyTrackingAgent}'s class-load observations can
+ * be attributed to the test that triggered them, including classes first loaded by a child thread.
  *
- * <p>Assumes tests execute sequentially on one thread per test (no parallel execution) —
- * a documented limitation of this Foundational slice, not a correctness issue for the
- * validator's target use case.
+ * <p>Tests must await child-thread work before they finish. The identity is copied when a child
+ * thread is created, so work that outlives its test cannot be attributed reliably. Tests executing
+ * in parallel remain outside this listener's supported model.
  */
 public final class TestBoundaryListener implements TestExecutionListener {
 
-    private static final ThreadLocal<TestIdentity> CURRENT_TEST = new ThreadLocal<>();
+    private static final InheritableThreadLocal<TestIdentity> CURRENT_TEST = new InheritableThreadLocal<>();
+    private static final ThreadLocal<Set<Class<?>>> CLASSES_AT_TEST_START = new ThreadLocal<>();
 
     /** The test currently executing on this thread, or {@code null} if none. */
     public static TestIdentity currentTest() {
@@ -27,13 +29,20 @@ public final class TestBoundaryListener implements TestExecutionListener {
     public void executionStarted(TestIdentifier testIdentifier) {
         if (testIdentifier.isTest()) {
             CURRENT_TEST.set(toTestIdentity(testIdentifier));
+            CLASSES_AT_TEST_START.set(DependencyTrackingAgent.loadedClasses());
         }
     }
 
     @Override
     public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
         if (testIdentifier.isTest()) {
+            TestIdentity currentTest = CURRENT_TEST.get();
+            if (currentTest != null) {
+                DependencyTrackingAgent.recordHiddenClassesLoadedSince(
+                        currentTest, CLASSES_AT_TEST_START.get());
+            }
             CURRENT_TEST.remove();
+            CLASSES_AT_TEST_START.remove();
         }
     }
 

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
@@ -5,10 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
@@ -61,6 +64,32 @@ class DependencyTrackingAgentTest {
         currentTest.set(FOO_TEST);
         agent.transform(null, null, null, null, "x".getBytes(StandardCharsets.UTF_8));
         assertTrue(agent.recordedDependencies().isEmpty());
+    }
+
+    @Test
+    void newlyCreatedHiddenClassUsesItsStableSourceName() throws Exception {
+        currentTest.set(FOO_TEST);
+        byte[] classFile;
+        try (InputStream stream = DependencyTrackingAgentTest.class
+                .getResourceAsStream("DependencyTrackingAgentTest.class")) {
+            assertTrue(stream != null, "test class bytes must be available as a resource");
+            classFile = stream.readAllBytes();
+        }
+
+        Class<?> hiddenClass = MethodHandles.lookup().defineHiddenClass(classFile, false).lookupClass();
+        agent.recordNewHiddenClasses(FOO_TEST, Set.of(), new Class<?>[] {hiddenClass});
+
+        assertTrue(agent.recordedDependencies().get(FOO_TEST)
+                .containsKey(DependencyTrackingAgentTest.class.getName()));
+    }
+
+    @Test
+    void moduleAwareTransformRecordsTheClass() throws Exception {
+        currentTest.set(FOO_TEST);
+
+        agent.transform(Object.class.getModule(), null, "com/example/Foo", null, null, "x".getBytes(StandardCharsets.UTF_8));
+
+        assertTrue(agent.recordedDependencies().get(FOO_TEST).containsKey("com.example.Foo"));
     }
 
     @Test

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingIntegrationTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingIntegrationTest.java
@@ -95,6 +95,82 @@ class DependencyTrackingIntegrationTest {
                 "cross-module dependency must be attributed (FR-011): " + recorded.get(consumerTest));
     }
 
+    @Test
+    void virtualThreadAttributionIncludesSealedAndHiddenClassLoadsOnJdk25(
+            @TempDir Path projectDir, @TempDir Path outDir) throws Exception {
+        Path agentJar = findOwnAgentJar();
+        Path recordFile = outDir.resolve("deps.json");
+
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.addSystemDependency(null, agentJar);
+        fixture.writeClass("com.example.VirtualDependency", """
+                package com.example;
+                public sealed interface VirtualDependency permits VirtualDependencyImplementation {
+                    String value();
+                }
+                final class VirtualDependencyImplementation implements VirtualDependency {
+                    public String value() { return "sealed"; }
+                }
+                """);
+        fixture.writeClass("com.example.HiddenTemplate", """
+                package com.example;
+                public class HiddenTemplate {}
+                """);
+        fixture.writeTest("com.example.Jdk25TrackingTest", """
+                package com.example;
+                import java.io.InputStream;
+                import java.lang.invoke.MethodHandles;
+                import java.util.concurrent.atomic.AtomicReference;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                import static org.junit.jupiter.api.Assertions.assertNotNull;
+                import static org.junit.jupiter.api.Assertions.assertTrue;
+
+                class Jdk25TrackingTest {
+                    @Test
+                    void tracksVirtualThreadSealedAndHiddenClassLoads() throws Exception {
+                        byte[] hiddenTemplateBytes;
+                        try (InputStream stream = getClass().getClassLoader()
+                                .getResourceAsStream("com/example/HiddenTemplate.class")) {
+                            assertNotNull(stream, "compiled hidden-class template must be available");
+                            hiddenTemplateBytes = stream.readAllBytes();
+                        }
+
+                        AtomicReference<Throwable> failure = new AtomicReference<>();
+                        Thread worker = Thread.startVirtualThread(() -> {
+                            try {
+                                assertEquals("sealed", new VirtualDependencyImplementation().value());
+                                assertTrue(MethodHandles.lookup()
+                                        .defineHiddenClass(hiddenTemplateBytes, true)
+                                        .lookupClass()
+                                        .isHidden());
+                            } catch (Throwable t) {
+                                failure.set(t);
+                            }
+                        });
+                        worker.join();
+                        if (failure.get() != null) {
+                            throw new AssertionError("virtual-thread work failed", failure.get());
+                        }
+                    }
+                }
+                """);
+        fixture.commit("initial");
+
+        runMvnTest(projectDir, agentJar, recordFile);
+
+        Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(recordFile);
+        TestIdentity jdk25Test = new TestIdentity(
+                "com.example.Jdk25TrackingTest", "tracksVirtualThreadSealedAndHiddenClassLoads");
+
+        assertTrue(recorded.containsKey(jdk25Test),
+                "expected an entry for " + jdk25Test + " in " + recorded.keySet());
+        assertTrue(recorded.get(jdk25Test).containsKey("com.example.VirtualDependencyImplementation"),
+                "sealed class loaded by the virtual thread must be attributed: " + recorded.get(jdk25Test));
+        assertTrue(recorded.get(jdk25Test).containsKey("com.example.HiddenTemplate"),
+                "hidden class must be attributed under its stable source class name: " + recorded.get(jdk25Test));
+    }
+
     private static Path findOwnAgentJar() throws IOException {
         Path targetDir = Path.of("target");
         try (var stream = Files.list(targetDir)) {

--- a/docs/fluencyloop/features/verify-java-25-tracking-agent-support/design.md
+++ b/docs/fluencyloop/features/verify-java-25-tracking-agent-support/design.md
@@ -1,0 +1,85 @@
+# Design: Verify Java 25 tracking agent support
+
+<!--
+FluencyLoop Stage 2 — one design.md per feature, committed alongside it.
+Defaults: a class diagram and a sequence diagram (the two first-class Mermaid types that
+pay their way most often). Add an interaction/flow view only when it earns its place.
+Keep the Mermaid blocks TOP-LEVEL (not nested in another code fence) so GitHub renders them.
+Delete this comment once the diagrams are real.
+-->
+
+started: 2026-07-20
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class TestBoundaryListener {
+    -InheritableThreadLocal~TestIdentity~ CURRENT_TEST
+    +currentTest() TestIdentity
+    +executionStarted(TestIdentifier)
+    +executionFinished(TestIdentifier, TestExecutionResult)
+  }
+  class DependencyTrackingAgent {
+    +transform(Module, ClassLoader, String, Class, ProtectionDomain, byte[]) byte[]
+    +transform(ClassLoader, String, Class, ProtectionDomain, byte[]) byte[]
+    +recordedDependencies() Map
+  }
+  class VirtualThread {
+    inherits "test identity at creation"
+  }
+  class SealedDependency
+  class HiddenTemplate
+  class DependencyRecordWriter
+
+  TestBoundaryListener --> VirtualThread : propagates TestIdentity
+  VirtualThread --> DependencyTrackingAgent : loads classes
+  DependencyTrackingAgent --> DependencyRecordWriter : writes test -> class checksum
+  VirtualThread --> SealedDependency : named class load
+  VirtualThread --> HiddenTemplate : hidden definition source
+```
+
+## Sequence: JDK 25 class-load attribution
+
+```mermaid
+sequenceDiagram
+  participant JUnit as JUnit test thread
+  participant Listener as TestBoundaryListener
+  participant VT as virtual thread
+  participant Agent as DependencyTrackingAgent
+  participant Record as dependency record
+
+  JUnit->>Listener: executionStarted(test)
+  Listener->>Listener: set TestIdentity
+  JUnit->>VT: Thread.startVirtualThread(work)
+  Note over Listener,VT: identity is copied when the child is created
+  VT->>Agent: module-aware class-load callback
+  Agent->>Agent: normalize stable class name and checksum bytecode
+  Agent->>Record: test -> dependency
+  VT-->>JUnit: join
+  JUnit->>Listener: executionFinished(test)
+  Listener->>Listener: clear parent identity
+```
+
+## Compatibility boundaries
+
+- The test uses a sealed production type and `Lookup#defineHiddenClass` from a virtual
+  thread on JDK 25. Hidden classes do not enter the class-load transformer, so the
+  listener compares the agent's loaded-class list at test start and finish. New hidden
+  classes are recorded under their stable source name, never their synthetic runtime
+  name, because selection matches changed source-class names.
+- The agent remains observation-only and returns `null`; it does not open modules or
+  rewrite bytecode. The JDK's module-aware `ClassFileTransformer` entry point is tested
+  directly as well as exercised by the subprocess integration test.
+- Identity is inherited only when a child thread is created. Tests must still await
+  asynchronous work before finishing, otherwise any tracker cannot reliably assign
+  late work to a completed test.
+
+## Validation
+
+1. Start a real Maven fixture under the built `-javaagent` on JDK 25.
+2. In one JUnit test, load a sealed implementation and define a hidden class from a
+   virtual thread; assert both stable source names are recorded for that test.
+3. Unit-test the module-bearing transformer callback and preserve the existing
+   null-name behavior for unnameable definitions.
+4. Run Maven's full verify lifecycle on JDK 25, then Gradle's complete check.

--- a/docs/fluencyloop/features/verify-java-25-tracking-agent-support/sessions/track-jdk-25-virtual-and-hidden-class-loads.md
+++ b/docs/fluencyloop/features/verify-java-25-tracking-agent-support/sessions/track-jdk-25-virtual-and-hidden-class-loads.md
@@ -1,0 +1,23 @@
+# Session: Track JDK 25 virtual and hidden class loads
+
+- **intent:** Track JDK 25 virtual and hidden class loads
+- **started:** 2026-07-20
+
+## Decision: Attribute JDK 25 child-thread and hidden-class loads to their test
+
+- **where:** `blastradius-core tracking boundary`
+- **why:** An inheritable test identity preserves attribution for a virtual thread created by
+  the test. Hidden classes bypass `ClassFileTransformer`, so a loaded-class delta at the test
+  boundary adds their stable source name to the dependency index.
+- **alternative:** Parse a null transformer class name from class bytes — rejected because the
+  JVM does not call the transformer for a hidden-class definition.
+- **design:** `../design.md#compatibility-boundaries`
+- **trust:** ✓ verified by the JDK 25 subprocess integration test.
+
+## Knowledge transfer
+
+- `InheritableThreadLocal` copies its value when a virtual child thread is created; the test must
+  join that child before JUnit finishes the parent test.
+- A hidden class has a synthetic runtime name, but its source-class portion before the final `/`
+  is the key the selector needs. Its bytecode is unavailable through the transformer, while the
+  persisted index deliberately consumes only dependency names.


### PR DESCRIPTION
## Summary

- Propagate the active test identity into virtual threads so their first class loads remain attributable.
- Capture hidden classes at the JUnit test boundary and index their stable source name.
- Add JDK 25 coverage for module-aware transformer dispatch, sealed classes, hidden classes, and virtual threads.

## Design

See docs/fluencyloop/features/verify-java-25-tracking-agent-support/design.md for the tracking flow and compatibility boundaries.

## Verification

- Maven full verify on OpenJDK 25.0.1.
- Gradle clean check for the Gradle plugin.

Closes #21