### PR TITLE
Version persisted dependency indexes

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "reduce-maven-plugin-integration-test-runtime-75",
-  "branch": "feature/reduce-maven-plugin-integration-test-runtime-75",
+  "feature": "version-dependency-indexes-and-safely-handle-incompatibility",
+  "branch": "feature/version-dependency-indexes-and-safely-handle-incompatibility",
   "stage": "review",
-  "last_session": "docs/fluencyloop/features/reduce-maven-plugin-integration-test-runtime-75/sessions/cache-successful-maven-plugin-setup-per-test-jvm.md",
+  "last_session": "docs/fluencyloop/features/version-dependency-indexes-and-safely-handle-incompatibility/sessions/apply-format-checks-in-maven-and-gradle-selection.md",
   "base_ref": "main",
   "updated": "2026-07-21"
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/index/DependencyIndexFormat.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/index/DependencyIndexFormat.java
@@ -1,0 +1,23 @@
+package io.github.baokhang83.blastradius.core.index;
+
+/** Version contract for persisted dependency-index JSON shared by the build integrations. */
+public final class DependencyIndexFormat {
+
+    /** The version emitted for every newly tracked dependency index. */
+    public static final int CURRENT_VERSION = 1;
+
+    private static final int LEGACY_UNVERSIONED_VERSION = 0;
+
+    private DependencyIndexFormat() {
+    }
+
+    /** Maps the one known unversioned schema to the current version without accepting future schemas. */
+    public static int migrateLegacyVersion(int version) {
+        return version == LEGACY_UNVERSIONED_VERSION ? CURRENT_VERSION : version;
+    }
+
+    /** Returns whether an index version is safe for the current selection implementation to use. */
+    public static boolean isCurrentVersion(int version) {
+        return version == CURRENT_VERSION;
+    }
+}

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/index/DependencyIndexFormatTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/index/DependencyIndexFormatTest.java
@@ -1,0 +1,27 @@
+package io.github.baokhang83.blastradius.core.index;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class DependencyIndexFormatTest {
+
+    @Test
+    void migratesTheKnownUnversionedLegacySchemaToTheCurrentVersion() {
+        assertEquals(DependencyIndexFormat.CURRENT_VERSION, DependencyIndexFormat.migrateLegacyVersion(0));
+    }
+
+    @Test
+    void leavesAnUnsupportedVersionUntouchedForTheCallerToReject() {
+        assertEquals(DependencyIndexFormat.CURRENT_VERSION + 1,
+                DependencyIndexFormat.migrateLegacyVersion(DependencyIndexFormat.CURRENT_VERSION + 1));
+    }
+
+    @Test
+    void recognizesOnlyTheCurrentVersionAsUsable() {
+        assertTrue(DependencyIndexFormat.isCurrentVersion(DependencyIndexFormat.CURRENT_VERSION));
+        assertFalse(DependencyIndexFormat.isCurrentVersion(DependencyIndexFormat.CURRENT_VERSION + 1));
+    }
+}

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ApplySelectionAction.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ApplySelectionAction.java
@@ -45,6 +45,11 @@ final class ApplySelectionAction implements Action<Task> {
         IndexApplicability applicability = new IndexApplicabilityResolver()
                 .resolve(indexStore, indexKey, comparisonBaseCommit, repositoryRoot);
         if (applicability.status() != IndexApplicability.Status.APPLICABLE) {
+            if (applicability.status() == IndexApplicability.Status.FORMAT_VERSION_MISMATCH) {
+                test.getLogger().lifecycle(
+                        "[blastradius] FALLBACK — persisted index uses an unsupported format version (FORMAT_VERSION_MISMATCH)");
+                return;
+            }
             test.getLogger().info("[blastradius] Gradle test task left unfiltered ({})", applicability.status());
             return;
         }

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/DependencyIndex.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/DependencyIndex.java
@@ -1,17 +1,30 @@
 package io.github.baokhang83.blastradius.gradle;
 
+import io.github.baokhang83.blastradius.core.index.DependencyIndexFormat;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-record DependencyIndex(String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies) {
+record DependencyIndex(int formatVersion, String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies) {
+
+    DependencyIndex {
+        formatVersion = DependencyIndexFormat.migrateLegacyVersion(formatVersion);
+    }
+
+    DependencyIndex(String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies) {
+        this(DependencyIndexFormat.CURRENT_VERSION, anchorCommit, builtAt, testDependencies);
+    }
 
     record TestDependencyEntry(TestIdentity test, Set<String> dependsOnClasses) {}
 
     Map<TestIdentity, Set<String>> testDependenciesByTest() {
         return testDependencies.stream()
                 .collect(Collectors.toUnmodifiableMap(TestDependencyEntry::test, TestDependencyEntry::dependsOnClasses));
+    }
+
+    boolean hasCurrentFormat() {
+        return DependencyIndexFormat.isCurrentVersion(formatVersion);
     }
 }

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/IndexApplicability.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/IndexApplicability.java
@@ -6,6 +6,7 @@ record IndexApplicability(Status status, DependencyIndex index) {
         APPLICABLE,
         MISSING,
         UNREADABLE,
+        FORMAT_VERSION_MISMATCH,
         ANCHOR_UNREACHABLE,
         ANCHOR_MISMATCH
     }
@@ -20,6 +21,10 @@ record IndexApplicability(Status status, DependencyIndex index) {
 
     static IndexApplicability unreadable() {
         return new IndexApplicability(Status.UNREADABLE, null);
+    }
+
+    static IndexApplicability formatVersionMismatch() {
+        return new IndexApplicability(Status.FORMAT_VERSION_MISMATCH, null);
     }
 
     static IndexApplicability anchorUnreachable() {

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/IndexApplicabilityResolver.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/IndexApplicabilityResolver.java
@@ -21,6 +21,9 @@ final class IndexApplicabilityResolver {
         if (index == null) {
             return IndexApplicability.missing();
         }
+        if (!index.hasCurrentFormat()) {
+            return IndexApplicability.formatVersionMismatch();
+        }
 
         if (!anchorIsReachable(index.anchorCommit(), projectDir)) {
             return IndexApplicability.anchorUnreachable();

--- a/blastradius-gradle-plugin/src/test/java/io/github/baokhang83/blastradius/gradle/BlastradiusPluginFunctionalTest.java
+++ b/blastradius-gradle-plugin/src/test/java/io/github/baokhang83/blastradius/gradle/BlastradiusPluginFunctionalTest.java
@@ -114,6 +114,20 @@ class BlastradiusPluginFunctionalTest {
         assertTrue(Files.exists(projectDir.resolve("build/bar-ran")));
     }
 
+    @Test
+    void leavesTheTaskUnfilteredWhenTheIndexFormatIsUnsupported() throws Exception {
+        writeProject();
+        String baselineCommit = commitBaseline();
+        changeFoo();
+        writeUnsupportedIndex(baselineCommit);
+
+        BuildResult result = runGradle("test");
+
+        assertTrue(result.getOutput().contains("FORMAT_VERSION_MISMATCH"), result.getOutput());
+        assertTrue(Files.exists(projectDir.resolve("build/foo-ran")));
+        assertTrue(Files.exists(projectDir.resolve("build/bar-ran")));
+    }
+
     private void writeProject() throws IOException {
         write("settings.gradle", "rootProject.name = 'consumer'\n");
         write("build.gradle", """
@@ -211,6 +225,17 @@ class BlastradiusPluginFunctionalTest {
                     {"test": {"className": "example.FooTest", "methodName": "checksFoo"}, "dependsOnClasses": ["example.Foo"]},
                     {"test": {"className": "example.BarTest", "methodName": "checksBar"}, "dependsOnClasses": ["example.Bar"]}
                   ]
+                }
+                """.formatted(baselineCommit));
+    }
+
+    private void writeUnsupportedIndex(String baselineCommit) throws IOException {
+        write(CommitIndexKey.forCommit(".blastradius/index.json", baselineCommit), """
+                {
+                  "formatVersion": 2,
+                  "anchorCommit": "%s",
+                  "builtAt": "2026-07-20T00:00:00Z",
+                  "testDependencies": []
                 }
                 """.formatted(baselineCommit));
     }

--- a/blastradius-gradle-plugin/src/test/java/io/github/baokhang83/blastradius/gradle/IndexApplicabilityResolverTest.java
+++ b/blastradius-gradle-plugin/src/test/java/io/github/baokhang83/blastradius/gradle/IndexApplicabilityResolverTest.java
@@ -3,6 +3,7 @@ package io.github.baokhang83.blastradius.gradle;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.github.baokhang83.blastradius.core.index.FileIndexStore;
+import io.github.baokhang83.blastradius.core.index.DependencyIndexFormat;
 import io.github.baokhang83.blastradius.core.index.IndexStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,6 +41,18 @@ class IndexApplicabilityResolverTest {
                 .resolve(store(projectDir), INDEX_KEY, expectedBaseCommit, projectDir);
 
         assertEquals(IndexApplicability.Status.ANCHOR_MISMATCH, applicability.status());
+    }
+
+    @Test
+    void unsupportedIndexFormatIsReportedAsAMismatch(@TempDir Path projectDir) throws Exception {
+        String baseCommit = commit(projectDir, "initial");
+        store(projectDir).put(INDEX_KEY, new DependencyIndex(
+                DependencyIndexFormat.CURRENT_VERSION + 1, baseCommit, Instant.now().toString(), List.of()));
+
+        IndexApplicability applicability = new IndexApplicabilityResolver()
+                .resolve(store(projectDir), INDEX_KEY, baseCommit, projectDir);
+
+        assertEquals(IndexApplicability.Status.FORMAT_VERSION_MISMATCH, applicability.status());
     }
 
     private static String commit(Path projectDir, String message) throws Exception {

--- a/blastradius-maven-plugin/README.md
+++ b/blastradius-maven-plugin/README.md
@@ -49,7 +49,7 @@ Three modes fall out of this, decided fresh on every invocation — never config
 |---|---|---|
 | **`TRACK`** | Current commit *is* `baseRef` (or `-Dblastradius.mode=track`) | Full suite runs, untouched. A subprocess rebuilds the index in the background for next time. |
 | **`SELECT`** | Not `baseRef`, and a usable index exists for the merge base | Surefire is narrowed to the affected tests. This is the fast path. |
-| **`FALLBACK`** | Not `baseRef`, and no usable index (missing, unreadable, unreachable, for another baseline commit, or no common ancestor) | Full suite runs, untouched. Nothing gained by tracking from a throwaway branch commit, so nothing is forked. |
+| **`FALLBACK`** | Not `baseRef`, and no usable index (missing, unreadable, unsupported format, unreachable, for another baseline commit, or no common ancestor) | Full suite runs, untouched. Nothing gained by tracking from a throwaway branch commit, so nothing is forked. |
 
 `TRACK` and `FALLBACK` are never treated as errors — they're the plugin being honest about
 not having enough information yet, and defaulting to safe.
@@ -155,7 +155,8 @@ Add `-Dblastradius.explain=true` for the per-test breakdown that line is pointin
 ```
 
 The reason in parentheses always tells you *why*: `MISSING` (no TRACK build exists for the
-resolved merge base), `UNREADABLE` (the index file is corrupt), `ANCHOR_UNREACHABLE` (its
+resolved merge base), `UNREADABLE` (the index file is corrupt), `FORMAT_VERSION_MISMATCH` (the
+index was written by an unsupported schema version), `ANCHOR_UNREACHABLE` (its
 recorded commit no longer exists, e.g. after a history rewrite), `ANCHOR_MISMATCH` (the stored
 index declares a different baseline), `MERGE_BASE_UNAVAILABLE` (the refs have no common
 ancestor), or `INTERNAL_ERROR` (the goal hit an unexpected fault mid-computation and safely
@@ -168,7 +169,9 @@ Both live under `.blastradius/` at the reactor root — add it to `.gitignore`.
 - **`<full-sha>/index.json`** — the persisted dependency map a `TRACK` build produces for its
   exact commit and a `SELECT` build reads for its resolved merge base. The default location is
   `.blastradius/<full-sha>/index.json`.
-  `{ anchorCommit, builtAt, testDependencies: [{ test, dependsOnClasses }] }`.
+  `{ formatVersion, anchorCommit, builtAt, testDependencies: [{ test, dependsOnClasses }] }`.
+  Newly tracked indexes use format version 1. Existing unversioned indexes are migrated in
+  memory; any other version safely falls back to the full suite.
 - **`last-build-report.json`** — this build's own decisions, machine-readable.
   `{ mode, indexApplicability, decisions: [{ test, selected, reason, matchedChangedClass }], selectedCount, totalCount }`.
   This is the source of truth every console line above is a rendering of — audit a specific

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/DependencyIndex.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/DependencyIndex.java
@@ -1,5 +1,6 @@
 package io.github.baokhang83.blastradius.plugin.index;
 
+import io.github.baokhang83.blastradius.core.index.DependencyIndexFormat;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import java.util.List;
 import java.util.Map;
@@ -17,7 +18,15 @@ import java.util.stream.Collectors;
  * checksums (data-model.md) — the proven {@code SelectionEngine}/{@code
  * DependencyMatchSelector} logic only ever consumes class names.
  */
-public record DependencyIndex(String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies) {
+public record DependencyIndex(int formatVersion, String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies) {
+
+    public DependencyIndex {
+        formatVersion = DependencyIndexFormat.migrateLegacyVersion(formatVersion);
+    }
+
+    public DependencyIndex(String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies) {
+        this(DependencyIndexFormat.CURRENT_VERSION, anchorCommit, builtAt, testDependencies);
+    }
 
     public record TestDependencyEntry(TestIdentity test, Set<String> dependsOnClasses) {}
 
@@ -25,5 +34,9 @@ public record DependencyIndex(String anchorCommit, String builtAt, List<TestDepe
     public Map<TestIdentity, Set<String>> testDependenciesByTest() {
         return testDependencies.stream()
                 .collect(Collectors.toUnmodifiableMap(TestDependencyEntry::test, TestDependencyEntry::dependsOnClasses));
+    }
+
+    public boolean hasCurrentFormat() {
+        return DependencyIndexFormat.isCurrentVersion(formatVersion);
     }
 }

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicability.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicability.java
@@ -12,6 +12,7 @@ public record IndexApplicability(Status status, DependencyIndex index) {
         APPLICABLE,
         MISSING,
         UNREADABLE,
+        FORMAT_VERSION_MISMATCH,
         ANCHOR_UNREACHABLE,
         ANCHOR_MISMATCH,
         MERGE_BASE_UNAVAILABLE,
@@ -35,6 +36,10 @@ public record IndexApplicability(Status status, DependencyIndex index) {
 
     public static IndexApplicability unreadable() {
         return new IndexApplicability(Status.UNREADABLE, null);
+    }
+
+    public static IndexApplicability formatVersionMismatch() {
+        return new IndexApplicability(Status.FORMAT_VERSION_MISMATCH, null);
     }
 
     public static IndexApplicability anchorUnreachable() {

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolver.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolver.java
@@ -26,6 +26,9 @@ public final class IndexApplicabilityResolver {
         if (index == null) {
             return IndexApplicability.missing();
         }
+        if (!index.hasCurrentFormat()) {
+            return IndexApplicability.formatVersionMismatch();
+        }
 
         if (!anchorIsReachable(index.anchorCommit(), projectDir)) {
             return IndexApplicability.anchorUnreachable();

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/ConsoleSummaryRenderer.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/ConsoleSummaryRenderer.java
@@ -50,6 +50,7 @@ public final class ConsoleSummaryRenderer {
         return switch (status) {
             case MISSING -> "no persisted index found (MISSING)";
             case UNREADABLE -> "persisted index could not be read (UNREADABLE)";
+            case FORMAT_VERSION_MISMATCH -> "persisted index uses an unsupported format version (FORMAT_VERSION_MISMATCH)";
             case ANCHOR_UNREACHABLE -> "persisted index's anchor commit is no longer reachable (ANCHOR_UNREACHABLE)";
             case ANCHOR_MISMATCH -> "persisted index does not match the resolved comparison base (ANCHOR_MISMATCH)";
             case MERGE_BASE_UNAVAILABLE -> "Git could not establish a common comparison base (MERGE_BASE_UNAVAILABLE)";

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/DependencyIndexIoTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/DependencyIndexIoTest.java
@@ -3,6 +3,7 @@ package io.github.baokhang83.blastradius.plugin.index;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.baokhang83.blastradius.core.index.DependencyIndexFormat;
 import io.github.baokhang83.blastradius.core.index.FileIndexStore;
 import io.github.baokhang83.blastradius.core.index.IndexStore;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
@@ -17,7 +18,7 @@ import org.junit.jupiter.api.io.TempDir;
 class DependencyIndexIoTest {
 
     @Test
-    void writtenIndexRoundTripsThroughAFile(@TempDir Path tempDir) {
+    void writtenIndexRoundTripsThroughAFile(@TempDir Path tempDir) throws Exception {
         IndexStore<DependencyIndex> store = new FileIndexStore<>(tempDir, DependencyIndex.class);
         TestIdentity fooTest = new TestIdentity("com.example.FooTest", "checksAdd");
         DependencyIndex original = new DependencyIndex(
@@ -27,6 +28,8 @@ class DependencyIndexIoTest {
 
         store.put("index.json", original);
         assertTrue(Files.exists(tempDir.resolve("index.json")));
+        assertTrue(Files.readString(tempDir.resolve("index.json"))
+                .contains("\"formatVersion\":" + DependencyIndexFormat.CURRENT_VERSION));
 
         DependencyIndex roundTripped = store.get("index.json").orElseThrow();
 
@@ -63,5 +66,21 @@ class DependencyIndexIoTest {
         IndexStore<DependencyIndex> store = new FileIndexStore<>(tempDir, DependencyIndex.class);
 
         assertTrue(store.get("does-not-exist.json").isEmpty());
+    }
+
+    @Test
+    void unversionedLegacyIndexMigratesToTheCurrentFormat(@TempDir Path tempDir) throws Exception {
+        IndexStore<DependencyIndex> store = new FileIndexStore<>(tempDir, DependencyIndex.class);
+        Files.writeString(tempDir.resolve("legacy.json"), """
+                {
+                  "anchorCommit": "a1b2c3d",
+                  "builtAt": "2026-07-09T10:03:00Z",
+                  "testDependencies": []
+                }
+                """);
+
+        DependencyIndex migrated = store.get("legacy.json").orElseThrow();
+
+        assertEquals(DependencyIndexFormat.CURRENT_VERSION, migrated.formatVersion());
     }
 }

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolverTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolverTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.github.baokhang83.blastradius.core.index.FileIndexStore;
+import io.github.baokhang83.blastradius.core.index.DependencyIndexFormat;
 import io.github.baokhang83.blastradius.core.index.IndexStore;
 import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
@@ -85,6 +86,18 @@ class IndexApplicabilityResolverTest {
         IndexApplicability applicability = resolver.resolve(store(projectDir), INDEX_KEY, expectedBaseCommit, projectDir);
 
         assertEquals(IndexApplicability.Status.ANCHOR_MISMATCH, applicability.status());
+        assertNull(applicability.index());
+    }
+
+    @Test
+    void unsupportedIndexFormatIsReportedAsAMismatch(@TempDir Path projectDir) {
+        String anchorCommit = FixtureProjectBuilder.singleModule(projectDir).commit("initial");
+        store(projectDir).put(INDEX_KEY, new DependencyIndex(
+                DependencyIndexFormat.CURRENT_VERSION + 1, anchorCommit, "2026-07-09T10:00:00Z", List.of()));
+
+        IndexApplicability applicability = resolver.resolve(store(projectDir), INDEX_KEY, anchorCommit, projectDir);
+
+        assertEquals(IndexApplicability.Status.FORMAT_VERSION_MISMATCH, applicability.status());
         assertNull(applicability.index());
     }
 

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/ConsoleSummaryRendererTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/ConsoleSummaryRendererTest.java
@@ -60,6 +60,16 @@ class ConsoleSummaryRendererTest {
                 "expected the fallback reason to be surfaced: " + lines.get(0));
     }
 
+    @Test
+    void fallbackModeNamesAnUnsupportedIndexFormat() {
+        BuildReport report = new BuildReport(
+                BuildReport.Mode.FALLBACK, IndexApplicability.Status.FORMAT_VERSION_MISMATCH, List.of(), 20, 20, null);
+
+        List<String> lines = renderer.render(report, null);
+
+        assertTrue(lines.get(0).contains("FORMAT_VERSION_MISMATCH"), lines.get(0));
+    }
+
     private static List<SelectionDecision> decisionsOfSizes(int matched, int newOrModified, int fallback, int noMatch) {
         List<SelectionDecision> decisions = new java.util.ArrayList<>();
         for (int i = 0; i < matched; i++) {

--- a/docs/fluencyloop/features/version-dependency-indexes-and-safely-handle-incompatibility/design.md
+++ b/docs/fluencyloop/features/version-dependency-indexes-and-safely-handle-incompatibility/design.md
@@ -1,0 +1,73 @@
+# Design: Version dependency indexes and safely handle incompatibility (#29)
+
+started: 2026-07-21
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class DependencyIndexFormat {
+    +CURRENT_VERSION int
+    +migrateLegacy(version) int
+    +isCurrent(version) boolean
+  }
+  class MavenDependencyIndex {
+    +formatVersion int
+  }
+  class GradleDependencyIndex {
+    +formatVersion int
+  }
+  class FileIndexStore {
+    +get(key) Optional
+    +put(key, value)
+  }
+  class MavenIndexApplicabilityResolver {
+    +resolve() IndexApplicability
+  }
+  class GradleIndexApplicabilityResolver {
+    +resolve() IndexApplicability
+  }
+
+  DependencyIndexFormat <.. MavenDependencyIndex : normalizes legacy version
+  DependencyIndexFormat <.. GradleDependencyIndex : normalizes legacy version
+  FileIndexStore --> MavenDependencyIndex : reads and writes JSON
+  FileIndexStore --> GradleDependencyIndex : reads and writes JSON
+  MavenIndexApplicabilityResolver --> MavenDependencyIndex
+  GradleIndexApplicabilityResolver --> GradleDependencyIndex
+```
+
+## Sequence: read an index safely
+
+```mermaid
+sequenceDiagram
+  participant Store as FileIndexStore
+  participant Model as DependencyIndex
+  participant Resolver as ApplicabilityResolver
+  participant Build as Maven or Gradle test task
+
+  Store->>Model: deserialize JSON
+  alt unversioned legacy JSON
+    Model->>Model: migrate version 0 to version 1 in memory
+  end
+  Model->>Resolver: index with formatVersion
+  alt current format version
+    Resolver->>Build: SELECT with the index
+  else unsupported format version
+    Resolver->>Build: named safe FALLBACK
+  end
+```
+
+## Compatibility cases
+
+| Stored index | Handling |
+| --- | --- |
+| No `formatVersion` field (the existing schema) | Migrate in memory as known legacy version 0. |
+| `formatVersion: 1` | Read and use as the current schema. |
+| Any other version | Report a named format mismatch and leave the test task unfiltered. |
+
+## Decision
+
+Keep the format contract in `blastradius-core` because Maven and Gradle persist the same index
+schema. Migrate only the known missing-version legacy schema in memory; reject any other version
+through each adapter's existing safe-fallback path. A hard failure would needlessly block a build,
+while accepting an unfamiliar schema could make an unsound selection.

--- a/docs/fluencyloop/features/version-dependency-indexes-and-safely-handle-incompatibility/sessions/apply-format-checks-in-maven-and-gradle-selection.md
+++ b/docs/fluencyloop/features/version-dependency-indexes-and-safely-handle-incompatibility/sessions/apply-format-checks-in-maven-and-gradle-selection.md
@@ -1,0 +1,24 @@
+# Session: Apply format checks in Maven and Gradle selection
+
+- **intent:** Apply format checks in Maven and Gradle selection
+- **started:** 2026-07-21
+
+## Decision: Reject unsupported index formats before selection
+
+- **where:** `blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolver.java; blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/IndexApplicabilityResolver.java`
+- **why:** Both adapters check the shared schema version before Git or selection work, allowing the known legacy schema and routing every unsupported version through a named full-test fallback.
+- **alternative:** Let Jackson fail generically or try to select with unknown data — rejected because users lose the actionable reason or risk an unsound test filter.
+- **design:** ../design.md#sequence-read-an-index-safely
+- **constitution:** §III, §IV, §V
+- **trust:** ✓ verified
+
+## Knowledge transfer
+
+- **DependencyIndex models:** Maven and Gradle emit `formatVersion: 1` for newly tracked
+  indexes, normalize Jackson's missing primitive value (`0`) for the known legacy schema, and
+  retain unfamiliar values so they can be rejected rather than disguised as current. **Status:**
+  verified by Maven index I/O and Gradle functional tests.
+- **IndexApplicability resolvers:** evaluate schema compatibility before commit reachability and
+  anchor matching. `FORMAT_VERSION_MISMATCH` carries no usable index, causing the existing
+  full-test fallback path; Maven and Gradle both surface that reason. **Status:** verified by
+  focused Maven and Gradle tests.

--- a/docs/fluencyloop/features/version-dependency-indexes-and-safely-handle-incompatibility/sessions/define-the-shared-dependency-index-format-contract.md
+++ b/docs/fluencyloop/features/version-dependency-indexes-and-safely-handle-incompatibility/sessions/define-the-shared-dependency-index-format-contract.md
@@ -1,0 +1,19 @@
+# Session: Define the shared dependency-index format contract
+
+- **intent:** Define the shared dependency-index format contract
+- **started:** 2026-07-21
+
+## Decision: Migrate only the known unversioned index schema
+
+- **where:** `blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/index/DependencyIndexFormat.java`
+- **why:** Maven and Gradle share one persisted schema, so one core contract maps only legacy version 0 to the current version and leaves every other value visible for a safe adapter fallback.
+- **alternative:** Treat all unknown versions as current or fail the build on read — rejected because the former can misread data and the latter blocks an otherwise safe full test run.
+- **design:** ../design.md#class-diagram
+- **constitution:** §II, §III, §IV
+- **trust:** ✓ verified
+
+## Knowledge transfer
+
+- **DependencyIndexFormat:** defines the version written by new indexes, upgrades only the
+  known missing-version legacy schema, and leaves unsupported values unchanged so an adapter can
+  reject them explicitly. **Status:** verified by focused core tests.


### PR DESCRIPTION
Closes #29.

## Intent

Version the persisted dependency-index schema and make incompatible indexes fail safe.

## Decisions

### Shared version contract

Use `DependencyIndexFormat` in core so Maven and Gradle write and recognize the same schema. New indexes emit `formatVersion: 1`.

### Compatibility handling

Migrate the one known unversioned legacy schema in memory. Any unsupported version becomes `FORMAT_VERSION_MISMATCH`, leaves tests unfiltered, and tells the user why.

## Validation

- `mvn -pl blastradius-maven-plugin -am test`
- `./gradlew clean test`
- `mvn clean verify` (all four Invoker fixtures)

## Design

See [the feature design](docs/fluencyloop/features/version-dependency-indexes-and-safely-handle-incompatibility/design.md).
