### PR TITLE
Run CI on JDK 21 and 25

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "verify-java-25-tracking-agent-support",
-  "branch": "feature/verify-java-25-tracking-agent-support",
+  "feature": "run-ci-on-jdk-21-and-25",
+  "branch": "feature/run-ci-on-jdk-21-and-25",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/verify-java-25-tracking-agent-support/sessions/track-jdk-25-virtual-and-hidden-class-loads.md",
+  "last_session": "docs/fluencyloop/features/run-ci-on-jdk-21-and-25/sessions/verify-jdk-matrix-coverage.md",
   "base_ref": "main",
   "updated": "2026-07-20"
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,12 @@ permissions:
 
 jobs:
   verify:
-    name: Maven 3.9.6 / JDK 21
+    name: Maven 3.9.6 / JDK ${{ matrix.java }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ['21', '25']
     steps:
       - uses: actions/checkout@v7
         with:
@@ -18,7 +22,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: ${{ matrix.java }}
           cache: maven
       - uses: stCarolas/setup-maven@v5
         with:

--- a/docs/fluencyloop/features/run-ci-on-jdk-21-and-25/design.md
+++ b/docs/fluencyloop/features/run-ci-on-jdk-21-and-25/design.md
@@ -1,0 +1,71 @@
+# Design: Run CI on JDK 21 and 25
+
+<!--
+FluencyLoop Stage 2 — one design.md per feature, committed alongside it.
+Defaults: a class diagram and a sequence diagram (the two first-class Mermaid types that
+pay their way most often). Add an interaction/flow view only when it earns its place.
+Keep the Mermaid blocks TOP-LEVEL (not nested in another code fence) so GitHub renders them.
+Delete this comment once the diagrams are real.
+-->
+
+started: 2026-07-20
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class BuildWorkflow {
+    push or pull_request trigger
+  }
+  class VerifyMatrix {
+    java: 21
+    java: 25
+    fail-fast: false
+  }
+  class SetupJava {
+    Temurin JDK
+    Maven dependency cache
+  }
+  class MavenVerify {
+    clean verify
+  }
+
+  BuildWorkflow --> VerifyMatrix : expands one job per JDK
+  VerifyMatrix --> SetupJava : provisions selected version
+  SetupJava --> MavenVerify : runs unchanged lifecycle
+```
+
+## Sequence: CI verification matrix
+
+```mermaid
+sequenceDiagram
+  participant Event as push / pull request
+  participant Workflow as Build workflow
+  participant J21 as JDK 21 job
+  participant J25 as JDK 25 job
+  participant Maven as Maven verify
+
+  Event->>Workflow: trigger
+  par matrix java = 21
+    Workflow->>J21: checkout and set up Temurin 21
+    J21->>Maven: clean verify
+  and matrix java = 25
+    Workflow->>J25: checkout and set up Temurin 25
+    J25->>Maven: clean verify
+  end
+```
+
+## Compatibility boundary
+
+- The build workflow, rather than the release workflow, is the compatibility gate: every push
+  and pull request proves the full Maven reactor and invoker tests on both supported LTS JDKs.
+- A single matrix job keeps checkout, Maven setup, caching, and verification identical across
+  JDKs. Duplicating two near-identical jobs was rejected because the steps could drift.
+- Matrix failures do not cancel their sibling job, so a JDK 21 regression cannot hide the JDK 25
+  result, or vice versa.
+
+## Validation
+
+1. Confirm the rendered workflow has one job for JDK 21 and one for JDK 25.
+2. Confirm both entries run the unchanged `mvn -B --no-transfer-progress clean verify` command.
+3. Merge only after both GitHub Actions matrix entries pass.

--- a/docs/fluencyloop/features/run-ci-on-jdk-21-and-25/design.md
+++ b/docs/fluencyloop/features/run-ci-on-jdk-21-and-25/design.md
@@ -57,8 +57,9 @@ sequenceDiagram
 
 ## Compatibility boundary
 
-- The build workflow, rather than the release workflow, is the compatibility gate: every push
-  and pull request proves the full Maven reactor and invoker tests on both supported LTS JDKs.
+- The build workflow, rather than the release workflow, is the compatibility gate: every pull
+  request and every push to `main` proves the full Maven reactor and invoker tests on both
+  supported LTS JDKs. Feature-branch pushes rely on the pull-request run, avoiding duplicate work.
 - A single matrix job keeps checkout, Maven setup, caching, and verification identical across
   JDKs. Duplicating two near-identical jobs was rejected because the steps could drift.
 - Matrix failures do not cancel their sibling job, so a JDK 21 regression cannot hide the JDK 25

--- a/docs/fluencyloop/features/run-ci-on-jdk-21-and-25/sessions/verify-jdk-matrix-coverage.md
+++ b/docs/fluencyloop/features/run-ci-on-jdk-21-and-25/sessions/verify-jdk-matrix-coverage.md
@@ -20,3 +20,15 @@
 - `fail-fast: false` lets both matrix entries finish after a sibling failure, preserving the
   complete compatibility evidence for review. GitHub Actions remains the final workflow-parser
   and runtime validation. Status: follow-up.
+- `push.branches: [main]` retains post-merge coverage while the pull-request event supplies the
+  feature-branch matrix, preventing the same commit from producing two identical check pairs.
+  Status: documented.
+
+## Decision: Avoid duplicate feature-branch CI runs
+
+- **where:** `.github/workflows/build.yml triggers`
+- **why:** Pull-request events already execute both JDK checks for a feature branch, while retaining push coverage on main verifies the merged result without duplicate checks.
+- **alternative:** Run on every push and pull request — rejected because each pull request receives the same JDK matrix twice.
+- **design:** ../design.md#compatibility-boundary
+- **constitution:** §II
+- **trust:** ✓ verified

--- a/docs/fluencyloop/features/run-ci-on-jdk-21-and-25/sessions/verify-jdk-matrix-coverage.md
+++ b/docs/fluencyloop/features/run-ci-on-jdk-21-and-25/sessions/verify-jdk-matrix-coverage.md
@@ -1,0 +1,22 @@
+# Session: Verify JDK matrix coverage
+
+- **intent:** Verify JDK matrix coverage
+- **started:** 2026-07-20
+
+## Decision: Use one independent JDK matrix job
+
+- **where:** `.github/workflows/build.yml verify job`
+- **why:** A single parameterized job guarantees both JDKs execute the same checkout, Maven setup, cache, and full verification lifecycle; fail-fast disabled preserves both results.
+- **alternative:** Two copied JDK-specific jobs — rejected because their setup and verification steps could drift.
+- **design:** ../design.md#compatibility-boundary
+- **constitution:** §VI
+- **trust:** ⚠ not independently verified
+
+## Knowledge transfer
+
+- The `verify` job is expanded once for each value in `matrix.java`; each job receives the
+  selected Temurin version through `actions/setup-java` and runs the same Maven reactor command.
+  Status: documented.
+- `fail-fast: false` lets both matrix entries finish after a sibling failure, preserving the
+  complete compatibility evidence for review. GitHub Actions remains the final workflow-parser
+  and runtime validation. Status: follow-up.


### PR DESCRIPTION
## Summary

- Run the full Maven verification workflow on Temurin JDK 21 and 25.
- Keep both matrix results visible when one JDK fails.
- Reuse one job definition so setup and verification steps stay identical.

## Design

See docs/fluencyloop/features/run-ci-on-jdk-21-and-25/design.md for the workflow shape.

## Verification

- Local YAML assertions confirm the JDK matrix, independent jobs, and matrix-driven Java setup.
- GitHub Actions will run the full Maven reactor and invoker suite on both JDKs.

Closes #22