### PR TITLE
test: reduce Maven plugin integration-test runtime

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "pr-merge-base-aware-diffing-28",
-  "branch": "feature/pr-merge-base-aware-diffing-28",
+  "feature": "reduce-maven-plugin-integration-test-runtime-75",
+  "branch": "feature/reduce-maven-plugin-integration-test-runtime-75",
   "stage": "review",
-  "last_session": "docs/fluencyloop/features/pr-merge-base-aware-diffing-28/sessions/apply-the-comparison-base-to-maven-and-gradle-selection.md",
+  "last_session": "docs/fluencyloop/features/reduce-maven-plugin-integration-test-runtime-75/sessions/cache-successful-maven-plugin-setup-per-test-jvm.md",
   "base_ref": "main",
   "updated": "2026-07-21"
 }

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
@@ -28,13 +28,15 @@ import java.util.concurrent.TimeUnit;
  */
 final class EndToEndTestSupport {
 
+    private static final PluginInstaller PLUGIN_INSTALLER = new PluginInstaller();
+
     private EndToEndTestSupport() {
     }
 
     static void installThisPluginOnce() throws IOException, InterruptedException {
-        runToCompletion(new ProcessBuilder(
+        PLUGIN_INSTALLER.installOnce(() -> runToCompletion(new ProcessBuilder(
                 "mvn", "-q", "-pl", "blastradius-maven-plugin", "-am", "install", "-DskipTests", "-Dinvoker.skip=true")
-                .directory(Path.of("..").toAbsolutePath().normalize().toFile()));
+                .directory(Path.of("..").toAbsolutePath().normalize().toFile())));
     }
 
     /** A single-module fixture with an independent Foo/FooTest and Bar/BarTest pair. */

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/PluginInstaller.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/PluginInstaller.java
@@ -1,0 +1,22 @@
+package io.github.baokhang83.blastradius.plugin.mojo;
+
+import java.io.IOException;
+
+final class PluginInstaller {
+
+    private boolean installed;
+
+    synchronized void installOnce(InstallAction action) throws IOException, InterruptedException {
+        if (installed) {
+            return;
+        }
+        action.run();
+        installed = true;
+    }
+
+    @FunctionalInterface
+    interface InstallAction {
+
+        void run() throws IOException, InterruptedException;
+    }
+}

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/PluginInstallerTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/PluginInstallerTest.java
@@ -1,0 +1,36 @@
+package io.github.baokhang83.blastradius.plugin.mojo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class PluginInstallerTest {
+
+    @Test
+    void installsOnlyOnceAfterASuccessfulInstall() throws Exception {
+        PluginInstaller installer = new PluginInstaller();
+        AtomicInteger installations = new AtomicInteger();
+
+        installer.installOnce(installations::incrementAndGet);
+        installer.installOnce(installations::incrementAndGet);
+
+        assertEquals(1, installations.get());
+    }
+
+    @Test
+    void retriesWhenTheFirstInstallFails() throws Exception {
+        PluginInstaller installer = new PluginInstaller();
+        AtomicInteger installations = new AtomicInteger();
+
+        assertThrows(IOException.class, () -> installer.installOnce(() -> {
+            installations.incrementAndGet();
+            throw new IOException("temporary failure");
+        }));
+        installer.installOnce(installations::incrementAndGet);
+
+        assertEquals(2, installations.get());
+    }
+}

--- a/docs/fluencyloop/features/reduce-maven-plugin-integration-test-runtime-75/design.md
+++ b/docs/fluencyloop/features/reduce-maven-plugin-integration-test-runtime-75/design.md
@@ -1,0 +1,74 @@
+# Design: Reduce Maven plugin integration-test runtime (#75)
+
+started: 2026-07-21
+
+## Performance baseline
+
+On 2026-07-21, a warm local run of `mvn -pl blastradius-maven-plugin -am test` completed in
+1m 22.45s. The Maven-plugin module took 1m 15s for 51 tests. The result includes a full,
+real fixture build for every end-to-end scenario and repeated setup installs of this plugin.
+
+After caching the successful setup install, the same command completed in 51.43s (53 tests),
+a 37.6% end-to-end reduction. The Maven-plugin module took 45.08s. Both measurements retain
+real fixture builds, `clean`, TRACK, SELECT, fallback, and agent-produced-index coverage.
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class EndToEndTestClass {
+    +beforeAll()
+    +scenarioTest()
+  }
+  class EndToEndTestSupport {
+    +installThisPluginOnce()
+    +trackDependencies(project, anchor)
+    +runMvnTest(project)
+  }
+  class PluginInstaller {
+    +installOnce(action)
+  }
+  class MavenInstallProcess {
+    mvn -pl blastradius-maven-plugin -am install
+  }
+  class FixtureMavenProcess {
+    mvn clean test
+  }
+
+  EndToEndTestClass --> EndToEndTestSupport
+  EndToEndTestSupport --> PluginInstaller
+  PluginInstaller --> MavenInstallProcess : only after successful first request
+  EndToEndTestSupport --> FixtureMavenProcess : each scenario keeps its own build
+```
+
+## Sequence: run an end-to-end scenario
+
+```mermaid
+sequenceDiagram
+  participant Test as JUnit test class
+  participant Support as EndToEndTestSupport
+  participant Installer as PluginInstaller
+  participant Maven as Maven process
+  participant Fixture as isolated fixture
+
+  Test->>Support: @BeforeAll installThisPluginOnce()
+  Support->>Installer: installOnce(install plugin)
+  alt first successful request in this test JVM
+    Installer->>Maven: install plugin into local repository
+    Maven-->>Installer: success
+    Installer-->>Support: remember successful install
+  else already installed
+    Installer-->>Support: no subprocess
+  end
+  Test->>Support: scenarioTest()
+  Support->>Fixture: create a fresh project directory
+  Support->>Maven: mvn clean test in that fixture
+  Maven-->>Test: assert real plugin behavior and agent output
+```
+
+## Decision
+
+Cache only the successful plugin-install setup within the Surefire JVM. Keep every scenario's
+separate fixture directory, `mvn clean test` invocation, and real agent-backed dependency-index
+coverage. Reusing mutable fixture directories, removing `clean`, or parallelizing nested Maven
+builds would need separate isolation and determinism evidence and is intentionally out of scope.

--- a/docs/fluencyloop/features/reduce-maven-plugin-integration-test-runtime-75/sessions/cache-successful-maven-plugin-setup-per-test-jvm.md
+++ b/docs/fluencyloop/features/reduce-maven-plugin-integration-test-runtime-75/sessions/cache-successful-maven-plugin-setup-per-test-jvm.md
@@ -1,0 +1,22 @@
+# Session: Cache successful Maven plugin setup per test JVM
+
+- **intent:** Cache successful Maven plugin setup per test JVM
+- **started:** 2026-07-21
+
+## Decision: Cache plugin setup only after success
+
+- **where:** `blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/PluginInstaller.java; blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java`
+- **why:** A single synchronized test-JVM guard removes repeated identical Maven installs while caching only a successful process result, so a failed setup remains retryable and each scenario still runs its own real fixture build.
+- **alternative:** Reuse fixture directories, remove clean, or persist a cross-run cache — rejected because those approaches can leak state or hide isolation failures.
+- **design:** ../design.md#class-diagram
+- **constitution:** §I, §II, §III
+- **trust:** ✓ verified
+
+## Knowledge transfer
+
+- **PluginInstaller:** keeps a synchronized, in-memory success flag for the Surefire JVM. It
+  invokes the supplied Maven-install action exactly once after it succeeds; an exception leaves
+  the flag unset, allowing a later request to retry. **Status:** verified by focused unit tests.
+- **EndToEndTestSupport:** delegates its existing plugin-install command to `PluginInstaller`,
+  while `trackDependencies` and `runMvnTest` continue launching separate `mvn clean test`
+  processes in fresh fixture directories. **Status:** verified by the full Maven-plugin suite.


### PR DESCRIPTION
Closes #75.

## Intent

Reduce the Maven plugin's end-to-end test runtime without weakening real Maven, Git, or agent coverage.

## Decision

Cache the Maven plugin setup install only after it succeeds, once per Surefire JVM. A failed install remains retryable. Each scenario still creates its own fixture project and runs its own `mvn clean test` subprocess.

Rejected: fixture reuse, removing `clean`, or a cross-run cache; each could leak state or make isolation failures less visible.

## Measured result

On the same warm local command, `mvn -pl blastradius-maven-plugin -am test` fell from **1m 22.45s** (51 tests) to **51.43s** (53 tests), a **37.6%** reduction.

## Validation

- Focused `PluginInstallerTest`: 2 passing tests
- `mvn -pl blastradius-maven-plugin -am test`: 53 passing tests
- `mvn clean verify`: passed, including all four Maven Invoker fixtures

## Design

See [the feature design](docs/fluencyloop/features/reduce-maven-plugin-integration-test-runtime-75/design.md).
