### PR TITLE
feat: add remote S3 index store

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "version-dependency-indexes-and-safely-handle-incompatibility",
-  "branch": "feature/version-dependency-indexes-and-safely-handle-incompatibility",
-  "stage": "review",
-  "last_session": "docs/fluencyloop/features/version-dependency-indexes-and-safely-handle-incompatibility/sessions/apply-format-checks-in-maven-and-gradle-selection.md",
+  "feature": "remote-index-backend-with-s3-compatible-object-storage-for-i",
+  "branch": "feature/remote-index-backend-with-s3-compatible-object-storage-for-i",
+  "stage": "build",
+  "last_session": "docs/fluencyloop/features/remote-index-backend-with-s3-compatible-object-storage-for-i/sessions/route-gradle-tracking-and-selection-through-the-configured-s.md",
   "base_ref": "main",
-  "updated": "2026-07-21"
+  "updated": "2026-07-25"
 }

--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ See [`blastradius-maven-plugin/README.md`](blastradius-maven-plugin/README.md) f
 configuration reference, what each build mode (`TRACK`/`SELECT`/`FALLBACK`) prints, and how
 to set it up in CI.
 
+### Sharing indexes across CI runners
+
+By default, indexes stay under the workspace's `.blastradius/` directory. If a trunk `TRACK`
+job and PR `SELECT` job run on separate workers, configure the Maven plugin or Gradle extension
+with `indexStore = s3`, a bucket, and a region. The shared object store lets the PR job read the
+same commit-keyed index that the trunk job wrote. Credentials come from the standard AWS
+credential chain; do not put access keys in build files. Missing or inaccessible remote indexes
+still run the full suite safely. See the [Maven S3 configuration reference](blastradius-maven-plugin/README.md#shared-s3-index-store).
+
 ```bash
 git clone https://github.com/baokhang83/blastradius.git
 cd blastradius

--- a/README.md
+++ b/README.md
@@ -8,21 +8,6 @@ train something probabilistic on historical flakiness. Blastradius does neither:
 uses that real, per-test dependency map to decide what to run next time. No training data,
 no heuristics, no opaque score.
 
-## Proven on real projects, not just fixtures
-
-Before any of this was trusted to actually skip tests in CI, it ran in shadow mode against
-real open-source history and had every decision checked against ground truth:
-
-| Project | Real history | Commit pairs analyzed | Would-miss cases | Savings |
-|---|---|---|---|---|
-| [commons-io](https://commons.apache.org/proper/commons-io/) | 6,230 commits | 5 | **0** | 41.2% of test executions correctly skipped |
-| [jsoup](https://jsoup.org/) | 2,455 commits | 100 | **0** | 2.0% skipped (83% of this window was non-source maintenance commits — correctly triggering the safe fallback, not a mechanism weakness) |
-
-**105 real commit pairs across two independent, unmodified production codebases. Zero
-missed test failures.** Full analysis and how three real mechanism bugs were found and
-fixed along the way (a hardcoded `argLine`, a JaCoCo collision, a parameterized-test
-name mismatch) is in [`SESSION.md`](SESSION.md).
-
 ## How it works
 
 1. **Track.** On a build of your base branch, a `java.lang.instrument` agent watches every

--- a/blastradius-gradle-plugin/build.gradle
+++ b/blastradius-gradle-plugin/build.gradle
@@ -22,6 +22,7 @@ gradlePlugin {
 
 dependencies {
     implementation project(path: ':blastradius-core', configuration: 'agentElements')
+    implementation project(':blastradius-s3-index-store')
     implementation 'org.eclipse.jgit:org.eclipse.jgit:6.9.0.202403050737-r'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
     implementation 'org.junit.platform:junit-platform-launcher:1.10.2'

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ApplySelectionAction.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ApplySelectionAction.java
@@ -28,12 +28,14 @@ final class ApplySelectionAction implements Action<Task> {
     private final String indexPathKey;
     private final String comparisonBaseCommit;
     private final String headCommit;
+    private final ConfiguredIndexStore configuredStore;
 
-    ApplySelectionAction(File repositoryDirectory, String indexPathKey, String comparisonBaseCommit, String headCommit) {
+    ApplySelectionAction(File repositoryDirectory, String indexPathKey, String comparisonBaseCommit, String headCommit, ConfiguredIndexStore configuredStore) {
         this.repositoryDirectory = repositoryDirectory;
         this.indexPathKey = indexPathKey;
         this.comparisonBaseCommit = comparisonBaseCommit;
         this.headCommit = headCommit;
+        this.configuredStore = configuredStore;
     }
 
     @Override
@@ -41,9 +43,13 @@ final class ApplySelectionAction implements Action<Task> {
         Test test = (Test) task;
         Path repositoryRoot = repositoryDirectory.toPath().toAbsolutePath().normalize();
         String indexKey = CommitIndexKey.forCommit(indexPathKey, comparisonBaseCommit);
-        IndexStore<DependencyIndex> indexStore = new FileIndexStore<>(repositoryRoot, DependencyIndex.class);
-        IndexApplicability applicability = new IndexApplicabilityResolver()
-                .resolve(indexStore, indexKey, comparisonBaseCommit, repositoryRoot);
+        IndexStore<DependencyIndex> indexStore = configuredStore.create(repositoryDirectory);
+        IndexApplicability applicability;
+        try {
+            applicability = new IndexApplicabilityResolver().resolve(indexStore, indexKey, comparisonBaseCommit, repositoryRoot);
+        } finally {
+            ConfiguredIndexStore.close(indexStore);
+        }
         if (applicability.status() != IndexApplicability.Status.APPLICABLE) {
             if (applicability.status() == IndexApplicability.Status.FORMAT_VERSION_MISMATCH) {
                 test.getLogger().lifecycle(

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusExtension.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusExtension.java
@@ -10,4 +10,15 @@ public abstract class BlastradiusExtension {
 
     /** Root-relative index-file template; each resolved commit receives its own key. */
     public abstract Property<String> getIndexPath();
+
+    /** Selects the local file store or the shared S3-compatible store. */
+    public abstract Property<String> getIndexStore();
+
+    public abstract Property<String> getS3Bucket();
+
+    public abstract Property<String> getS3Prefix();
+
+    public abstract Property<String> getS3Region();
+
+    public abstract Property<String> getS3Endpoint();
 }

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusPlugin.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusPlugin.java
@@ -17,6 +17,8 @@ public final class BlastradiusPlugin implements Plugin<Project> {
         BlastradiusExtension extension = project.getExtensions()
                 .create("blastradius", BlastradiusExtension.class);
         extension.getIndexPath().convention(".blastradius/index.json");
+        extension.getIndexStore().convention("file");
+        extension.getS3Prefix().convention("");
 
         project.getPluginManager().withPlugin("java", ignored -> project.afterEvaluate(ignoredProject -> {
             Path repositoryDirectory = project.getRootDir().toPath();
@@ -28,20 +30,22 @@ public final class BlastradiusPlugin implements Plugin<Project> {
             GitBuildState resolvedGitState = gitState.get();
             Path normalizedRepositoryDirectory = repositoryDirectory.toAbsolutePath().normalize();
             String indexPathKey = normalizedRepositoryDirectory.relativize(indexPath.toAbsolutePath().normalize()).toString();
+            ConfiguredIndexStore indexStore = new ConfiguredIndexStore(extension.getIndexStore().get(), extension.getS3Bucket().getOrNull(),
+                    extension.getS3Prefix().get(), extension.getS3Region().getOrNull(), extension.getS3Endpoint().getOrNull());
 
             project.getTasks().withType(Test.class).configureEach(test -> configureTest(
-                    project, test, repositoryDirectory, indexPathKey, resolvedGitState, extension.getBaseRef().get()));
+                    project, test, repositoryDirectory, indexPathKey, resolvedGitState, extension.getBaseRef().get(), indexStore));
         }));
     }
 
     private static void configureTest(Project project, Test test, Path repositoryDirectory, String indexPathKey, GitBuildState gitState,
-            String baseReference) {
+            String baseReference, ConfiguredIndexStore indexStore) {
         test.getInputs().property("blastradius.baseReference", baseReference);
         test.getInputs().property("blastradius.headCommit", gitState.headCommit());
         test.getInputs().property("blastradius.baseReferenceCommit", gitState.baseReferenceCommit());
 
         if (gitState.baseReferenceBuild()) {
-            configureTracking(test, repositoryDirectory, indexPathKey, gitState.headCommit());
+            configureTracking(test, repositoryDirectory, indexPathKey, gitState.headCommit(), indexStore);
         } else if (!gitState.comparisonBaseAvailable()) {
             test.doFirst(new NoComparisonBaseFallbackAction());
         } else {
@@ -53,11 +57,11 @@ public final class BlastradiusPlugin implements Plugin<Project> {
                     .files(project.files(baselineIndexPath.toFile()).filter(File::isFile))
                     .withPathSensitivity(PathSensitivity.RELATIVE);
             test.doFirst(new ApplySelectionAction(
-                    repositoryDirectory.toFile(), indexPathKey, comparisonBase, gitState.headCommit()));
+                    repositoryDirectory.toFile(), indexPathKey, comparisonBase, gitState.headCommit(), indexStore));
         }
     }
 
-    private static void configureTracking(Test test, Path repositoryDirectory, String indexPathKey, String anchorCommit) {
+    private static void configureTracking(Test test, Path repositoryDirectory, String indexPathKey, String anchorCommit, ConfiguredIndexStore indexStore) {
         File recordPrefix = new File(test.getTemporaryDir(), "blastradius-dependencies.json");
         File agentJar = new AgentJarLocator().locate().toFile();
         test.jvmArgs("-javaagent:" + agentJar.getAbsolutePath() + "=" + recordPrefix.getAbsolutePath());
@@ -65,6 +69,6 @@ public final class BlastradiusPlugin implements Plugin<Project> {
         test.getOutputs().doNotCacheIf("TRACK must execute test workers to produce dependency records", ignoredTask -> true);
         test.doFirst(new PrepareTrackingAction(recordPrefix));
         test.doLast(new WriteTrackingIndexAction(
-                repositoryDirectory.toFile(), indexPathKey, recordPrefix, anchorCommit));
+                repositoryDirectory.toFile(), indexPathKey, recordPrefix, anchorCommit, indexStore));
     }
 }

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ConfiguredIndexStore.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ConfiguredIndexStore.java
@@ -1,0 +1,27 @@
+package io.github.baokhang83.blastradius.gradle;
+
+import io.github.baokhang83.blastradius.core.index.FileIndexStore;
+import io.github.baokhang83.blastradius.core.index.IndexStore;
+import io.github.baokhang83.blastradius.s3.S3IndexStoreConfiguration;
+import io.github.baokhang83.blastradius.s3.S3IndexStoreFactory;
+import java.io.File;
+import java.net.URI;
+
+record ConfiguredIndexStore(String type, String bucket, String prefix, String region, String endpoint) {
+    IndexStore<DependencyIndex> create(File root) {
+        if (type == null || type.isBlank() || "file".equalsIgnoreCase(type)) {
+            return new FileIndexStore<>(root.toPath(), DependencyIndex.class);
+        }
+        if (!"s3".equalsIgnoreCase(type)) {
+            throw new IllegalArgumentException("blastradius.indexStore must be file or s3");
+        }
+        return S3IndexStoreFactory.create(new S3IndexStoreConfiguration(
+                bucket, prefix, region, endpoint == null || endpoint.isBlank() ? null : URI.create(endpoint)), DependencyIndex.class);
+    }
+
+    static void close(IndexStore<?> store) {
+        if (store instanceof AutoCloseable closeable) {
+            try { closeable.close(); } catch (Exception ignored) { }
+        }
+    }
+}

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/WriteTrackingIndexAction.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/WriteTrackingIndexAction.java
@@ -1,7 +1,7 @@
 package io.github.baokhang83.blastradius.gradle;
 
-import io.github.baokhang83.blastradius.core.index.FileIndexStore;
 import io.github.baokhang83.blastradius.core.index.CommitIndexKey;
+import io.github.baokhang83.blastradius.core.index.IndexStore;
 import io.github.baokhang83.blastradius.core.tracking.DependencyRecordReader;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import java.io.File;
@@ -20,12 +20,14 @@ final class WriteTrackingIndexAction implements Action<Task> {
     private final String indexPathKey;
     private final File recordPrefix;
     private final String anchorCommit;
+    private final ConfiguredIndexStore configuredStore;
 
-    WriteTrackingIndexAction(File repositoryDirectory, String indexPathKey, File recordPrefix, String anchorCommit) {
+    WriteTrackingIndexAction(File repositoryDirectory, String indexPathKey, File recordPrefix, String anchorCommit, ConfiguredIndexStore configuredStore) {
         this.repositoryDirectory = repositoryDirectory;
         this.indexPathKey = indexPathKey;
         this.recordPrefix = recordPrefix;
         this.anchorCommit = anchorCommit;
+        this.configuredStore = configuredStore;
     }
 
     @Override
@@ -37,8 +39,12 @@ final class WriteTrackingIndexAction implements Action<Task> {
                     .toList();
             Path repositoryRoot = repositoryDirectory.toPath().toAbsolutePath().normalize();
             String indexKey = CommitIndexKey.forCommit(indexPathKey, anchorCommit);
-            new FileIndexStore<>(repositoryRoot, DependencyIndex.class).put(
-                    indexKey, new DependencyIndex(anchorCommit, Instant.now().toString(), entries));
+            IndexStore<DependencyIndex> store = configuredStore.create(repositoryDirectory);
+            try {
+                store.put(indexKey, new DependencyIndex(anchorCommit, Instant.now().toString(), entries));
+            } finally {
+                ConfiguredIndexStore.close(store);
+            }
             task.getLogger().lifecycle("[blastradius] TRACK — {} / {} tests selected", entries.size(), entries.size());
         } catch (RuntimeException e) {
             throw new GradleException("failed to create the blastradius dependency index after TRACK", e);

--- a/blastradius-maven-plugin/README.md
+++ b/blastradius-maven-plugin/README.md
@@ -101,6 +101,11 @@ separate page for each goal, including `help-mojo.html` and `select-mojo.html`.
 |---|---|---|---|---|
 | `baseRef` | `-DbaseRef` | — | **yes** | The target git reference (`main`, `origin/main`, a tag — anything JGit can resolve). Non-target builds compare from its merge base with `HEAD`. |
 | `indexPath` | `-DindexPath` | `.blastradius/index.json` | no | Root-relative index-file template. The merge-base SHA is inserted before its filename for `SELECT`, so the default produces `.blastradius/<full-sha>/index.json`. Rejected if it resolves outside the project directory. |
+| `indexStore` | `-DindexStore` | `file` | no | `file` keeps indexes in the reactor workspace. Set to `s3` to share indexes between runners. |
+| `s3Bucket` | `-Ds3Bucket` | — | when `indexStore=s3` | Bucket holding the shared indexes. |
+| `s3Prefix` | `-Ds3Prefix` | empty | no | Optional object-key prefix below the bucket. |
+| `s3Region` | `-Ds3Region` | — | when `indexStore=s3` | AWS region used to sign S3 requests. |
+| `s3Endpoint` | `-Ds3Endpoint` | — | no | Optional S3-compatible endpoint, for example MinIO. Path-style access is enabled when supplied. |
 | — | `-Dblastradius.mode=track` | — | no | Force `TRACK` regardless of what commit you're on — for explicitly pre-warming the index outside an ordinary trunk build. |
 | — | `-Dblastradius.explain=true` | `false` | no | Print the full per-test decision listing to the console, not just the aggregate summary. |
 
@@ -115,6 +120,27 @@ module's own goal execution resolves the same commit-keyed path.
   restored between CI runs the same way you already cache `~/.m2` — it has to survive
   between the trunk job that wrote it and the PR job that reads it, or every PR build stays
   in `FALLBACK` forever (see below).
+
+### Shared S3 index store
+
+Use S3 when the trunk `TRACK` job and PR `SELECT` job run on different workers and cannot
+share a workspace cache:
+
+```xml
+<configuration>
+  <baseRef>main</baseRef>
+  <indexStore>s3</indexStore>
+  <s3Bucket>ci-dependency-indexes</s3Bucket>
+  <s3Prefix>blastradius</s3Prefix>
+  <s3Region>eu-central-1</s3Region>
+</configuration>
+```
+
+The plugin uses the AWS SDK default credential chain. Configure credentials through standard
+CI environment variables, a workload/instance role, or a shared AWS profile; never put access
+keys in the POM. For MinIO or another S3-compatible service, add `s3Endpoint`; its region is
+still required for request signing. A missing, unreadable, unauthorized, or malformed remote
+index remains a safe `FALLBACK` that runs the full suite.
 
 ## What you'll see in the Maven output
 

--- a/blastradius-maven-plugin/pom.xml
+++ b/blastradius-maven-plugin/pom.xml
@@ -40,6 +40,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>io.github.baokhang83.blastradius</groupId>
+            <artifactId>blastradius-s3-index-store</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
             <version>${jgit.version}</version>
@@ -142,6 +147,10 @@
                         <relocation>
                             <pattern>com.fasterxml.jackson</pattern>
                             <shadedPattern>io.github.baokhang83.blastradius.plugin.internal.jackson</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>software.amazon.awssdk</pattern>
+                            <shadedPattern>io.github.baokhang83.blastradius.plugin.internal.awssdk</shadedPattern>
                         </relocation>
                     </relocations>
                     <transformers>

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
@@ -4,6 +4,8 @@ import io.github.baokhang83.blastradius.core.git.ChangedFile;
 import io.github.baokhang83.blastradius.core.index.CommitIndexKey;
 import io.github.baokhang83.blastradius.core.index.FileIndexStore;
 import io.github.baokhang83.blastradius.core.index.IndexStore;
+import io.github.baokhang83.blastradius.s3.S3IndexStoreConfiguration;
+import io.github.baokhang83.blastradius.s3.S3IndexStoreFactory;
 import io.github.baokhang83.blastradius.core.selection.NewOrModifiedTestSelector;
 import io.github.baokhang83.blastradius.core.selection.SelectionDecision;
 import io.github.baokhang83.blastradius.core.selection.SelectionEngine;
@@ -19,6 +21,7 @@ import io.github.baokhang83.blastradius.plugin.report.ConsoleSummaryRenderer;
 import io.github.baokhang83.blastradius.plugin.report.ExplainListingRenderer;
 import io.github.baokhang83.blastradius.plugin.track.TrackRunner;
 import java.net.URISyntaxException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -55,6 +58,21 @@ public final class SelectMojo extends AbstractMojo {
 
     @Parameter(property = "indexPath", defaultValue = ".blastradius/index.json")
     private String indexPath;
+
+    @Parameter(property = "indexStore", defaultValue = "file")
+    private String indexStoreType;
+
+    @Parameter(property = "s3Bucket")
+    private String s3Bucket;
+
+    @Parameter(property = "s3Prefix", defaultValue = "")
+    private String s3Prefix;
+
+    @Parameter(property = "s3Region")
+    private String s3Region;
+
+    @Parameter(property = "s3Endpoint")
+    private String s3Endpoint;
 
     @Parameter(property = "blastradius.mode")
     private String mode;
@@ -115,28 +133,58 @@ public final class SelectMojo extends AbstractMojo {
                     + "\" resolves outside the project directory (" + resolvedIndexPath + ")");
         }
         String indexPathKey = normalizedReactorRoot.relativize(resolvedIndexPath).toString();
-        IndexStore<DependencyIndex> indexStore = new FileIndexStore<>(normalizedReactorRoot, DependencyIndex.class);
+        IndexStore<DependencyIndex> indexStore = createIndexStore(normalizedReactorRoot);
 
-        CurrentChanges changes;
         try {
-            changes = currentChangesResolver.resolve(reactorRoot, baseRef);
-        } catch (IllegalStateException e) {
-            throw new MojoExecutionException("invalid configuration: " + e.getMessage(), e);
+            CurrentChanges changes;
+            try {
+                changes = currentChangesResolver.resolve(reactorRoot, baseRef);
+            } catch (IllegalStateException e) {
+                throw new MojoExecutionException("invalid configuration: " + e.getMessage(), e);
+            }
+            IndexApplicability applicability = changes.comparisonBaseCommit()
+                    .map(comparisonBase -> indexApplicabilityResolver.resolve(
+                            indexStore,
+                            CommitIndexKey.forCommit(indexPathKey, comparisonBase),
+                            comparisonBase,
+                            reactorRoot))
+                    .orElseGet(IndexApplicability::mergeBaseUnavailable);
+
+            BuildReport.Mode resolvedMode = determineMode(changes, applicability, mode);
+
+            switch (resolvedMode) {
+                case TRACK -> runTrack(changes, applicability, reactorRoot, indexStore, indexPathKey);
+                case SELECT -> runSelect(changes, applicability);
+                case FALLBACK -> runFallback(applicability);
+            }
+        } finally {
+            close(indexStore);
         }
-        IndexApplicability applicability = changes.comparisonBaseCommit()
-                .map(comparisonBase -> indexApplicabilityResolver.resolve(
-                        indexStore,
-                        CommitIndexKey.forCommit(indexPathKey, comparisonBase),
-                        comparisonBase,
-                        reactorRoot))
-                .orElseGet(IndexApplicability::mergeBaseUnavailable);
+    }
 
-        BuildReport.Mode resolvedMode = determineMode(changes, applicability, mode);
+    private IndexStore<DependencyIndex> createIndexStore(Path root) throws MojoExecutionException {
+        if (indexStoreType == null || indexStoreType.isBlank() || "file".equalsIgnoreCase(indexStoreType)) {
+            return new FileIndexStore<>(root, DependencyIndex.class);
+        }
+        if (!"s3".equalsIgnoreCase(indexStoreType)) {
+            throw new MojoExecutionException("invalid configuration: indexStore must be file or s3");
+        }
+        try {
+            return S3IndexStoreFactory.create(new S3IndexStoreConfiguration(
+                    s3Bucket, s3Prefix, s3Region, s3Endpoint == null || s3Endpoint.isBlank() ? null : URI.create(s3Endpoint)),
+                    DependencyIndex.class);
+        } catch (IllegalArgumentException e) {
+            throw new MojoExecutionException("invalid S3 index-store configuration: " + e.getMessage(), e);
+        }
+    }
 
-        switch (resolvedMode) {
-            case TRACK -> runTrack(changes, applicability, reactorRoot, indexStore, indexPathKey);
-            case SELECT -> runSelect(changes, applicability);
-            case FALLBACK -> runFallback(applicability);
+    private static void close(IndexStore<?> store) {
+        if (store instanceof AutoCloseable closeable) {
+            try {
+                closeable.close();
+            } catch (Exception ignored) {
+                // The index operation already completed; closing an SDK client must not change its result.
+            }
         }
     }
 

--- a/blastradius-s3-index-store/build.gradle
+++ b/blastradius-s3-index-store/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'java-library'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 21
+}
+
+dependencies {
+    api project(':blastradius-core')
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
+    implementation platform('software.amazon.awssdk:bom:2.41.33')
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:url-connection-client'
+    testImplementation platform('org.junit:junit-bom:5.10.2')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+}

--- a/blastradius-s3-index-store/pom.xml
+++ b/blastradius-s3-index-store/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.github.baokhang83.blastradius</groupId>
+        <artifactId>blastradius-parent</artifactId>
+        <version>0.1.0</version>
+    </parent>
+    <artifactId>blastradius-s3-index-store</artifactId>
+    <name>blastradius S3 index store</name>
+    <dependencies>
+        <dependency>
+            <groupId>io.github.baokhang83.blastradius</groupId>
+            <artifactId>blastradius-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>apache-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>software.amazon.awssdk</groupId>
+                    <artifactId>netty-nio-client</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>url-connection-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/AwsS3ObjectStore.java
+++ b/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/AwsS3ObjectStore.java
@@ -1,0 +1,68 @@
+package io.github.baokhang83.blastradius.s3;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Optional;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/** AWS SDK adapter that treats a missing object as an absent dependency index. */
+final class AwsS3ObjectStore implements S3ObjectStore {
+
+    private final S3Client client;
+    private final String bucket;
+
+    AwsS3ObjectStore(S3Client client, String bucket) {
+        this.client = client;
+        if (bucket == null || bucket.isBlank()) {
+            throw new IllegalArgumentException("S3 bucket must not be blank");
+        }
+        this.bucket = bucket;
+    }
+
+    @Override
+    public Optional<byte[]> get(String key) {
+        try {
+            ResponseBytes<GetObjectResponse> response = client.getObject(
+                    GetObjectRequest.builder().bucket(bucket).key(key).build(), ResponseTransformer.toBytes());
+            return Optional.of(response.asByteArray());
+        } catch (NoSuchKeyException e) {
+            return Optional.empty();
+        } catch (S3Exception e) {
+            if (e.statusCode() == 404) {
+                return Optional.empty();
+            }
+            throw unavailable("read", key, e);
+        } catch (SdkException e) {
+            throw unavailable("read", key, e);
+        }
+    }
+
+    @Override
+    public void put(String key, byte[] value) {
+        try {
+            client.putObject(PutObjectRequest.builder().bucket(bucket).key(key).contentType("application/json").build(),
+                    RequestBody.fromBytes(value));
+        } catch (SdkException e) {
+            throw unavailable("write", key, e);
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    private static UncheckedIOException unavailable(String operation, String key, SdkException cause) {
+        return new UncheckedIOException("failed to " + operation + " dependency index at S3 key " + key,
+                new IOException(cause));
+    }
+}

--- a/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/S3IndexStore.java
+++ b/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/S3IndexStore.java
@@ -1,0 +1,88 @@
+package io.github.baokhang83.blastradius.s3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.baokhang83.blastradius.core.index.IndexStore;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/** A JSON-backed {@link IndexStore} whose values live under an S3 object-key prefix. */
+public final class S3IndexStore<T> implements IndexStore<T>, AutoCloseable {
+
+    private final S3ObjectStore objects;
+    private final String prefix;
+    private final Class<T> valueType;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    S3IndexStore(S3ObjectStore objects, String prefix, Class<T> valueType) {
+        this.objects = objects;
+        this.prefix = normalizePrefix(prefix);
+        this.valueType = valueType;
+    }
+
+    @Override
+    public Optional<T> get(String key) {
+        return objects.get(objectKey(key)).map(this::deserialize);
+    }
+
+    @Override
+    public void put(String key, T value) {
+        try {
+            objects.put(objectKey(key), mapper.writeValueAsBytes(value));
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to serialize dependency index", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        objects.close();
+    }
+
+    private T deserialize(byte[] payload) {
+        try {
+            T value = mapper.readValue(payload, valueType);
+            if (value == null) {
+                throw new IOException("index value must not be null");
+            }
+            return value;
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to read dependency index from S3", e);
+        }
+    }
+
+    private String objectKey(String key) {
+        if (key == null || key.isBlank()) {
+            throw new IllegalArgumentException("index key must not be blank");
+        }
+        try {
+            Path path = Path.of(key).normalize();
+            if (path.isAbsolute() || path.getNameCount() == 0 || path.startsWith("..")) {
+                throw new IllegalArgumentException("index key must stay below the configured S3 prefix: " + key);
+            }
+            String normalizedKey = path.toString().replace('\\', '/');
+            return prefix.isEmpty() ? normalizedKey : prefix + "/" + normalizedKey;
+        } catch (InvalidPathException e) {
+            throw new IllegalArgumentException("invalid index key: " + key, e);
+        }
+    }
+
+    private static String normalizePrefix(String prefix) {
+        if (prefix == null || prefix.isBlank()) {
+            return "";
+        }
+        String normalized = prefix.replace('\\', '/');
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        if (normalized.isBlank() || normalized.equals(".") || normalized.startsWith("../") || normalized.contains("/../")) {
+            throw new IllegalArgumentException("S3 prefix must not escape its bucket: " + prefix);
+        }
+        return normalized;
+    }
+}

--- a/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/S3IndexStoreConfiguration.java
+++ b/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/S3IndexStoreConfiguration.java
@@ -1,0 +1,16 @@
+package io.github.baokhang83.blastradius.s3;
+
+import java.net.URI;
+
+/** Non-secret configuration required to address an S3 or S3-compatible index store. */
+public record S3IndexStoreConfiguration(String bucket, String prefix, String region, URI endpoint) {
+
+    public S3IndexStoreConfiguration {
+        if (bucket == null || bucket.isBlank()) {
+            throw new IllegalArgumentException("S3 bucket must not be blank");
+        }
+        if (region == null || region.isBlank()) {
+            throw new IllegalArgumentException("S3 region must not be blank");
+        }
+    }
+}

--- a/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/S3IndexStoreFactory.java
+++ b/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/S3IndexStoreFactory.java
@@ -1,0 +1,23 @@
+package io.github.baokhang83.blastradius.s3;
+
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+/** Creates stores that authenticate through the AWS SDK's standard credential-provider chain. */
+public final class S3IndexStoreFactory {
+
+    private S3IndexStoreFactory() {}
+
+    public static <T> S3IndexStore<T> create(S3IndexStoreConfiguration configuration, Class<T> valueType) {
+        S3ClientBuilder builder = S3Client.builder()
+                .region(Region.of(configuration.region()))
+                .credentialsProvider(DefaultCredentialsProvider.create());
+        if (configuration.endpoint() != null) {
+            builder.endpointOverride(configuration.endpoint()).forcePathStyle(true);
+        }
+        return new S3IndexStore<>(new AwsS3ObjectStore(builder.build(), configuration.bucket()),
+                configuration.prefix(), valueType);
+    }
+}

--- a/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/S3ObjectStore.java
+++ b/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/S3ObjectStore.java
@@ -1,0 +1,14 @@
+package io.github.baokhang83.blastradius.s3;
+
+import java.util.Optional;
+
+/** Byte-oriented object operations needed by {@link S3IndexStore}. */
+interface S3ObjectStore extends AutoCloseable {
+
+    Optional<byte[]> get(String key);
+
+    void put(String key, byte[] value);
+
+    @Override
+    default void close() {}
+}

--- a/blastradius-s3-index-store/src/test/java/io/github/baokhang83/blastradius/s3/S3IndexStoreIntegrationTest.java
+++ b/blastradius-s3-index-store/src/test/java/io/github/baokhang83/blastradius/s3/S3IndexStoreIntegrationTest.java
@@ -1,0 +1,80 @@
+package io.github.baokhang83.blastradius.s3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
+
+class S3IndexStoreIntegrationTest {
+
+    private static final String BUCKET = "blastradius-indexes";
+
+    @Test
+    void trackRunnerStoreCanBeReadByAFreshSelectRunnerStore() throws IOException {
+        try (S3ProtocolServer server = new S3ProtocolServer(); S3Client trackClient = client(server.endpoint());
+                S3Client selectClient = client(server.endpoint())) {
+            trackClient.createBucket(request -> request.bucket(BUCKET));
+            S3IndexStore<StoredIndex> trackStore = new S3IndexStore<>(new AwsS3ObjectStore(trackClient, BUCKET), "ci", StoredIndex.class);
+            S3IndexStore<StoredIndex> selectStore = new S3IndexStore<>(new AwsS3ObjectStore(selectClient, BUCKET), "ci", StoredIndex.class);
+
+            trackStore.put(".blastradius/0123456789abcdef0123456789abcdef01234567/index.json", new StoredIndex("TRACK"));
+
+            assertEquals(new StoredIndex("TRACK"), selectStore.get(".blastradius/0123456789abcdef0123456789abcdef01234567/index.json").orElseThrow());
+        }
+    }
+
+    private static S3Client client(URI endpoint) {
+        return S3Client.builder().endpointOverride(endpoint).region(Region.US_EAST_1)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("test", "test")))
+                .serviceConfiguration(S3Configuration.builder().chunkedEncodingEnabled(false).build())
+                .forcePathStyle(true).build();
+    }
+
+    private static final class S3ProtocolServer implements AutoCloseable {
+        private final Map<String, byte[]> objects = new ConcurrentHashMap<>();
+        private final HttpServer server;
+
+        S3ProtocolServer() throws IOException {
+            server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+            server.createContext("/", exchange -> {
+                String key = exchange.getRequestURI().getPath();
+                if ("PUT".equals(exchange.getRequestMethod())) {
+                    objects.put(key, exchange.getRequestBody().readAllBytes());
+                    exchange.sendResponseHeaders(200, -1);
+                } else if ("GET".equals(exchange.getRequestMethod()) && objects.containsKey(key)) {
+                    byte[] value = objects.get(key);
+                    exchange.sendResponseHeaders(200, value.length);
+                    exchange.getResponseBody().write(value);
+                } else {
+                    byte[] error = "<Error><Code>NoSuchKey</Code></Error>".getBytes(StandardCharsets.UTF_8);
+                    exchange.sendResponseHeaders(404, error.length);
+                    exchange.getResponseBody().write(error);
+                }
+                exchange.close();
+            });
+            server.start();
+        }
+
+        URI endpoint() {
+            return URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
+
+    private record StoredIndex(String mode) {}
+}

--- a/blastradius-s3-index-store/src/test/java/io/github/baokhang83/blastradius/s3/S3IndexStoreTest.java
+++ b/blastradius-s3-index-store/src/test/java/io/github/baokhang83/blastradius/s3/S3IndexStoreTest.java
@@ -1,0 +1,55 @@
+package io.github.baokhang83.blastradius.s3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class S3IndexStoreTest {
+
+    @Test
+    void roundTripsJsonBelowTheConfiguredPrefix() {
+        InMemoryObjectStore objects = new InMemoryObjectStore();
+        S3IndexStore<StoredIndex> store = new S3IndexStore<>(objects, "ci/indexes", StoredIndex.class);
+
+        store.put(".blastradius/main/index.json", new StoredIndex("main"));
+
+        assertEquals(new StoredIndex("main"), store.get(".blastradius/main/index.json").orElseThrow());
+        assertEquals("ci/indexes/.blastradius/main/index.json", objects.values.keySet().iterator().next());
+    }
+
+    @Test
+    void missingObjectIsAnAbsentIndex() {
+        S3IndexStore<StoredIndex> store = new S3IndexStore<>(new InMemoryObjectStore(), "ci", StoredIndex.class);
+
+        assertFalse(store.get(".blastradius/main/index.json").isPresent());
+    }
+
+    @Test
+    void rejectsObjectKeysThatEscapeTheConfiguredPrefix() {
+        S3IndexStore<StoredIndex> store = new S3IndexStore<>(new InMemoryObjectStore(), "ci", StoredIndex.class);
+
+        assertThrows(IllegalArgumentException.class, () -> store.get("../other/index.json"));
+        assertThrows(IllegalArgumentException.class, () -> store.put("/absolute/index.json", new StoredIndex("ignored")));
+    }
+
+    private record StoredIndex(String anchor) {}
+
+    private static final class InMemoryObjectStore implements S3ObjectStore {
+        private final Map<String, byte[]> values = new HashMap<>();
+
+        @Override
+        public Optional<byte[]> get(String key) {
+            return Optional.ofNullable(values.get(key));
+        }
+
+        @Override
+        public void put(String key, byte[] value) {
+            values.put(key, value);
+        }
+    }
+}

--- a/docs/fluencyloop/features/remote-index-backend-with-s3-compatible-object-storage-for-i/design.md
+++ b/docs/fluencyloop/features/remote-index-backend-with-s3-compatible-object-storage-for-i/design.md
@@ -1,0 +1,133 @@
+# Design: Remote index backend with S3-compatible object storage for issue #27
+
+<!--
+FluencyLoop Stage 2 — one design.md per feature, committed alongside it.
+Defaults: a class diagram and a sequence diagram (the two first-class Mermaid types that
+pay their way most often). Add an interaction/flow view only when it earns its place.
+Keep the Mermaid blocks TOP-LEVEL (not nested in another code fence) so GitHub renders them.
+Delete this comment once the diagrams are real.
+-->
+
+started: 2026-07-25
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class IndexStore~T~ {
+    <<interface>>
+    +get(key) Optional~T~
+    +put(key, value) void
+  }
+  class FileIndexStore~T~
+  class S3IndexStore~T~ {
+    -S3Client client
+    -String bucket
+    -String prefix
+    +get(key) Optional~T~
+    +put(key, value) void
+  }
+  class S3ClientFactory {
+    +create(configuration) S3Client
+  }
+  class S3IndexStoreConfiguration {
+    +bucket String
+    +prefix String
+    +region String
+    +endpoint URI
+  }
+  class MavenSelectMojo
+  class GradleIndexActions
+  class DefaultCredentialsProvider
+  class RemoteObjectStore
+  class DependencyIndex
+
+  IndexStore~T~ <|.. FileIndexStore~T~
+  IndexStore~T~ <|.. S3IndexStore~T~
+  S3IndexStore~T~ --> RemoteObjectStore : GET or PUT JSON object
+  S3ClientFactory --> DefaultCredentialsProvider : standard chain
+  S3ClientFactory --> S3IndexStoreConfiguration : builds client
+  MavenSelectMojo --> S3ClientFactory : configured store
+  GradleIndexActions --> S3ClientFactory : configured store
+  MavenSelectMojo --> IndexStore~DependencyIndex~
+  GradleIndexActions --> IndexStore~DependencyIndex~
+  S3IndexStore~T~ --> DependencyIndex : JSON payload
+```
+
+## Sequence: TRACK on one runner, SELECT on another
+
+```mermaid
+sequenceDiagram
+  participant Track as TRACK runner
+  participant Plugin as Maven or Gradle plugin
+  participant Factory as S3 client factory
+  participant Chain as standard credential chain
+  participant Store as S3IndexStore
+  participant S3 as S3-compatible object store
+  participant Select as SELECT runner
+
+  Track->>Plugin: TRACK creates DependencyIndex
+  Plugin->>Factory: create configured S3 client
+  Factory->>Chain: resolve environment, profile, or role credentials
+  Factory-->>Plugin: S3 client
+  Plugin->>Store: put(commit-keyed index)
+  Store->>S3: PUT prefix plus commit key JSON
+  S3-->>Store: success
+
+  Select->>Plugin: SELECT resolves comparison-base key
+  Plugin->>Factory: create configured S3 client
+  Factory->>Chain: resolve runner credentials
+  Factory-->>Plugin: S3 client
+  Plugin->>Store: get(same commit-keyed index)
+  Store->>S3: GET prefix plus commit key JSON
+  alt object exists and passes applicability checks
+    S3-->>Store: DependencyIndex JSON
+    Store-->>Plugin: DependencyIndex
+    Plugin-->>Select: SELECT narrowed tests
+  else object missing, unreadable, or incompatible
+    Store-->>Plugin: empty or store error
+    Plugin-->>Select: safe full-suite FALLBACK
+  end
+```
+
+## Design
+
+- Keep `IndexStore<T>` as the common contract. Add an AWS SDK v2-backed `S3IndexStore<T>` in a
+  dedicated module, so the core tracking agent stays independent of cloud dependencies and the
+  build plugins opt into S3 only when configured.
+- Configure `bucket`, optional `prefix`, `region`, and optional endpoint through both the Maven
+  plugin and Gradle extension. An endpoint selects an S3-compatible provider such as MinIO; the
+  region remains required because AWS Signature V4 uses it when signing requests.
+- Build clients with the SDK's default credential-provider chain. Credentials are deliberately
+  absent from plugin configuration: CI can supply environment or workload-role credentials and
+  local users can use their shared AWS profile.
+- Preserve the current commit-keyed object name. A base-ref TRACK writes the object and a PR
+  runner SELECT reads the same key, which enables sharing without a runner-local workspace.
+- Preserve safety semantics: a missing object maps to no index, and transport, authentication,
+  JSON, or applicability failures leave tests unfiltered. Remote storage must never create an
+  empty selection or conceal an error as a valid index.
+
+## Constitution check
+
+- **§I - TDD:** start with failing unit tests for object-key construction, missing-object handling,
+  JSON round trips, and configuration validation before implementation. Add plugin configuration
+  tests and a two-client integration test using an S3-compatible test service.
+- **§II - simplicity:** add one concrete backend behind the existing two-method `IndexStore`
+  interface. Do not introduce a generic cloud-provider abstraction, retries, replication, or
+  credential configuration in this feature.
+- **§III - safety:** an unavailable, unauthorized, corrupt, or incompatible remote index keeps
+  the existing full-suite fallback. Credentials never appear in configuration, reports, or logs.
+- **§IV - deterministic core:** commit-key construction and index validation remain local and
+  deterministic. Only the configured storage transport is remote.
+- **§VI - current foundations:** use the maintained AWS SDK for Java v2 and its documented
+  default credential chain and endpoint configuration.
+
+## Validation
+
+1. Unit tests prove the store maps a missing S3 object to empty, serializes and deserializes the
+   existing JSON format, applies a normalized prefix, and surfaces other S3 failures for the
+   callers' safe fallback.
+2. Maven and Gradle tests prove configuration creates the remote store only when requested and
+   preserves the local store by default.
+3. An integration test runs TRACK using one plugin client and SELECT using a fresh client against
+   an S3-compatible service, proving the index is shared across runners.

--- a/docs/fluencyloop/features/remote-index-backend-with-s3-compatible-object-storage-for-i/sessions/add-an-isolated-aws-s3-index-store-backend.md
+++ b/docs/fluencyloop/features/remote-index-backend-with-s3-compatible-object-storage-for-i/sessions/add-an-isolated-aws-s3-index-store-backend.md
@@ -1,0 +1,20 @@
+# Session: Add an isolated AWS S3 index-store backend
+
+- **intent:** Add an isolated AWS S3 index-store backend
+- **started:** 2026-07-25
+
+## Knowledge transfer
+
+- **S3IndexStore:** maps the existing typed index JSON to a caller-supplied, root-relative key under an optional bucket prefix. Missing objects are represented as an absent index; malformed JSON becomes an `UncheckedIOException` so existing applicability resolvers preserve full-suite fallback. **status:** documented.
+- **AwsS3ObjectStore:** owns only AWS SDK byte reads and writes. A 404 is normal index absence, while authentication, transport, and other S3 errors are surfaced as unreadable storage rather than treated as valid data. **status:** documented.
+- **S3IndexStoreFactory:** creates an SDK v2 client with the standard credential-provider chain. It uses an explicit endpoint and path-style access only for S3-compatible providers, and keeps credential values out of the plugin configuration. **status:** documented.
+- **Dependency graph:** the new module keeps cloud dependencies out of the tracking agent. The JDK URL-connection HTTP client is selected explicitly and SLF4J is aligned in dependency management because the repository enforces dependency convergence. **status:** documented.
+
+## Decision: isolated S3 transport behind the existing index-store contract
+
+- **where:** `blastradius-s3-index-store`
+- **why:** The cloud client stays outside the tracking-agent core while both build plugins can share one JSON and object-key implementation.
+- **alternative:** Put AWS SDK calls in core or duplicate them per plugin — rejected: either burdens local agent users with cloud dependencies or lets plugin behavior drift.
+- **design:** ../design.md#class-diagram
+- **constitution:** §II
+- **trust:** ✓ verified

--- a/docs/fluencyloop/features/remote-index-backend-with-s3-compatible-object-storage-for-i/sessions/configure-maven-to-select-the-remote-s3-index-store.md
+++ b/docs/fluencyloop/features/remote-index-backend-with-s3-compatible-object-storage-for-i/sessions/configure-maven-to-select-the-remote-s3-index-store.md
@@ -1,0 +1,41 @@
+# Session: Configure Maven to select the remote S3 index store
+
+- **intent:** Configure Maven to select the remote S3 index store
+- **started:** 2026-07-25
+
+<!--
+FluencyLoop Stage 3 — a session is a slice of the build. One block per meaningful decision,
+appended at the slice boundary as it's taught. No `commits:` field: the feature is a branch,
+so the PR view derives commits live from git.
+
+Each decision is a `## Decision:` heading followed by a bullet list — one bullet per field, so
+it renders one-per-line as real Markdown (plain `key: value` lines collapse into a single
+paragraph when rendered). Fields:
+
+  where        — file/area the decision lives in (NOT a line number — survives refactoring)
+  why          — the rationale, taught live before it was written
+  alternative  — the rejected option and why (this is what makes it rationale, not description)
+  design       — (optional) ../design.md#anchor — the diagram this decision shaped or used
+  constitution — (optional) §N — the principle this decision serves or trades off against
+  trust        — ✓ verified | ⚠ not independently verified  (about the DECISION, never the person)
+
+Delete this comment and the example below once real decisions land.
+-->
+
+---
+
+## Decision: <chose X over Y>
+
+- **where:** `<path/to/File.ext>`
+- **why:** <the one-line why, engaged with — not post-hoc narration>
+- **alternative:** <the rejected option> — rejected: <why>
+- **trust:** ⚠ not independently verified
+
+## Decision: ship the AWS SDK inside the Maven plugin
+
+- **where:** `blastradius-maven-plugin/pom.xml and SelectMojo`
+- **why:** S3 is opt-in through non-secret plugin settings, while shading keeps consumer dependency graphs isolated.
+- **alternative:** Require adopters to supply a matching AWS SDK — rejected: consumer builds would become version-coupled to the plugin.
+- **design:** ../design.md#class-diagram
+- **constitution:** §VI
+- **trust:** ✓ verified

--- a/docs/fluencyloop/features/remote-index-backend-with-s3-compatible-object-storage-for-i/sessions/route-gradle-tracking-and-selection-through-the-configured-s.md
+++ b/docs/fluencyloop/features/remote-index-backend-with-s3-compatible-object-storage-for-i/sessions/route-gradle-tracking-and-selection-through-the-configured-s.md
@@ -1,0 +1,41 @@
+# Session: Route Gradle tracking and selection through the configured store
+
+- **intent:** Route Gradle tracking and selection through the configured store
+- **started:** 2026-07-25
+
+<!--
+FluencyLoop Stage 3 — a session is a slice of the build. One block per meaningful decision,
+appended at the slice boundary as it's taught. No `commits:` field: the feature is a branch,
+so the PR view derives commits live from git.
+
+Each decision is a `## Decision:` heading followed by a bullet list — one bullet per field, so
+it renders one-per-line as real Markdown (plain `key: value` lines collapse into a single
+paragraph when rendered). Fields:
+
+  where        — file/area the decision lives in (NOT a line number — survives refactoring)
+  why          — the rationale, taught live before it was written
+  alternative  — the rejected option and why (this is what makes it rationale, not description)
+  design       — (optional) ../design.md#anchor — the diagram this decision shaped or used
+  constitution — (optional) §N — the principle this decision serves or trades off against
+  trust        — ✓ verified | ⚠ not independently verified  (about the DECISION, never the person)
+
+Delete this comment and the example below once real decisions land.
+-->
+
+---
+
+## Decision: <chose X over Y>
+
+- **where:** `<path/to/File.ext>`
+- **why:** <the one-line why, engaged with — not post-hoc narration>
+- **alternative:** <the rejected option> — rejected: <why>
+- **trust:** ⚠ not independently verified
+
+## Decision: create S3 clients only inside Gradle task actions
+
+- **where:** `blastradius-gradle-plugin task actions`
+- **why:** Configuration stays as serializable values while TRACK and SELECT create and close the remote client at execution time.
+- **alternative:** Create an S3 client during Gradle configuration — rejected: live credentials and network state would leak into configuration-cache inputs.
+- **design:** ../design.md#sequence-track-on-one-runner-select-on-another
+- **constitution:** §IV
+- **trust:** ✓ verified

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 
     <modules>
         <module>blastradius-core</module>
+        <module>blastradius-s3-index-store</module>
         <module>blastradius-validator</module>
         <module>blastradius-maven-plugin</module>
     </modules>
@@ -74,6 +75,8 @@
         <central.publishing.plugin.version>0.11.0</central.publishing.plugin.version>
         <flatten.plugin.version>1.6.0</flatten.plugin.version>
         <invoker.plugin.version>3.10.1</invoker.plugin.version>
+        <aws.sdk.version>2.41.33</aws.sdk.version>
+        <slf4j.version>2.0.18</slf4j.version>
     </properties>
 
     <dependencyManagement>
@@ -84,6 +87,18 @@
                 <version>${junit.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws.sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,4 +12,4 @@ dependencyResolutionManagement {
 
 rootProject.name = 'blastradius'
 
-include 'blastradius-core', 'blastradius-gradle-plugin'
+include 'blastradius-core', 'blastradius-s3-index-store', 'blastradius-gradle-plugin'


### PR DESCRIPTION
## Summary
- Add an AWS SDK v2 S3-backed index store in a dedicated module.
- Configure Maven and Gradle to use a shared store while preserving local-file defaults.
- Document S3 setup, credential-chain behavior, and S3-compatible endpoints.

## Key decisions
- Cloud transport stays outside the tracking-agent core, keeping local users free of cloud dependencies.
- Gradle creates S3 clients inside task actions, never during configuration.
- Missing or unreadable remote indexes preserve the safe full-suite fallback.

## Verification
- Full Maven reactor passed.
- Full Gradle suite passed.
- The S3 integration test writes with one fresh AWS client and reads with another over an S3-compatible HTTP endpoint.

## Design
See docs/fluencyloop/features/remote-index-backend-with-s3-compatible-object-storage-for-i/design.md.