### PR TITLE
Diff PR changes from their merge base

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "commit-keyed-index-baseline-resolution-26",
-  "branch": "feature/commit-keyed-index-baseline-resolution-26",
+  "feature": "pr-merge-base-aware-diffing-28",
+  "branch": "feature/pr-merge-base-aware-diffing-28",
   "stage": "review",
-  "last_session": "docs/fluencyloop/features/commit-keyed-index-baseline-resolution-26/sessions/route-baseline-keys-through-maven-and-gradle.md",
+  "last_session": "docs/fluencyloop/features/pr-merge-base-aware-diffing-28/sessions/apply-the-comparison-base-to-maven-and-gradle-selection.md",
   "base_ref": "main",
-  "updated": "2026-07-20"
+  "updated": "2026-07-21"
 }

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ name mismatch) is in [`SESSION.md`](SESSION.md).
 1. **Track.** On a build of your base branch, a `java.lang.instrument` agent watches every
    class actually loaded while each test runs and records which production classes it
    really touched — ground truth, not a guess.
-2. **Diff.** On every other build, the current commit is diffed against your base
-   reference: JVM source changes (Java and conventional Kotlin) vs. everything else
-   (config, resources, `pom.xml`, migrations).
+2. **Diff.** On every other build, the current commit is diffed from its merge base with your
+   base reference. This isolates the PR's own JVM source changes (Java and conventional Kotlin)
+   from changes that landed on the target branch after the PR diverged.
 3. **Select.** A test runs if one of its tracked dependencies changed, it's new or was
    itself modified, or a non-source change triggered the conservative "just run
    everything" fallback.

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/GitComparison.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/GitComparison.java
@@ -1,0 +1,20 @@
+package io.github.baokhang83.blastradius.core.git;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/** The commits that define one build's comparison with a configured Git reference. */
+public record GitComparison(
+        String headCommit, String baseReferenceCommit, Optional<String> comparisonBaseCommit) {
+
+    public GitComparison {
+        Objects.requireNonNull(headCommit, "headCommit");
+        Objects.requireNonNull(baseReferenceCommit, "baseReferenceCommit");
+        Objects.requireNonNull(comparisonBaseCommit, "comparisonBaseCommit");
+    }
+
+    /** Whether this build is executing the configured base reference itself. */
+    public boolean baseReferenceBuild() {
+        return headCommit.equals(baseReferenceCommit);
+    }
+}

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/MergeBaseResolver.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/MergeBaseResolver.java
@@ -1,0 +1,49 @@
+package io.github.baokhang83.blastradius.core.git;
+
+import java.nio.file.Path;
+import java.util.Optional;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.revwalk.filter.RevFilter;
+
+/** Resolves a build's HEAD, configured target, and their Git merge base. */
+public final class MergeBaseResolver {
+
+    public GitComparison resolve(Path repositoryDirectory, String baseReference) {
+        try (Git git = Git.open(repositoryDirectory.toFile())) {
+            Repository repository = git.getRepository();
+            ObjectId baseId = repository.resolve(baseReference);
+            ObjectId headId = repository.resolve("HEAD");
+            if (baseId == null) {
+                throw new IllegalStateException(
+                        "base reference \"" + baseReference + "\" does not resolve to a commit in " + repositoryDirectory);
+            }
+            if (headId == null) {
+                throw new IllegalStateException("HEAD does not resolve to a commit in " + repositoryDirectory);
+            }
+
+            Optional<String> comparisonBase = headId.equals(baseId)
+                    ? Optional.of(baseId.getName())
+                    : findMergeBase(repository, headId, baseId);
+            return new GitComparison(headId.getName(), baseId.getName(), comparisonBase);
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to open git repository at " + repositoryDirectory, e);
+        }
+    }
+
+    private static Optional<String> findMergeBase(Repository repository, ObjectId headId, ObjectId baseId)
+            throws java.io.IOException {
+        try (RevWalk walk = new RevWalk(repository)) {
+            walk.setRevFilter(RevFilter.MERGE_BASE);
+            walk.markStart(walk.parseCommit(headId));
+            walk.markStart(walk.parseCommit(baseId));
+            RevCommit mergeBase = walk.next();
+            return mergeBase == null ? Optional.empty() : Optional.of(mergeBase.getName());
+        }
+    }
+}

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/git/MergeBaseResolverTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/git/MergeBaseResolverTest.java
@@ -1,0 +1,131 @@
+package io.github.baokhang83.blastradius.core.git;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
+import java.nio.file.Path;
+import org.eclipse.jgit.api.Git;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MergeBaseResolverTest {
+
+    private final MergeBaseResolver resolver = new MergeBaseResolver();
+
+    @Test
+    void resolvesTheBranchPointWhenTheTargetBranchAdvances(@TempDir Path projectDir) throws Exception {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        String branchPoint = fixture.commit("initial");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.branchCreate().setName("feature").call();
+            git.checkout().setName("feature").call();
+        }
+        fixture.writeClass("com.example.FeatureOnly", "package com.example; class FeatureOnly {}");
+        String featureHead = fixture.commit("feature change");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("main").call();
+        }
+        fixture.writeClass("com.example.TargetOnly", "package com.example; class TargetOnly {}");
+        String targetTip = fixture.commit("target change");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("feature").call();
+        }
+
+        GitComparison comparison = resolver.resolve(projectDir, "main");
+
+        assertEquals(featureHead, comparison.headCommit());
+        assertEquals(targetTip, comparison.baseReferenceCommit());
+        assertEquals(branchPoint, comparison.comparisonBaseCommit().orElseThrow());
+        assertFalse(comparison.baseReferenceBuild());
+    }
+
+    @Test
+    void recognizesTheBaseReferenceBuild(@TempDir Path projectDir) {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        String mainHead = fixture.commit("initial");
+
+        GitComparison comparison = resolver.resolve(projectDir, "main");
+
+        assertEquals(mainHead, comparison.comparisonBaseCommit().orElseThrow());
+        assertTrue(comparison.baseReferenceBuild());
+    }
+
+    @Test
+    void reportsNoComparisonBaseForUnrelatedHistories(@TempDir Path projectDir) throws Exception {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.commit("main history");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("unrelated").setOrphan(true).call();
+        }
+        fixture.writeResource("unrelated.txt", "unrelated history");
+        fixture.commit("unrelated history");
+
+        GitComparison comparison = resolver.resolve(projectDir, "main");
+
+        assertTrue(comparison.comparisonBaseCommit().isEmpty());
+        assertFalse(comparison.baseReferenceBuild());
+    }
+
+    @Test
+    void resolvesTheTargetTipAfterTheFeatureMergesIt(@TempDir Path projectDir) throws Exception {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.commit("initial");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setCreateBranch(true).setName("feature").call();
+        }
+        fixture.writeClass("com.example.FeatureOnly", "package com.example; class FeatureOnly {}");
+        fixture.commit("feature change");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("main").call();
+        }
+        fixture.writeClass("com.example.TargetOnly", "package com.example; class TargetOnly {}");
+        String targetTip = fixture.commit("target change");
+
+        String mergeHead;
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("feature").call();
+            git.merge().include(git.getRepository().resolve("main")).call();
+            mergeHead = git.getRepository().resolve("HEAD").getName();
+        }
+
+        GitComparison comparison = resolver.resolve(projectDir, "main");
+
+        assertEquals(mergeHead, comparison.headCommit());
+        assertEquals(targetTip, comparison.comparisonBaseCommit().orElseThrow());
+    }
+
+    @Test
+    void resolvesTheTargetTipAfterAFeatureIsRebasedOntoIt(@TempDir Path projectDir) throws Exception {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.commit("initial");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setCreateBranch(true).setName("feature").call();
+        }
+        fixture.writeClass("com.example.FeatureOnly", "package com.example; class FeatureOnly {}");
+        fixture.commit("feature change");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("main").call();
+        }
+        fixture.writeClass("com.example.TargetOnly", "package com.example; class TargetOnly {}");
+        String targetTip = fixture.commit("target change");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("feature").call();
+            git.rebase().setUpstream("main").call();
+        }
+
+        GitComparison comparison = resolver.resolve(projectDir, "main");
+
+        assertEquals(targetTip, comparison.comparisonBaseCommit().orElseThrow());
+    }
+}

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ApplySelectionAction.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ApplySelectionAction.java
@@ -26,13 +26,13 @@ final class ApplySelectionAction implements Action<Task> {
 
     private final File repositoryDirectory;
     private final String indexPathKey;
-    private final String baseCommit;
+    private final String comparisonBaseCommit;
     private final String headCommit;
 
-    ApplySelectionAction(File repositoryDirectory, String indexPathKey, String baseCommit, String headCommit) {
+    ApplySelectionAction(File repositoryDirectory, String indexPathKey, String comparisonBaseCommit, String headCommit) {
         this.repositoryDirectory = repositoryDirectory;
         this.indexPathKey = indexPathKey;
-        this.baseCommit = baseCommit;
+        this.comparisonBaseCommit = comparisonBaseCommit;
         this.headCommit = headCommit;
     }
 
@@ -40,10 +40,10 @@ final class ApplySelectionAction implements Action<Task> {
     public void execute(Task task) {
         Test test = (Test) task;
         Path repositoryRoot = repositoryDirectory.toPath().toAbsolutePath().normalize();
-        String indexKey = CommitIndexKey.forCommit(indexPathKey, baseCommit);
+        String indexKey = CommitIndexKey.forCommit(indexPathKey, comparisonBaseCommit);
         IndexStore<DependencyIndex> indexStore = new FileIndexStore<>(repositoryRoot, DependencyIndex.class);
         IndexApplicability applicability = new IndexApplicabilityResolver()
-                .resolve(indexStore, indexKey, baseCommit, repositoryRoot);
+                .resolve(indexStore, indexKey, comparisonBaseCommit, repositoryRoot);
         if (applicability.status() != IndexApplicability.Status.APPLICABLE) {
             test.getLogger().info("[blastradius] Gradle test task left unfiltered ({})", applicability.status());
             return;
@@ -53,7 +53,7 @@ final class ApplySelectionAction implements Action<Task> {
             Set<TestIdentity> allTests = new TestDiscoverer().discoverAllTests(
                     test.getClasspath().getFiles(), test.getTestClassesDirs().getFiles());
             List<ChangedFile> changedFiles = new ChangedFileClassifier().classify(
-                    repositoryDirectory.toPath(), baseCommit, headCommit);
+                    repositoryDirectory.toPath(), comparisonBaseCommit, headCommit);
             List<SelectionDecision> decisions = computeDecisions(allTests, applicability.index(), changedFiles);
             applyFilter(test, decisions);
             test.getLogger().lifecycle("[blastradius] SELECT — {} / {} tests selected", decisions.stream()

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusPlugin.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusPlugin.java
@@ -38,18 +38,22 @@ public final class BlastradiusPlugin implements Plugin<Project> {
             String baseReference) {
         test.getInputs().property("blastradius.baseReference", baseReference);
         test.getInputs().property("blastradius.headCommit", gitState.headCommit());
-        test.getInputs().property("blastradius.baseCommit", gitState.baseCommit());
+        test.getInputs().property("blastradius.baseReferenceCommit", gitState.baseReferenceCommit());
 
         if (gitState.baseReferenceBuild()) {
             configureTracking(test, repositoryDirectory, indexPathKey, gitState.headCommit());
+        } else if (!gitState.comparisonBaseAvailable()) {
+            test.doFirst(new NoComparisonBaseFallbackAction());
         } else {
+            String comparisonBase = gitState.comparisonBaseCommit();
+            test.getInputs().property("blastradius.comparisonBaseCommit", comparisonBase);
             Path baselineIndexPath = repositoryDirectory.resolve(
-                    CommitIndexKey.forCommit(indexPathKey, gitState.baseCommit()));
+                    CommitIndexKey.forCommit(indexPathKey, comparisonBase));
             test.getInputs()
                     .files(project.files(baselineIndexPath.toFile()).filter(File::isFile))
                     .withPathSensitivity(PathSensitivity.RELATIVE);
             test.doFirst(new ApplySelectionAction(
-                    repositoryDirectory.toFile(), indexPathKey, gitState.baseCommit(), gitState.headCommit()));
+                    repositoryDirectory.toFile(), indexPathKey, comparisonBase, gitState.headCommit()));
         }
     }
 

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/GitBuildState.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/GitBuildState.java
@@ -3,9 +3,13 @@ package io.github.baokhang83.blastradius.gradle;
 import java.io.Serializable;
 
 /** Immutable Git state captured during Gradle configuration and used as a task input. */
-record GitBuildState(String headCommit, String baseCommit) implements Serializable {
+record GitBuildState(String headCommit, String baseReferenceCommit, String comparisonBaseCommit) implements Serializable {
 
     boolean baseReferenceBuild() {
-        return headCommit.equals(baseCommit);
+        return headCommit.equals(baseReferenceCommit);
+    }
+
+    boolean comparisonBaseAvailable() {
+        return comparisonBaseCommit != null;
     }
 }

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/GitBuildStateSource.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/GitBuildStateSource.java
@@ -1,16 +1,15 @@
 package io.github.baokhang83.blastradius.gradle;
 
+import io.github.baokhang83.blastradius.core.git.GitComparison;
+import io.github.baokhang83.blastradius.core.git.MergeBaseResolver;
 import javax.inject.Inject;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.Repository;
 import org.gradle.api.GradleException;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.ValueSource;
 import org.gradle.api.provider.ValueSourceParameters;
 
-/** Supplies the current and baseline commit as a configuration-cache tracked value. */
+/** Supplies HEAD, the configured target tip, and their comparison base as configuration-cache state. */
 public abstract class GitBuildStateSource implements ValueSource<GitBuildState, GitBuildStateSource.Parameters> {
 
     public interface Parameters extends ValueSourceParameters {
@@ -25,18 +24,14 @@ public abstract class GitBuildStateSource implements ValueSource<GitBuildState, 
 
     @Override
     public GitBuildState obtain() {
-        try (Git git = Git.open(getParameters().getRepositoryDirectory().getAsFile().get())) {
-            Repository repository = git.getRepository();
-            ObjectId baseCommit = repository.resolve(getParameters().getBaseReference().get());
-            ObjectId headCommit = repository.resolve("HEAD");
-            if (baseCommit == null) {
-                throw new GradleException("base reference \"" + getParameters().getBaseReference().get()
-                        + "\" does not resolve to a commit");
-            }
-            if (headCommit == null) {
-                throw new GradleException("HEAD does not resolve to a commit");
-            }
-            return new GitBuildState(headCommit.getName(), baseCommit.getName());
+        try {
+            GitComparison comparison = new MergeBaseResolver().resolve(
+                    getParameters().getRepositoryDirectory().getAsFile().get().toPath(),
+                    getParameters().getBaseReference().get());
+            return new GitBuildState(
+                    comparison.headCommit(),
+                    comparison.baseReferenceCommit(),
+                    comparison.comparisonBaseCommit().orElse(null));
         } catch (GradleException e) {
             throw e;
         } catch (Exception e) {

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/NoComparisonBaseFallbackAction.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/NoComparisonBaseFallbackAction.java
@@ -1,0 +1,14 @@
+package io.github.baokhang83.blastradius.gradle;
+
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+
+/** Leaves tests unfiltered when Git cannot establish a common comparison base. */
+final class NoComparisonBaseFallbackAction implements Action<Task> {
+
+    @Override
+    public void execute(Task task) {
+        task.getLogger().lifecycle(
+                "[blastradius] FALLBACK — Git could not establish a common comparison base (MERGE_BASE_UNAVAILABLE)");
+    }
+}

--- a/blastradius-gradle-plugin/src/test/java/io/github/baokhang83/blastradius/gradle/BlastradiusPluginFunctionalTest.java
+++ b/blastradius-gradle-plugin/src/test/java/io/github/baokhang83/blastradius/gradle/BlastradiusPluginFunctionalTest.java
@@ -79,6 +79,41 @@ class BlastradiusPluginFunctionalTest {
         assertFalse(Files.exists(projectDir.resolve("build/bar-ran")));
     }
 
+    @Test
+    void selectsAgainstTheMergeBaseWhenMainAdvancesAfterTheFeatureBranches() throws Exception {
+        writeProject();
+        String branchPoint = commitBaseline();
+        changeFoo();
+        advanceMainWithBarChange();
+        writeIndex(branchPoint);
+
+        BuildResult result = runGradle("clean", "test");
+
+        assertTrue(result.getOutput().contains("[blastradius] SELECT — 1 / 2 tests selected"), result.getOutput());
+        assertTrue(Files.exists(projectDir.resolve("build/foo-ran")));
+        assertFalse(Files.exists(projectDir.resolve("build/bar-ran")));
+    }
+
+    @Test
+    void leavesTheTaskUnfilteredWhenTheHistoriesHaveNoCommonAncestor() throws Exception {
+        writeProject();
+        commitBaseline();
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("unrelated").setOrphan(true).call();
+        }
+        write("unrelated.txt", "unrelated history\n");
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.add().addFilepattern(".").call();
+            git.commit().setMessage("unrelated history").setAuthor("fixture", "fixture@example.invalid").call();
+        }
+
+        BuildResult result = runGradle("clean", "test");
+
+        assertTrue(result.getOutput().contains("MERGE_BASE_UNAVAILABLE"), result.getOutput());
+        assertTrue(Files.exists(projectDir.resolve("build/foo-ran")));
+        assertTrue(Files.exists(projectDir.resolve("build/bar-ran")));
+    }
+
     private void writeProject() throws IOException {
         write("settings.gradle", "rootProject.name = 'consumer'\n");
         write("build.gradle", """
@@ -152,6 +187,18 @@ class BlastradiusPluginFunctionalTest {
             git.checkout().setCreateBranch(true).setName("feature").call();
             git.add().addFilepattern("src/main/java/example/Foo.java").call();
             git.commit().setMessage("change foo").setAuthor("fixture", "fixture@example.invalid").call();
+        }
+    }
+
+    private void advanceMainWithBarChange() throws Exception {
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("main").call();
+        }
+        write("src/main/java/example/Bar.java", "package example; public final class Bar { public int value() { return 4; } }\n");
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.add().addFilepattern("src/main/java/example/Bar.java").call();
+            git.commit().setMessage("advance main").setAuthor("fixture", "fixture@example.invalid").call();
+            git.checkout().setName("feature").call();
         }
     }
 

--- a/blastradius-maven-plugin/README.md
+++ b/blastradius-maven-plugin/README.md
@@ -33,9 +33,10 @@ fail, only how many tests get the chance to.
    fresh dependency map — which test touched which production classes. This runs as an
    independent `mvn test` subprocess; your own build's Surefire execution is completely
    untouched by it.
-2. **Diff.** On every other build, the goal diffs the current commit against `baseRef` —
-   JVM source changes (Java and conventional Kotlin) vs. everything else (config, resources,
-   `pom.xml`, migrations).
+2. **Diff.** On every other build, the goal finds the merge base of the current commit and
+   `baseRef`, then diffs from that common ancestor to `HEAD`. This excludes target-branch
+   changes that landed after the branch diverged while still classifying JVM source changes
+   (Java and conventional Kotlin) versus config, resources, `pom.xml`, and migrations.
 3. **Select.** A test runs if **(a)** one of its tracked dependencies changed, **(b)** it's
    new or was itself modified, or **(c)** a non-source-code change triggered the
    conservative "just run everything" fallback.
@@ -47,8 +48,8 @@ Three modes fall out of this, decided fresh on every invocation — never config
 | Mode | When | What happens |
 |---|---|---|
 | **`TRACK`** | Current commit *is* `baseRef` (or `-Dblastradius.mode=track`) | Full suite runs, untouched. A subprocess rebuilds the index in the background for next time. |
-| **`SELECT`** | Not `baseRef`, and a usable index exists | Surefire is narrowed to the affected tests. This is the fast path. |
-| **`FALLBACK`** | Not `baseRef`, and no usable index (missing, unreadable, unreachable, or for another baseline commit) | Full suite runs, untouched. Nothing gained by tracking from a throwaway branch commit, so nothing is forked. |
+| **`SELECT`** | Not `baseRef`, and a usable index exists for the merge base | Surefire is narrowed to the affected tests. This is the fast path. |
+| **`FALLBACK`** | Not `baseRef`, and no usable index (missing, unreadable, unreachable, for another baseline commit, or no common ancestor) | Full suite runs, untouched. Nothing gained by tracking from a throwaway branch commit, so nothing is forked. |
 
 `TRACK` and `FALLBACK` are never treated as errors — they're the plugin being honest about
 not having enough information yet, and defaulting to safe.
@@ -98,8 +99,8 @@ separate page for each goal, including `help-mojo.html` and `select-mojo.html`.
 
 | Parameter | CLI property | Default | Required | Meaning |
 |---|---|---|---|---|
-| `baseRef` | `-DbaseRef` | — | **yes** | The git reference every build diffs against (`main`, `origin/main`, a tag — anything JGit can resolve). |
-| `indexPath` | `-DindexPath` | `.blastradius/index.json` | no | Root-relative index-file template. The resolved baseline SHA is inserted before its filename, so the default produces `.blastradius/<full-sha>/index.json`. Rejected if it resolves outside the project directory. |
+| `baseRef` | `-DbaseRef` | — | **yes** | The target git reference (`main`, `origin/main`, a tag — anything JGit can resolve). Non-target builds compare from its merge base with `HEAD`. |
+| `indexPath` | `-DindexPath` | `.blastradius/index.json` | no | Root-relative index-file template. The merge-base SHA is inserted before its filename for `SELECT`, so the default produces `.blastradius/<full-sha>/index.json`. Rejected if it resolves outside the project directory. |
 | — | `-Dblastradius.mode=track` | — | no | Force `TRACK` regardless of what commit you're on — for explicitly pre-warming the index outside an ordinary trunk build. |
 | — | `-Dblastradius.explain=true` | `false` | no | Print the full per-test decision listing to the console, not just the aggregate summary. |
 
@@ -154,17 +155,18 @@ Add `-Dblastradius.explain=true` for the per-test breakdown that line is pointin
 ```
 
 The reason in parentheses always tells you *why*: `MISSING` (no TRACK build exists for the
-resolved baseline), `UNREADABLE` (the index file is corrupt), `ANCHOR_UNREACHABLE` (its
+resolved merge base), `UNREADABLE` (the index file is corrupt), `ANCHOR_UNREACHABLE` (its
 recorded commit no longer exists, e.g. after a history rewrite), `ANCHOR_MISMATCH` (the stored
-index declares a different baseline), or `INTERNAL_ERROR` (the goal hit an unexpected fault
-mid-computation and safely bailed out to a full run rather than crash the build or guess).
+index declares a different baseline), `MERGE_BASE_UNAVAILABLE` (the refs have no common
+ancestor), or `INTERNAL_ERROR` (the goal hit an unexpected fault mid-computation and safely
+bailed out to a full run rather than crash the build or guess).
 
 ## The files it writes
 
 Both live under `.blastradius/` at the reactor root — add it to `.gitignore`.
 
 - **`<full-sha>/index.json`** — the persisted dependency map a `TRACK` build produces for its
-  exact commit and a `SELECT` build reads for its resolved baseline. The default location is
+  exact commit and a `SELECT` build reads for its resolved merge base. The default location is
   `.blastradius/<full-sha>/index.json`.
   `{ anchorCommit, builtAt, testDependencies: [{ test, dependsOnClasses }] }`.
 - **`last-build-report.json`** — this build's own decisions, machine-readable.

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/diff/CurrentChanges.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/diff/CurrentChanges.java
@@ -2,22 +2,26 @@ package io.github.baokhang83.blastradius.plugin.diff;
 
 import io.github.baokhang83.blastradius.core.git.ChangedFile;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * The live build's own analog of the validator's {@code CommitPair}/{@code ChangedFile} —
  * computed once per {@code blastradius:select} invocation, not persisted (data-model.md).
  *
  * @param baseReference     the configured base git reference, as given (branch name or SHA)
- * @param resolvedBaseCommit {@code baseReference} resolved to a concrete commit
+ * @param resolvedBaseCommit {@code baseReference} resolved to its current concrete commit
+ * @param comparisonBaseCommit common ancestor of {@code currentCommit} and
+ *                             {@code resolvedBaseCommit}, if Git can establish one
  * @param currentCommit     the commit actually being built (HEAD)
  * @param isBaseRefBuild    {@code currentCommit == resolvedBaseCommit} — this build IS the
  *                          base reference (research.md #1's trigger for TRACK mode)
- * @param changedFiles      diff between {@code resolvedBaseCommit} and {@code currentCommit};
- *                          empty when {@code isBaseRefBuild = true}
+ * @param changedFiles      diff between {@code comparisonBaseCommit} and {@code currentCommit};
+ *                          empty when the build is the base ref or no common ancestor exists
  */
 public record CurrentChanges(
         String baseReference,
         String resolvedBaseCommit,
+        Optional<String> comparisonBaseCommit,
         String currentCommit,
         boolean isBaseRefBuild,
         List<ChangedFile> changedFiles) {}

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/diff/CurrentChangesResolver.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/diff/CurrentChangesResolver.java
@@ -2,11 +2,10 @@ package io.github.baokhang83.blastradius.plugin.diff;
 
 import io.github.baokhang83.blastradius.core.git.ChangedFile;
 import io.github.baokhang83.blastradius.core.git.ChangedFileClassifier;
+import io.github.baokhang83.blastradius.core.git.GitComparison;
+import io.github.baokhang83.blastradius.core.git.MergeBaseResolver;
 import java.nio.file.Path;
 import java.util.List;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.Repository;
 
 /**
  * Resolves the current build's changes relative to a configured base reference
@@ -17,33 +16,23 @@ import org.eclipse.jgit.lib.Repository;
 public final class CurrentChangesResolver {
 
     private final ChangedFileClassifier changedFileClassifier = new ChangedFileClassifier();
+    private final MergeBaseResolver mergeBaseResolver = new MergeBaseResolver();
 
     public CurrentChanges resolve(Path projectDir, String baseReference) {
-        ObjectId resolvedBaseId;
-        ObjectId currentId;
-        try (Git git = Git.open(projectDir.toFile())) {
-            Repository repository = git.getRepository();
-            resolvedBaseId = repository.resolve(baseReference);
-            currentId = repository.resolve("HEAD");
-        } catch (Exception e) {
-            throw new IllegalStateException("failed to open git repository at " + projectDir, e);
-        }
-        if (resolvedBaseId == null) {
-            throw new IllegalStateException(
-                    "base reference \"" + baseReference + "\" does not resolve to a commit in " + projectDir);
-        }
-        if (currentId == null) {
-            throw new IllegalStateException("HEAD does not resolve to a commit in " + projectDir);
-        }
-
-        String resolvedBaseCommit = resolvedBaseId.getName();
-        String currentCommit = currentId.getName();
-        boolean isBaseRefBuild = resolvedBaseCommit.equals(currentCommit);
-
-        List<ChangedFile> changedFiles = isBaseRefBuild
+        GitComparison comparison = mergeBaseResolver.resolve(projectDir, baseReference);
+        List<ChangedFile> changedFiles = comparison.baseReferenceBuild()
                 ? List.of()
-                : changedFileClassifier.classify(projectDir, resolvedBaseCommit, currentCommit);
+                : comparison.comparisonBaseCommit()
+                        .map(comparisonBase -> changedFileClassifier.classify(
+                                projectDir, comparisonBase, comparison.headCommit()))
+                        .orElseGet(List::of);
 
-        return new CurrentChanges(baseReference, resolvedBaseCommit, currentCommit, isBaseRefBuild, changedFiles);
+        return new CurrentChanges(
+                baseReference,
+                comparison.baseReferenceCommit(),
+                comparison.comparisonBaseCommit(),
+                comparison.headCommit(),
+                comparison.baseReferenceBuild(),
+                changedFiles);
     }
 }

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicability.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicability.java
@@ -14,6 +14,7 @@ public record IndexApplicability(Status status, DependencyIndex index) {
         UNREADABLE,
         ANCHOR_UNREACHABLE,
         ANCHOR_MISMATCH,
+        MERGE_BASE_UNAVAILABLE,
         /**
          * Not a property of the index itself — set only when an otherwise-{@code
          * APPLICABLE} index's {@code SELECT} computation hits an unexpected internal
@@ -42,6 +43,10 @@ public record IndexApplicability(Status status, DependencyIndex index) {
 
     public static IndexApplicability anchorMismatch() {
         return new IndexApplicability(Status.ANCHOR_MISMATCH, null);
+    }
+
+    public static IndexApplicability mergeBaseUnavailable() {
+        return new IndexApplicability(Status.MERGE_BASE_UNAVAILABLE, null);
     }
 
     public static IndexApplicability internalError() {

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
@@ -123,9 +123,13 @@ public final class SelectMojo extends AbstractMojo {
         } catch (IllegalStateException e) {
             throw new MojoExecutionException("invalid configuration: " + e.getMessage(), e);
         }
-        String baselineIndexKey = CommitIndexKey.forCommit(indexPathKey, changes.resolvedBaseCommit());
-        IndexApplicability applicability = indexApplicabilityResolver.resolve(
-                indexStore, baselineIndexKey, changes.resolvedBaseCommit(), reactorRoot);
+        IndexApplicability applicability = changes.comparisonBaseCommit()
+                .map(comparisonBase -> indexApplicabilityResolver.resolve(
+                        indexStore,
+                        CommitIndexKey.forCommit(indexPathKey, comparisonBase),
+                        comparisonBase,
+                        reactorRoot))
+                .orElseGet(IndexApplicability::mergeBaseUnavailable);
 
         BuildReport.Mode resolvedMode = determineMode(changes, applicability, mode);
 

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/ConsoleSummaryRenderer.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/ConsoleSummaryRenderer.java
@@ -51,7 +51,8 @@ public final class ConsoleSummaryRenderer {
             case MISSING -> "no persisted index found (MISSING)";
             case UNREADABLE -> "persisted index could not be read (UNREADABLE)";
             case ANCHOR_UNREACHABLE -> "persisted index's anchor commit is no longer reachable (ANCHOR_UNREACHABLE)";
-            case ANCHOR_MISMATCH -> "persisted index does not match the resolved baseline commit (ANCHOR_MISMATCH)";
+            case ANCHOR_MISMATCH -> "persisted index does not match the resolved comparison base (ANCHOR_MISMATCH)";
+            case MERGE_BASE_UNAVAILABLE -> "Git could not establish a common comparison base (MERGE_BASE_UNAVAILABLE)";
             case INTERNAL_ERROR -> "an internal error occurred during selection computation (INTERNAL_ERROR)";
             case APPLICABLE -> throw new IllegalStateException("FALLBACK mode never has an APPLICABLE index");
         };

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/diff/CurrentChangesResolverTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/diff/CurrentChangesResolverTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.github.baokhang83.blastradius.core.git.FileKind;
 import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
 import java.nio.file.Path;
+import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -54,5 +55,34 @@ class CurrentChangesResolverTest {
         CurrentChanges changes = resolver.resolve(projectDir, initial);
 
         assertEquals(initial, changes.baseReference());
+    }
+
+    @Test
+    void diffsTheFeatureBranchFromItsMergeBaseNotTheAdvancedTarget(@TempDir Path projectDir) throws Exception {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        String branchPoint = fixture.commit("initial");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setCreateBranch(true).setName("feature").call();
+        }
+        fixture.writeClass("com.example.FeatureOnly", "package com.example; class FeatureOnly {}");
+        fixture.commit("feature change");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("main").call();
+        }
+        fixture.writeClass("com.example.TargetOnly", "package com.example; class TargetOnly {}");
+        String targetTip = fixture.commit("target change");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("feature").call();
+        }
+
+        CurrentChanges changes = resolver.resolve(projectDir, "main");
+
+        assertEquals(targetTip, changes.resolvedBaseCommit());
+        assertEquals(branchPoint, changes.comparisonBaseCommit().orElseThrow());
+        assertEquals(1, changes.changedFiles().size());
+        assertEquals("com.example.FeatureOnly", changes.changedFiles().get(0).changedClassName());
     }
 }

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeEndToEndTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeEndToEndTest.java
@@ -8,6 +8,7 @@ import io.github.baokhang83.blastradius.plugin.index.DependencyIndex;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -162,5 +163,57 @@ class SelectModeEndToEndTest {
         assertTrue(reportJson.contains("\"mode\":\"SELECT\""), "expected mode=SELECT in:\n" + reportJson);
         assertTrue(reportJson.contains("\"selectedCount\":2"), "expected selectedCount=2 in:\n" + reportJson);
         assertTrue(reportJson.contains("\"totalCount\":3"), "expected totalCount=3 in:\n" + reportJson);
+    }
+
+    @Test
+    void ignoresTargetOnlyChangesWhenSelectingOnADivergedFeatureBranch(@TempDir Path projectDir) throws Exception {
+        FixtureProjectBuilder fixture = EndToEndTestSupport.seedFooBarFixture(projectDir);
+        String branchPoint = fixture.commit("initial");
+        DependencyIndex index = EndToEndTestSupport.trackDependencies(projectDir, branchPoint);
+        EndToEndTestSupport.writeIndex(projectDir, index);
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setCreateBranch(true).setName("feature").call();
+        }
+        fixture.writeClass("com.example.Foo",
+                "package com.example; public class Foo { public int value() { return 99; } }");
+        fixture.writeTest("com.example.FooTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class FooTest {
+                    @Test
+                    void checksFoo() { assertEquals(99, new Foo().value()); }
+                }
+                """);
+        fixture.commit("feature changes Foo");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("main").call();
+        }
+        fixture.writeClass("com.example.Bar",
+                "package com.example; public class Bar { public int value() { return 7; } }");
+        fixture.writeTest("com.example.BarTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class BarTest {
+                    @Test
+                    void checksBar() { assertEquals(7, new Bar().value()); }
+                }
+                """);
+        fixture.commit("main changes Bar");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("feature").call();
+        }
+        fixture.addBuildPlugin(null, EndToEndTestSupport.pluginXml("main"));
+
+        String output = EndToEndTestSupport.runMvnTest(projectDir);
+
+        assertTrue(output.contains("BUILD SUCCESS"), "expected the build to succeed:\n" + output);
+        assertTrue(output.contains("[blastradius] 1 / 2 tests selected"), output);
+        assertTrue(output.contains("Running com.example.FooTest"), "expected FooTest to run:\n" + output);
+        assertFalse(output.contains("Running com.example.BarTest"), "expected BarTest to remain skipped:\n" + output);
     }
 }

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojoModeRoutingTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojoModeRoutingTest.java
@@ -7,14 +7,15 @@ import io.github.baokhang83.blastradius.plugin.index.DependencyIndex;
 import io.github.baokhang83.blastradius.plugin.index.IndexApplicability;
 import io.github.baokhang83.blastradius.plugin.report.BuildReport;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class SelectMojoModeRoutingTest {
 
     private static final CurrentChanges BASE_REF_BUILD =
-            new CurrentChanges("main", "abc123", "abc123", true, List.of());
+            new CurrentChanges("main", "abc123", Optional.of("abc123"), "abc123", true, List.of());
     private static final CurrentChanges PR_BUILD =
-            new CurrentChanges("main", "abc123", "def456", false, List.of());
+            new CurrentChanges("main", "abc123", Optional.of("abc123"), "def456", false, List.of());
 
     @Test
     void baseRefBuildAlwaysRoutesToTrack() {
@@ -63,6 +64,13 @@ class SelectMojoModeRoutingTest {
     @Test
     void prBuildWithUnreachableAnchorRoutesToFallback() {
         BuildReport.Mode mode = SelectMojo.determineMode(PR_BUILD, IndexApplicability.anchorUnreachable(), null);
+
+        assertEquals(BuildReport.Mode.FALLBACK, mode);
+    }
+
+    @Test
+    void prBuildWithoutAMergeBaseRoutesToFallback() {
+        BuildReport.Mode mode = SelectMojo.determineMode(PR_BUILD, IndexApplicability.mergeBaseUnavailable(), null);
 
         assertEquals(BuildReport.Mode.FALLBACK, mode);
     }

--- a/docs/fluencyloop/features/pr-merge-base-aware-diffing-28/design.md
+++ b/docs/fluencyloop/features/pr-merge-base-aware-diffing-28/design.md
@@ -1,0 +1,103 @@
+# Design: PR merge-base-aware diffing (#28)
+
+started: 2026-07-21
+
+## Intent
+
+Compare a PR build with its Git merge base against the configured target ref, rather than
+with the target's current tip. This excludes changes that have landed on the target since the
+branch diverged while retaining the existing full-test fallback when Git cannot establish a
+safe comparison point.
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class MergeBaseResolver {
+    +resolve(repositoryDirectory, baseReference) GitComparison
+  }
+  class GitComparison {
+    +headCommit: String
+    +baseReferenceCommit: String
+    +comparisonBaseCommit: Optional~String~
+    +baseReferenceBuild() boolean
+  }
+  class CurrentChangesResolver {
+    +resolve(projectDirectory, baseReference) CurrentChanges
+  }
+  class CurrentChanges {
+    +comparisonBaseCommit: Optional~String~
+    +changedFiles: List~ChangedFile~
+  }
+  class GitBuildStateSource {
+    +obtain() GitBuildState
+  }
+  class GitBuildState {
+    +comparisonBaseCommit: Optional~String~
+  }
+  class ChangedFileClassifier {
+    +classify(repository, base, head) List~ChangedFile~
+  }
+
+  MergeBaseResolver --> GitComparison : resolves
+  CurrentChangesResolver --> MergeBaseResolver : uses
+  CurrentChangesResolver --> CurrentChanges : builds
+  GitBuildStateSource --> MergeBaseResolver : uses
+  GitBuildStateSource --> GitBuildState : builds
+  CurrentChangesResolver --> ChangedFileClassifier : comparison base to HEAD
+```
+
+`MergeBaseResolver` belongs in core because Maven and Gradle need the same Git rule. The
+adapters keep their existing models, but carry the comparison base separately from the configured
+ref's resolved tip: a base-ref build is still exactly `HEAD == baseReferenceCommit` and remains
+the only automatic `TRACK` trigger.
+
+## Sequence: SELECT on a PR branch
+
+```mermaid
+sequenceDiagram
+  participant Plugin as Maven or Gradle adapter
+  participant Merge as MergeBaseResolver
+  participant Git as JGit repository
+  participant Index as Commit-keyed index store
+  participant Classifier as ChangedFileClassifier
+
+  Plugin->>Merge: resolve(repository, baseRef)
+  Merge->>Git: resolve HEAD and baseRef tip
+  Merge->>Git: find merge base of HEAD and target tip
+  alt common ancestor found
+    Merge-->>Plugin: head, target tip, comparison base
+    Plugin->>Index: read key for comparison base
+    alt matching index exists
+      Plugin->>Classifier: diff comparison base to HEAD
+      Classifier-->>Plugin: PR-only changed files
+      Plugin-->>Plugin: apply dependency selection
+    else index absent or invalid
+      Plugin-->>Plugin: full-test fallback
+    end
+  else no common ancestor
+    Merge-->>Plugin: no comparison base
+    Plugin-->>Plugin: explained full-test fallback
+  end
+```
+
+## Key decisions
+
+- Use JGit's graph-aware merge-base calculation once in shared core, rather than a two-tree
+  diff from the moving `baseRef` tip. A target branch may advance after a PR branches; diffing
+  that new tip against `HEAD` wrongly includes the target's own work.
+- Key SELECT's index lookup and changed-file diff to the merge base. The stored index then
+  describes the exact code snapshot from which the PR's changes are measured.
+- Preserve `HEAD == resolved baseRef` as the `TRACK` rule. A merge base equal to `HEAD` on a
+  branch is not evidence that the branch is the target build.
+- Treat unrelated histories or a missing merge base as a named safe fallback, not an error or a
+  guessed comparison. This protects selection correctness through unusual rebases or force-pushes.
+
+## Validation
+
+- Core graph fixtures cover a diverged target branch, a merge commit, a rebased branch, and no
+  common ancestor.
+- Maven and Gradle adapter tests prove they propagate the comparison base to both the diff and
+  commit-keyed lookup.
+- End-to-end fixtures confirm a target-only change is not selected by a PR build, while a PR
+  change still is.

--- a/docs/fluencyloop/features/pr-merge-base-aware-diffing-28/sessions/apply-the-comparison-base-to-maven-and-gradle-selection.md
+++ b/docs/fluencyloop/features/pr-merge-base-aware-diffing-28/sessions/apply-the-comparison-base-to-maven-and-gradle-selection.md
@@ -1,0 +1,33 @@
+# Session: Apply the comparison base to Maven and Gradle selection
+
+- **intent:** Apply the comparison base to Maven and Gradle selection
+- **started:** 2026-07-21
+
+## Decision: Use the merge base for both SELECT inputs
+
+- **where:** `blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/diff/CurrentChangesResolver.java; blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java; blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusPlugin.java`
+- **why:** The same comparison-base SHA keys the persisted index and bounds the diff to HEAD, so target-only commits after a branch diverges cannot affect PR selection.
+- **alternative:** Use the resolved target tip as the index and diff baseline — rejected because it mixes target-only changes into the PR comparison.
+- **design:** ../design.md#sequence-select-on-a-pr-branch
+- **constitution:** §III, §IV, §V
+- **trust:** ✓ verified
+
+## Decision: Leave the task unfiltered when no common ancestor exists
+
+- **where:** `blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/GitBuildState.java; blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/NoComparisonBaseFallbackAction.java; blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicability.java`
+- **why:** An absent merge base has no sound index key or diff endpoint, so both adapters surface a named safe fallback instead of guessing; Gradle models the nullable value in configuration-cache state.
+- **alternative:** Invent an index key, compare with the target tip, or fail the test task — rejected because those options can misselect tests or turn an uncertain comparison into a build failure.
+- **design:** ../design.md#sequence-select-on-a-pr-branch
+- **constitution:** §III, §V
+- **trust:** ✓ verified
+
+## Knowledge transfer
+
+- **Maven comparison state:** `CurrentChanges` keeps the configured ref's resolved tip distinct
+  from its optional merge base with `HEAD`. Only a present comparison base is used to locate an
+  index and classify changes; otherwise `MERGE_BASE_UNAVAILABLE` reports the conservative
+  fallback. **Status:** verified by the real Maven diverged-branch subprocess test.
+- **Gradle configuration-cache state:** `GitBuildState` uses a nullable comparison-base string
+  because the state is serialized by Gradle. A present value becomes both a task input and the
+  key for `ApplySelectionAction`; no value installs an action that leaves the normal full test
+  task unfiltered. **Status:** verified by the Gradle functional diverged-branch test.

--- a/docs/fluencyloop/features/pr-merge-base-aware-diffing-28/sessions/resolve-a-pr-comparison-base-in-shared-core.md
+++ b/docs/fluencyloop/features/pr-merge-base-aware-diffing-28/sessions/resolve-a-pr-comparison-base-in-shared-core.md
@@ -1,0 +1,24 @@
+# Session: Resolve a PR comparison base in shared core
+
+- **intent:** Resolve a PR comparison base in shared core
+- **started:** 2026-07-21
+
+## Decision: Use one graph-aware resolver for both build integrations
+
+- **where:** `blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/MergeBaseResolver.java; blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/GitComparison.java`
+- **why:** Maven and Gradle must calculate the same comparison base; one JGit-backed resolver returns the target tip separately from the merge base and exposes no-common-ancestor explicitly.
+- **alternative:** Resolve the target tip and diff it directly, or duplicate merge-base traversal in each plugin — rejected because target-only commits leak into PR selection and duplicate graph logic can diverge.
+- **design:** ../design.md#class-diagram
+- **constitution:** §II, §III, §IV
+- **trust:** ✓ verified
+
+## Knowledge transfer
+
+- **GitComparison:** preserves three distinct values: the build's `HEAD`, the configured
+  reference's current tip, and an optional common ancestor. `baseReferenceBuild()` compares the
+  first two only, so a branch whose merge base happens to equal `HEAD` never becomes a TRACK
+  build by accident. **Status:** verified by the base-reference fixture.
+- **MergeBaseResolver:** uses JGit's `RevFilter.MERGE_BASE` over the two resolved commits and
+  returns an empty comparison base for unrelated histories. Callers can then take the safe,
+  explicit fallback rather than inventing a diff endpoint. **Status:** verified by the divergent
+  history, merge-commit, rebase, and unrelated-history fixtures.


### PR DESCRIPTION
Closes #28.

## Intent

Diff a feature build from the Git merge base with its configured target, rather than from the target's moving tip.

## Decisions

### Shared comparison resolver

Use the core `MergeBaseResolver` for Maven and Gradle so both integrations distinguish the target tip from the optional common comparison base.

### Exact SELECT baseline

Use the merge base for both the persisted-index key and the `mergeBase..HEAD` diff. Target-only commits made after a feature branch diverges therefore do not affect selection.

### Safe no-common-ancestor handling

When Git cannot establish a common ancestor, leave the test task unfiltered and report `MERGE_BASE_UNAVAILABLE` instead of guessing at a diff endpoint.

## Design

See [the feature design](docs/fluencyloop/features/pr-merge-base-aware-diffing-28/design.md).

## Validation

- `mvn clean verify`
- `./gradlew clean test`
