### PR TITLE
Verify Kotlin-aware dependency tracking

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "run-ci-on-jdk-21-and-25",
-  "branch": "feature/run-ci-on-jdk-21-and-25",
+  "feature": "verify-kotlin-aware-dependency-tracking",
+  "branch": "feature/verify-kotlin-aware-dependency-tracking",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/run-ci-on-jdk-21-and-25/sessions/verify-jdk-matrix-coverage.md",
+  "last_session": "docs/fluencyloop/features/verify-kotlin-aware-dependency-tracking/sessions/detect-kotlin-inline-modifier-variants-conservatively.md",
   "base_ref": "main",
   "updated": "2026-07-20"
 }

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ name mismatch) is in [`SESSION.md`](SESSION.md).
    class actually loaded while each test runs and records which production classes it
    really touched — ground truth, not a guess.
 2. **Diff.** On every other build, the current commit is diffed against your base
-   reference: Java source changes vs. everything else (config, resources, `pom.xml`,
-   migrations).
+   reference: JVM source changes (Java and conventional Kotlin) vs. everything else
+   (config, resources, `pom.xml`, migrations).
 3. **Select.** A test runs if one of its tracked dependencies changed, it's new or was
    itself modified, or a non-source change triggered the conservative "just run
    everything" fallback.
@@ -81,6 +81,21 @@ Fully supported, without extra bookkeeping. Because tracking is based on actual 
 loads rather than a static per-module dependency graph, a change in one module correctly
 selects a *dependent* test living in another module — attribution falls out of the
 mechanism itself.
+
+## Kotlin/JVM support
+
+Blastradius recognizes conventional Kotlin source roots — `src/main/kotlin` and
+`src/test/kotlin` — alongside their Java equivalents. A changed `Greeting.kt` contributes both
+the ordinary `Greeting` name and Kotlin's generated `GreetingKt` file facade; recorded nested
+or lambda classes such as `GreetingKt$format$1` are attributed to that stable source root.
+
+Kotlin inline functions are deliberately conservative. Their bodies are copied into callers, so
+there may be no stable class load to attribute to the changed source file. If either side of a
+Kotlin change contains an inline function, Blastradius runs the full suite instead of narrowing.
+
+Custom `@file:JvmName` facades and Kotlin source files whose emitted class names do not follow
+their file names are outside this filename-based mapping. Keep the recommended regular full-suite
+run for those projects and for any other compiler-generated edge case.
 
 ## Why this is safe to use
 

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/ChangedFile.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/ChangedFile.java
@@ -1,6 +1,7 @@
 package io.github.baokhang83.blastradius.core.git;
 
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * One file that differs between a commit pair's base and head.
@@ -18,5 +19,20 @@ public record ChangedFile(String path, FileKind kind, String changedClassName) {
         if (kind == FileKind.JAVA_SOURCE) {
             Objects.requireNonNull(changedClassName, "changedClassName required for JAVA_SOURCE");
         }
+    }
+
+    /**
+     * JVM class names a source change can affect. Kotlin emits a file facade named
+     * {@code FileNameKt} for top-level declarations in addition to an ordinary class whose
+     * name follows the source file name.
+     */
+    public Set<String> candidateClassNames() {
+        if (kind != FileKind.JAVA_SOURCE) {
+            return Set.of();
+        }
+        if (path.endsWith(".kt")) {
+            return Set.of(changedClassName, changedClassName + "Kt");
+        }
+        return Set.of(changedClassName);
     }
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/ChangedFileClassifier.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/ChangedFileClassifier.java
@@ -1,5 +1,7 @@
 package io.github.baokhang83.blastradius.core.git;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,18 +15,24 @@ import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.CanonicalTreeParser;
+import java.util.regex.Pattern;
 
 /**
  * Diffs a commit pair and classifies each changed file as {@link FileKind#JAVA_SOURCE}
  * (subject to dependency-match selection) or {@link FileKind#NON_SOURCE} (subject to the
- * conservative fallback rule, per FR-006). Java source class names are derived from the
- * standard Maven {@code src/main/java/} / {@code src/test/java/} layout, which also
- * makes multi-module reactors module-agnostic here (research.md #5).
+ * conservative fallback rule, per FR-006). Java and conventional Kotlin source class names are
+ * derived from standard Maven source layouts, which also makes multi-module reactors
+ * module-agnostic here (research.md #5). Kotlin files with an {@code inline fun} on either side
+ * of a diff deliberately fall back: the compiler copies their body into callers, so no stable
+ * class-load dependency can prove every affected test was selected.
  */
 public final class ChangedFileClassifier {
 
     private static final String MAIN_JAVA_MARKER = "src/main/java/";
     private static final String TEST_JAVA_MARKER = "src/test/java/";
+    private static final String MAIN_KOTLIN_MARKER = "src/main/kotlin/";
+    private static final String TEST_KOTLIN_MARKER = "src/test/kotlin/";
+    private static final Pattern INLINE_FUNCTION = Pattern.compile("\\binline\\b(?:\\s+[A-Za-z]+)*\\s+fun\\b");
 
     public List<ChangedFile> classify(Path repoPath, String baseCommit, String headCommit) {
         try (Git git = Git.open(repoPath.toFile())) {
@@ -48,7 +56,7 @@ public final class ChangedFileClassifier {
                     String path = entry.getChangeType() == DiffEntry.ChangeType.DELETE
                             ? entry.getOldPath()
                             : entry.getNewPath();
-                    result.add(classifyPath(path));
+                    result.add(classifyEntry(path, entry, reader));
                 }
                 return result;
             }
@@ -58,7 +66,10 @@ public final class ChangedFileClassifier {
         }
     }
 
-    private static ChangedFile classifyPath(String path) {
+    private static ChangedFile classifyEntry(String path, DiffEntry entry, ObjectReader reader) throws IOException {
+        if (path.endsWith(".kt") && containsInlineFunction(entry, reader)) {
+            return new ChangedFile(path, FileKind.NON_SOURCE, null);
+        }
         String className = classNameFromPath(path);
         if (className != null) {
             return new ChangedFile(path, FileKind.JAVA_SOURCE, className);
@@ -67,6 +78,19 @@ public final class ChangedFileClassifier {
             return new ChangedFile(path, FileKind.INERT, null);
         }
         return new ChangedFile(path, FileKind.NON_SOURCE, null);
+    }
+
+    private static boolean containsInlineFunction(DiffEntry entry, ObjectReader reader) throws IOException {
+        return sourceContainsInlineFunction(entry.getOldId().toObjectId(), reader)
+                || sourceContainsInlineFunction(entry.getNewId().toObjectId(), reader);
+    }
+
+    private static boolean sourceContainsInlineFunction(ObjectId sourceId, ObjectReader reader) throws IOException {
+        if (ObjectId.zeroId().equals(sourceId)) {
+            return false;
+        }
+        String source = new String(reader.open(sourceId).getBytes(), StandardCharsets.UTF_8);
+        return INLINE_FUNCTION.matcher(source).find();
     }
 
     // Documentation and media extensions that cannot affect a test outcome.
@@ -114,16 +138,24 @@ public final class ChangedFileClassifier {
 
     private static String classNameFromPath(String path) {
         String marker = null;
-        if (path.contains(MAIN_JAVA_MARKER)) {
+        String extension;
+        if (path.contains(MAIN_JAVA_MARKER) && path.endsWith(".java")) {
             marker = MAIN_JAVA_MARKER;
-        } else if (path.contains(TEST_JAVA_MARKER)) {
+            extension = ".java";
+        } else if (path.contains(TEST_JAVA_MARKER) && path.endsWith(".java")) {
             marker = TEST_JAVA_MARKER;
-        }
-        if (marker == null || !path.endsWith(".java")) {
+            extension = ".java";
+        } else if (path.contains(MAIN_KOTLIN_MARKER) && path.endsWith(".kt")) {
+            marker = MAIN_KOTLIN_MARKER;
+            extension = ".kt";
+        } else if (path.contains(TEST_KOTLIN_MARKER) && path.endsWith(".kt")) {
+            marker = TEST_KOTLIN_MARKER;
+            extension = ".kt";
+        } else {
             return null;
         }
         String relative = path.substring(path.indexOf(marker) + marker.length());
-        String withoutExtension = relative.substring(0, relative.length() - ".java".length());
+        String withoutExtension = relative.substring(0, relative.length() - extension.length());
         return withoutExtension.replace('/', '.');
     }
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/FileKind.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/FileKind.java
@@ -3,7 +3,8 @@ package io.github.baokhang83.blastradius.core.git;
 /**
  * How a changed file is treated by selection:
  * <ul>
- *   <li>{@link #JAVA_SOURCE} — subject to dependency-match selection;</li>
+ *   <li>{@link #JAVA_SOURCE} — JVM source subject to dependency-match selection;
+ *       this legacy-named value covers Java and conventional Kotlin source paths;</li>
  *   <li>{@link #NON_SOURCE} — subject to the conservative fallback rule (FR-006), because it
  *       may affect a test outcome in a way class-load tracking cannot observe;</li>
  *   <li>{@link #INERT} — provably cannot affect any test outcome (docs, license, images,

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/DependencyMatchSelector.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/DependencyMatchSelector.java
@@ -7,9 +7,11 @@ import java.util.Set;
 public final class DependencyMatchSelector {
 
     public SelectionDecision select(TestIdentity test, Set<String> testDependencies, Set<String> changedClassNames) {
-        for (String dependency : testDependencies) {
-            if (changedClassNames.contains(dependency)) {
-                return SelectionDecision.dependencyMatch(test, dependency);
+        for (String changedClassName : changedClassNames) {
+            if (testDependencies.contains(changedClassName)
+                    || testDependencies.stream().anyMatch(
+                            dependency -> dependency.startsWith(changedClassName + "$"))) {
+                return SelectionDecision.dependencyMatch(test, changedClassName);
             }
         }
         return SelectionDecision.noMatch(test);

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionEngine.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionEngine.java
@@ -1,7 +1,6 @@
 package io.github.baokhang83.blastradius.core.selection;
 
 import io.github.baokhang83.blastradius.core.git.ChangedFile;
-import io.github.baokhang83.blastradius.core.git.FileKind;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,8 +40,7 @@ public final class SelectionEngine {
         }
 
         Set<String> changedClassNames = changedFiles.stream()
-                .filter(f -> f.kind() == FileKind.JAVA_SOURCE)
-                .map(ChangedFile::changedClassName)
+                .flatMap(file -> file.candidateClassNames().stream())
                 .collect(Collectors.toUnmodifiableSet());
 
         List<SelectionDecision> decisions = new ArrayList<>();

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/git/ChangedFileClassifierTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/git/ChangedFileClassifierTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -40,6 +41,46 @@ class ChangedFileClassifierTest {
         ChangedFile fooTest = single(changed, "src/test/java/com/example/FooTest.java");
         assertEquals(FileKind.JAVA_SOURCE, fooTest.kind());
         assertEquals("com.example.FooTest", fooTest.changedClassName());
+    }
+
+    @Test
+    void kotlinSourceChangeProvidesClassAndFileFacadeCandidates(@TempDir Path tempDir) {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(tempDir);
+        String base = fixture.commit("initial");
+        fixture.writeResource("src/main/kotlin/com/example/Greeting.kt", """
+                package com.example
+                class Greeting
+                """);
+        String head = fixture.commit("add Kotlin greeting");
+
+        ChangedFile greeting = single(classifier.classify(tempDir, base, head),
+                "src/main/kotlin/com/example/Greeting.kt");
+
+        assertEquals(FileKind.JAVA_SOURCE, greeting.kind());
+        assertEquals("com.example.Greeting", greeting.changedClassName());
+        assertEquals(Set.of("com.example.Greeting", "com.example.GreetingKt"),
+                greeting.candidateClassNames());
+    }
+
+    @Test
+    void kotlinInlineFunctionChangeFallsBackToTheFullSuite(@TempDir Path tempDir) {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(tempDir);
+        fixture.writeResource("src/main/kotlin/com/example/Greeting.kt", """
+                package com.example
+                fun greeting() = "hello"
+                """);
+        String base = fixture.commit("ordinary Kotlin greeting");
+        fixture.writeResource("src/main/kotlin/com/example/Greeting.kt", """
+                package com.example
+                inline suspend fun greeting() = "hello"
+                """);
+        String head = fixture.commit("inline Kotlin greeting");
+
+        ChangedFile greeting = single(classifier.classify(tempDir, base, head),
+                "src/main/kotlin/com/example/Greeting.kt");
+
+        assertEquals(FileKind.NON_SOURCE, greeting.kind());
+        assertNull(greeting.changedClassName());
     }
 
     @Test

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/DependencyMatchSelectorTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/DependencyMatchSelectorTest.java
@@ -35,6 +35,17 @@ class DependencyMatchSelectorTest {
     }
 
     @Test
+    void selectsWhenACompilerGeneratedNestedClassBelongsToAChangedSourceCandidate() {
+        SelectionDecision decision = selector.select(FOO_TEST,
+                Set.of("com.example.GreetingKt$format$1"),
+                Set.of("com.example.GreetingKt"));
+
+        assertTrue(decision.selected());
+        assertEquals(SelectionReason.DEPENDENCY_MATCH, decision.reason());
+        assertEquals("com.example.GreetingKt", decision.matchedChangedClass());
+    }
+
+    @Test
     void emptyDependencySetNeverMatches() {
         SelectionDecision decision = selector.select(FOO_TEST, Set.of(), Set.of("com.example.Foo"));
         assertFalse(decision.selected());

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/SelectionEngineTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/SelectionEngineTest.java
@@ -69,6 +69,18 @@ class SelectionEngineTest {
     }
 
     @Test
+    void kotlinFileFacadeCandidateContributesToDependencyMatching() {
+        List<ChangedFile> changed = List.of(new ChangedFile(
+                "src/main/kotlin/com/example/Greeting.kt", FileKind.JAVA_SOURCE, "com.example.Greeting"));
+
+        List<SelectionDecision> decisions = engine.selectAll(
+                Set.of(MATCHED_TEST), Map.of(MATCHED_TEST, Set.of("com.example.GreetingKt")), Set.of(), changed);
+
+        assertTrue(decisions.getFirst().selected());
+        assertEquals("com.example.GreetingKt", decisions.getFirst().matchedChangedClass());
+    }
+
+    @Test
     void producesExactlyOneDecisionPerTest() {
         List<SelectionDecision> decisions = engine.selectAll(
                 Set.of(MATCHED_TEST, UNRELATED_TEST, NEW_TEST), Map.of(), Set.of(), List.of());

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/testsupport/FixtureProjectBuilder.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/testsupport/FixtureProjectBuilder.java
@@ -19,6 +19,7 @@ import org.eclipse.jgit.lib.PersonIdent;
 public final class FixtureProjectBuilder {
 
     private static final PersonIdent AUTHOR = new PersonIdent("fixture", "fixture@example.invalid");
+    private static final String KOTLIN_VERSION = "2.4.10";
 
     private final Path root;
     private final Git git;
@@ -82,22 +83,81 @@ public final class FixtureProjectBuilder {
         return writeTestInModule(null, fqcn, source);
     }
 
+    /** Write (or overwrite) a Kotlin production class in the single-module project. */
+    public FixtureProjectBuilder writeKotlinClass(String fqcn, String source) {
+        return writeKotlinClassInModule(null, fqcn, source);
+    }
+
+    /** Write (or overwrite) a Kotlin test class in the single-module project. */
+    public FixtureProjectBuilder writeKotlinTest(String fqcn, String source) {
+        return writeKotlinTestInModule(null, fqcn, source);
+    }
+
     /** Write (or overwrite) a production class in {@code module} (null = single-module root). */
     public FixtureProjectBuilder writeClassInModule(String module, String fqcn, String source) {
-        write(sourcePath(module, "main", fqcn), source);
+        write(sourcePath(module, "main", fqcn, ".java"), source);
         return this;
     }
 
     /** Write (or overwrite) a test class in {@code module} (null = single-module root). */
     public FixtureProjectBuilder writeTestInModule(String module, String fqcn, String source) {
-        write(sourcePath(module, "test", fqcn), source);
+        write(sourcePath(module, "test", fqcn, ".java"), source);
+        return this;
+    }
+
+    /** Write (or overwrite) a Kotlin production class in {@code module} (null = single-module root). */
+    public FixtureProjectBuilder writeKotlinClassInModule(String module, String fqcn, String source) {
+        write(sourcePath(module, "main", fqcn, ".kt"), source);
+        return this;
+    }
+
+    /** Write (or overwrite) a Kotlin test class in {@code module} (null = single-module root). */
+    public FixtureProjectBuilder writeKotlinTestInModule(String module, String fqcn, String source) {
+        write(sourcePath(module, "test", fqcn, ".kt"), source);
+        return this;
+    }
+
+    /** Enables Maven's Kotlin compiler extension in the single-module fixture. */
+    public FixtureProjectBuilder enableKotlin() {
+        return enableKotlinInModule(null);
+    }
+
+    /** Enables Maven's Kotlin compiler extension in {@code module} (null = single-module root). */
+    public FixtureProjectBuilder enableKotlinInModule(String module) {
+        Path pomPath = module == null ? root.resolve("pom.xml") : root.resolve(module).resolve("pom.xml");
+        try {
+            String pom = Files.readString(pomPath, StandardCharsets.UTF_8);
+            if (!pom.contains("<artifactId>kotlin-maven-plugin</artifactId>")) {
+                pom = pom.replace("</properties>", """
+                            <kotlin.version>%s</kotlin.version>
+                        </properties>""".formatted(KOTLIN_VERSION));
+                pom = pom.replace("</dependencies>", """
+                            <dependency>
+                                <groupId>org.jetbrains.kotlin</groupId>
+                                <artifactId>kotlin-stdlib</artifactId>
+                                <version>${kotlin.version}</version>
+                            </dependency>
+                        </dependencies>""");
+                pom = pom.replace("</plugins>", """
+                            <plugin>
+                                <groupId>org.jetbrains.kotlin</groupId>
+                                <artifactId>kotlin-maven-plugin</artifactId>
+                                <version>${kotlin.version}</version>
+                                <extensions>true</extensions>
+                            </plugin>
+                        </plugins>""");
+                Files.writeString(pomPath, pom, StandardCharsets.UTF_8);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
         return this;
     }
 
     /** Delete a previously-written file (module-relative fqcn), e.g. to simulate removal. */
     public FixtureProjectBuilder deleteClassInModule(String module, String fqcn) {
         try {
-            Files.deleteIfExists(sourcePath(module, "main", fqcn));
+            Files.deleteIfExists(sourcePath(module, "main", fqcn, ".java"));
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
@@ -179,10 +239,11 @@ public final class FixtureProjectBuilder {
         return git;
     }
 
-    private Path sourcePath(String module, String mainOrTest, String fqcn) {
+    private Path sourcePath(String module, String mainOrTest, String fqcn, String extension) {
         Path base = module == null ? root : root.resolve(module);
-        String relative = fqcn.replace('.', '/') + ".java";
-        return base.resolve("src").resolve(mainOrTest).resolve("java").resolve(relative);
+        String relative = fqcn.replace('.', '/') + extension;
+        String languageDirectory = ".kt".equals(extension) ? "kotlin" : "java";
+        return base.resolve("src").resolve(mainOrTest).resolve(languageDirectory).resolve(relative);
     }
 
     private static void write(Path file, String content) {

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ApplySelectionAction.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ApplySelectionAction.java
@@ -2,7 +2,6 @@ package io.github.baokhang83.blastradius.gradle;
 
 import io.github.baokhang83.blastradius.core.git.ChangedFile;
 import io.github.baokhang83.blastradius.core.git.ChangedFileClassifier;
-import io.github.baokhang83.blastradius.core.git.FileKind;
 import io.github.baokhang83.blastradius.core.selection.NewOrModifiedTestSelector;
 import io.github.baokhang83.blastradius.core.selection.SelectionDecision;
 import io.github.baokhang83.blastradius.core.selection.SelectionEngine;
@@ -70,8 +69,7 @@ final class ApplySelectionAction implements Action<Task> {
                             return merged;
                         }));
         Set<String> changedClassNames = changedFiles.stream()
-                .filter(file -> file.kind() == FileKind.JAVA_SOURCE)
-                .map(ChangedFile::changedClassName)
+                .flatMap(file -> file.candidateClassNames().stream())
                 .collect(Collectors.toUnmodifiableSet());
         Set<TestIdentity> newOrModifiedTests = allTests.stream()
                 .filter(test -> new NewOrModifiedTestSelector().appliesTo(

--- a/blastradius-maven-plugin/README.md
+++ b/blastradius-maven-plugin/README.md
@@ -34,7 +34,8 @@ fail, only how many tests get the chance to.
    independent `mvn test` subprocess; your own build's Surefire execution is completely
    untouched by it.
 2. **Diff.** On every other build, the goal diffs the current commit against `baseRef` —
-   Java source changes vs. everything else (config, resources, `pom.xml`, migrations).
+   JVM source changes (Java and conventional Kotlin) vs. everything else (config, resources,
+   `pom.xml`, migrations).
 3. **Select.** A test runs if **(a)** one of its tracked dependencies changed, **(b)** it's
    new or was itself modified, or **(c)** a non-source-code change triggered the
    conservative "just run everything" fallback.
@@ -175,6 +176,21 @@ Fully supported. The goal runs once per module and computes an independent, corr
 Surefire filter for each — a change in one module correctly selects a *dependent* test in
 another module, because tracking is based on actual class loads observed at runtime, not a
 static per-module dependency graph that would need separate bookkeeping to get right.
+
+## Kotlin/JVM support
+
+Kotlin sources in the standard Maven roots (`src/main/kotlin` and `src/test/kotlin`) participate
+in the same track-and-select flow. For a changed `Greeting.kt`, Blastradius matches both the
+source-root class (`Greeting`) and Kotlin's `GreetingKt` file facade. Compiler-generated nested
+and lambda classes with names such as `GreetingKt$format$1` match their stable source root.
+
+If either version of a changed Kotlin file contains an inline function, the goal runs the full
+suite. Kotlin copies inline bodies into callers, so runtime class loads cannot reliably identify
+every test affected by that source file.
+
+Custom `@file:JvmName` facades and types whose emitted class names do not follow the source file
+name are outside this filename-based mapping. Retain the regular full-suite run recommended below
+when those patterns are in use.
 
 ## Reading a build's result
 

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
@@ -1,7 +1,6 @@
 package io.github.baokhang83.blastradius.plugin.mojo;
 
 import io.github.baokhang83.blastradius.core.git.ChangedFile;
-import io.github.baokhang83.blastradius.core.git.FileKind;
 import io.github.baokhang83.blastradius.core.selection.NewOrModifiedTestSelector;
 import io.github.baokhang83.blastradius.core.selection.SelectionDecision;
 import io.github.baokhang83.blastradius.core.selection.SelectionEngine;
@@ -271,8 +270,7 @@ public final class SelectMojo extends AbstractMojo {
                         }));
 
         Set<String> changedClassNames = changedFiles.stream()
-                .filter(f -> f.kind() == FileKind.JAVA_SOURCE)
-                .map(ChangedFile::changedClassName)
+                .flatMap(file -> file.candidateClassNames().stream())
                 .collect(Collectors.toUnmodifiableSet());
 
         Set<TestIdentity> newOrModifiedTests = allTests.stream()

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeEndToEndTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeEndToEndTest.java
@@ -63,6 +63,62 @@ class SelectModeEndToEndTest {
                 "expected BarTest to be skipped (no dependency match):\n" + output);
     }
 
+    @Test
+    void kotlinFileFacadeChangeSelectsOnlyItsTrackedKotlinTest(@TempDir Path projectDir) throws Exception {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.enableKotlin();
+        fixture.ignoreTargetDirectory();
+        fixture.writeKotlinClass("com.example.Greeting", """
+                package com.example
+                fun greeting(): String = "hello"
+                """);
+        fixture.writeKotlinTest("com.example.GreetingTest", """
+                package com.example
+                import org.junit.jupiter.api.Assertions.assertEquals
+                import org.junit.jupiter.api.Test
+                class GreetingTest {
+                    @Test fun checksGreeting() {
+                        assertEquals("hello", greeting())
+                    }
+                }
+                """);
+        fixture.writeKotlinClass("com.example.Unrelated", """
+                package com.example
+                class Unrelated {
+                    fun value(): Int = 7
+                }
+                """);
+        fixture.writeKotlinTest("com.example.UnrelatedTest", """
+                package com.example
+                import org.junit.jupiter.api.Assertions.assertEquals
+                import org.junit.jupiter.api.Test
+                class UnrelatedTest {
+                    @Test fun checksUnrelated() {
+                        assertEquals(7, Unrelated().value())
+                    }
+                }
+                """);
+        String anchorCommit = fixture.commit("initial Kotlin fixture");
+
+        DependencyIndex index = EndToEndTestSupport.trackDependencies(projectDir, anchorCommit);
+        new DependencyIndexWriter().write(projectDir.resolve(".blastradius/index.json"), index);
+
+        fixture.writeKotlinClass("com.example.Greeting", """
+                package com.example
+                fun greeting(): String = listOf("hello").single()
+                """);
+        fixture.commit("change Kotlin greeting");
+        fixture.addBuildPlugin(null, EndToEndTestSupport.pluginXml(anchorCommit));
+
+        String output = EndToEndTestSupport.runMvnTest(projectDir);
+
+        assertTrue(output.contains("BUILD SUCCESS"), "expected the build to succeed:\n" + output);
+        assertTrue(output.contains("Running com.example.GreetingTest"),
+                "expected the affected Kotlin test to run:\n" + output);
+        assertFalse(output.contains("Running com.example.UnrelatedTest"),
+                "expected the independent Kotlin test to be skipped:\n" + output);
+    }
+
     /**
      * US3 (tasks.md T034/T037/T040): the console summary and the persisted {@code
      * BuildReport} JSON must both reflect the actual decisions, live — not just in

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
@@ -11,7 +11,6 @@ import io.github.baokhang83.blastradius.core.git.ChangedFileClassifier;
 import io.github.baokhang83.blastradius.validator.git.CommitCheckout;
 import io.github.baokhang83.blastradius.validator.git.CommitPair;
 import io.github.baokhang83.blastradius.validator.git.CommitWindowResolver;
-import io.github.baokhang83.blastradius.core.git.FileKind;
 import io.github.baokhang83.blastradius.validator.git.PairStatus;
 import io.github.baokhang83.blastradius.validator.report.AnalysisReport;
 import io.github.baokhang83.blastradius.validator.report.ReportWriter;
@@ -156,8 +155,7 @@ public final class RunCommand {
         List<ChangedFile> changedFiles =
                 changedFileClassifier.classify(targetRepo, pair.baseCommit(), pair.headCommit());
         Set<String> changedClassNames = changedFiles.stream()
-                .filter(f -> f.kind() == FileKind.JAVA_SOURCE)
-                .map(ChangedFile::changedClassName)
+                .flatMap(file -> file.candidateClassNames().stream())
                 .collect(Collectors.toUnmodifiableSet());
 
         Set<TestIdentity> allTests = groundTruth.stream().map(GroundTruthResult::test).collect(Collectors.toSet());

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/verdict/WouldMissComparator.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/verdict/WouldMissComparator.java
@@ -9,7 +9,6 @@ import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -27,8 +26,7 @@ public final class WouldMissComparator {
                 decisions.stream().collect(Collectors.toMap(SelectionDecision::test, Function.identity()));
 
         List<String> changedClasses = pair.changedFiles().stream()
-                .map(ChangedFile::changedClassName)
-                .filter(Objects::nonNull)
+                .flatMap(file -> file.candidateClassNames().stream())
                 .toList();
 
         List<WouldMissCase> misses = new ArrayList<>();

--- a/docs/fluencyloop/features/verify-kotlin-aware-dependency-tracking/design.md
+++ b/docs/fluencyloop/features/verify-kotlin-aware-dependency-tracking/design.md
@@ -1,0 +1,88 @@
+# Design: Verify Kotlin-aware dependency tracking
+
+started: 2026-07-20
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class ChangedFileClassifier {
+    +classify(repo, base, head) List~ChangedFile~
+    -containsInlineFunction(oldOrNewSource) boolean
+  }
+  class ChangedFile {
+    +candidateClassNames() Set~String~
+  }
+  class DependencyMatchSelector {
+    +select(test, dependencies, changedCandidates) SelectionDecision
+  }
+  class KotlinSource {
+    src/main/kotlin/**/Greeting.kt
+  }
+  class KotlinFileFacade {
+    GreetingKt
+  }
+  class SyntheticClass {
+    GreetingKt$format$1
+  }
+
+  ChangedFileClassifier --> ChangedFile : classify .kt source
+  ChangedFile --> DependencyMatchSelector : file name + *Kt candidates
+  DependencyMatchSelector --> KotlinFileFacade : exact match
+  DependencyMatchSelector --> SyntheticClass : enclosing-name match
+  KotlinSource --> KotlinFileFacade : compiler emits
+  KotlinFileFacade --> SyntheticClass : compiler may emit
+```
+
+## Sequence: selecting after a Kotlin source change
+
+```mermaid
+sequenceDiagram
+  participant Git as Git diff
+  participant Classifier as ChangedFileClassifier
+  participant Selector as DependencyMatchSelector
+  participant Index as tracked dependency index
+  participant Surefire as Maven Surefire
+
+  Git->>Classifier: changed src/main/kotlin/.../Greeting.kt
+  alt source contains inline function
+    Classifier->>Selector: NON_SOURCE change
+    Selector->>Surefire: select full suite (safe fallback)
+  else ordinary Kotlin source
+    Classifier->>Selector: Greeting and GreetingKt candidates
+    Selector->>Index: find exact or candidate$... dependency
+    Index-->>Selector: affected test identities
+    Selector->>Surefire: run only affected tests
+  end
+```
+
+## Design
+
+- Keep the persisted `ChangedFile` schema and its `JAVA_SOURCE` enum value stable. It now
+  means source that can participate in JVM class-level matching, including conventional
+  Kotlin sources under `src/main/kotlin` and `src/test/kotlin`.
+- A Kotlin path produces two candidates: its ordinary file-name class and Kotlin's
+  generated `FileNameKt` file facade. The selector also treats a tracked dependency named
+  `candidate$...` as a match, covering compiler-generated nested and lambda classes while
+  reporting the stable source candidate as the reason.
+- An inline Kotlin function has no dependable class-load boundary: the compiler copies its
+  body into each caller. The classifier examines both sides of a changed `.kt` file; if
+  either contains `inline fun`, it deliberately marks the file `NON_SOURCE`. The existing
+  conservative fallback then runs the full suite rather than risk missing an affected test.
+- The Kotlin fixture uses Maven's Kotlin compiler plugin and exercises a real track →
+  select build. It proves one affected Kotlin test runs while an independent test is
+  skipped. Focused classifier/selector tests cover file facades, `$`-suffixed generated
+  classes, and the inline fallback.
+- User documentation describes the supported layout and these safety boundaries. In
+  particular, custom `@file:JvmName` facades and source files whose JVM declarations do
+  not follow their file name remain caveats; teams using them should retain the recommended
+  regular full-suite run.
+
+## Validation
+
+1. Make core unit tests fail first for Kotlin source classification, facade/synthetic
+   matching, and inline fallback; then make them pass.
+2. Run a real Maven fixture with Kotlin sources under the tracking agent, persist its
+   index, change the Kotlin production source, and prove `SELECT` runs only the affected
+   Kotlin test.
+3. Run the complete Maven reactor verification on JDK 21 and 25.

--- a/docs/fluencyloop/features/verify-kotlin-aware-dependency-tracking/sessions/classify-kotlin-source-and-preserve-safe-inline-fallback.md
+++ b/docs/fluencyloop/features/verify-kotlin-aware-dependency-tracking/sessions/classify-kotlin-source-and-preserve-safe-inline-fallback.md
@@ -1,0 +1,27 @@
+# Session: Classify Kotlin source and preserve safe inline fallback
+
+- **intent:** Classify Kotlin source and preserve safe inline fallback
+- **started:** 2026-07-20
+
+## Knowledge transfer
+
+- **ChangedFile candidate mapping** — Java sources yield their one ordinary JVM name; a
+  conventional Kotlin source yields both its file-name root and the compiler's `FileNameKt`
+  facade. These are stable names selection can compare with tracked class loads. **Status:**
+  documented.
+- **Synthetic-class attribution** — a tracked Kotlin lambda or nested compiler artifact is named
+  beneath a stable root with `$`. Matching that suffix against the changed root keeps the report
+  explainable without depending on compiler-specific generated names. **Status:** documented.
+- **Inline safety boundary** — Kotlin copies `inline fun` bodies into callers, so neither the
+  facade nor its generated artifact necessarily loads while the affected test executes. A changed
+  Kotlin file containing an inline function on either side of the diff becomes `NON_SOURCE`,
+  activating the existing full-suite fallback. **Status:** documented.
+
+## Decision: Map Kotlin source changes to stable JVM roots and fall back for inline functions
+
+- **where:** `core git classification and dependency matching`
+- **why:** Kotlin file facades and compiler-generated nested classes need stable source-root candidates; inline bodies are copied into callers, so a class-load record cannot prove every affected test.
+- **alternative:** Track exact generated Kotlin class names or parse compiler metadata — rejected: generated names are compiler-dependent and inline calls can erase the source class-load boundary.
+- **design:** ../design.md#design
+- **constitution:** §III
+- **trust:** ✓ verified

--- a/docs/fluencyloop/features/verify-kotlin-aware-dependency-tracking/sessions/detect-kotlin-inline-modifier-variants-conservatively.md
+++ b/docs/fluencyloop/features/verify-kotlin-aware-dependency-tracking/sessions/detect-kotlin-inline-modifier-variants-conservatively.md
@@ -1,0 +1,22 @@
+# Session: Detect Kotlin inline modifier variants conservatively
+
+- **intent:** Detect Kotlin inline modifier variants conservatively
+- **started:** 2026-07-20
+
+## Knowledge transfer
+
+- **Kotlin modifier order** — `inline` can be followed by another function modifier, including
+  `suspend`, before `fun`. The fallback detector therefore recognizes an inline modifier sequence
+  rather than only the adjacent phrase `inline fun`. **Status:** documented.
+- **Conservative source scan** — the classifier reads both old and new Kotlin blobs from Git and
+  uses a deliberately broad text pattern. A false positive merely preserves the full suite;
+  avoiding an inline false negative is the safety-critical outcome. **Status:** documented.
+
+## Decision: Use a conservative inline-modifier detector instead of parsing Kotlin
+
+- **where:** `ChangedFileClassifier Kotlin inline fallback`
+- **why:** Kotlin permits modifier order such as inline suspend fun; treating a potential inline declaration as non-source avoids a false-negative selection even when a text scan is broader than necessary.
+- **alternative:** Parse Kotlin syntax or match only inline fun — rejected: a parser adds a compiler-language dependency, while the narrow text pattern missed valid modifier order.
+- **design:** ../design.md#design
+- **constitution:** §III
+- **trust:** ✓ verified

--- a/docs/fluencyloop/features/verify-kotlin-aware-dependency-tracking/sessions/wire-kotlin-candidates-through-every-selection-entry-point.md
+++ b/docs/fluencyloop/features/verify-kotlin-aware-dependency-tracking/sessions/wire-kotlin-candidates-through-every-selection-entry-point.md
@@ -1,0 +1,24 @@
+# Session: Wire Kotlin candidates through every selection entry point
+
+- **intent:** Wire Kotlin candidates through every selection entry point
+- **started:** 2026-07-20
+
+## Knowledge transfer
+
+- **Selection entry points** — the core engine, Maven adapter, Gradle adapter, and validator
+  independently derive the changed-class set before applying the selection rules. Each expands a
+  `ChangedFile` through `candidateClassNames()` so Kotlin file facades have the same semantics
+  everywhere. **Status:** documented.
+- **Maven fixture setup** — the test fixture enables `kotlin-maven-plugin` with Maven extensions,
+  adds Kotlin standard library at runtime, and writes source under the conventional Kotlin roots.
+  This makes the end-to-end test compile and discover real Kotlin JUnit classes rather than
+  simulating their bytecode. **Status:** documented.
+
+## Decision: Expand Kotlin candidates before every selection entry point
+
+- **where:** `core engine, Maven and Gradle adapters, and validator`
+- **why:** Each entry point determines modified tests before invoking the shared engine, so all must see the same file facade and source-root candidates for consistent selection.
+- **alternative:** Expand candidates only inside the core selection engine — rejected: Maven, Gradle, and the validator each derive new-or-modified tests first and would retain divergent behavior.
+- **design:** ../design.md#design
+- **constitution:** §IV
+- **trust:** ✓ verified


### PR DESCRIPTION
Closes #23

## Summary

- Recognize conventional Kotlin source roots and match both file-name classes and generated FileNameKt facades.
- Attribute compiler-generated nested/lambda classes through their stable source root, while safely falling back for changed inline functions.
- Prove the full Maven track-to-select path on a Kotlin file facade; document supported behavior and caveats.

## Validation

- mvn clean verify
- Focused Maven file-facade end-to-end test after the final fixture strengthening

## Review note

- Gradle check was not run locally: this repository has no Gradle wrapper and Gradle is not installed.