### PR TITLE
JSON selection report (#31)

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "remote-index-backend-with-s3-compatible-object-storage-for-i",
-  "branch": "feature/remote-index-backend-with-s3-compatible-object-storage-for-i",
+  "feature": "json-selection-report-31",
+  "branch": "feature/json-selection-report-31",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/remote-index-backend-with-s3-compatible-object-storage-for-i/sessions/route-gradle-tracking-and-selection-through-the-configured-s.md",
+  "last_session": "docs/fluencyloop/features/json-selection-report-31/sessions/capture-completed-test-timings-without-changing-selection-be.md",
   "base_ref": "main",
-  "updated": "2026-07-25"
+  "updated": "2026-07-26"
 }

--- a/blastradius-maven-plugin/README.md
+++ b/blastradius-maven-plugin/README.md
@@ -190,7 +190,9 @@ bailed out to a full run rather than crash the build or guess).
 
 ## The files it writes
 
-Both live under `.blastradius/` at the reactor root — add it to `.gitignore`.
+These files live under `.blastradius/` — add it to `.gitignore`. The shared index is rooted at
+the reactor root; each module execution writes its own report and timing cache under that
+module's project directory.
 
 - **`<full-sha>/index.json`** — the persisted dependency map a `TRACK` build produces for its
   exact commit and a `SELECT` build reads for its resolved merge base. The default location is
@@ -198,10 +200,21 @@ Both live under `.blastradius/` at the reactor root — add it to `.gitignore`.
   `{ formatVersion, anchorCommit, builtAt, testDependencies: [{ test, dependsOnClasses }] }`.
   Newly tracked indexes use format version 1. Existing unversioned indexes are migrated in
   memory; any other version safely falls back to the full suite.
-- **`last-build-report.json`** — this build's own decisions, machine-readable.
-  `{ mode, indexApplicability, decisions: [{ test, selected, reason, matchedChangedClass }], selectedCount, totalCount }`.
-  This is the source of truth every console line above is a rendering of — audit a specific
-  test's outcome here without re-running anything.
+- **`last-build-report.json`** — schema version 1 of this build's machine-readable selection
+  report. It includes `{ schemaVersion, mode, indexApplicability, changedFiles, decisions,
+  selectedCount, skippedCount, totalCount, reasonCounts, estimatedTimeSavedMillis,
+  timingCoverage }`. `reasonCounts` always includes every `SelectionReason`, including zero
+  buckets, so CI parsers do not need mode-specific handling. `estimatedTimeSavedMillis` is set
+  only when every skipped test has a timing sample; otherwise it is `null` and `timingCoverage`
+  states how much of the skipped set is known. The selected/skipped counts describe the set the
+  goal passes to Surefire/Failsafe, not a claim about the test engines' final outcome.
+- **`test-timings.json`** — version 1 local cache of the most recently observed duration for
+  each test. The goal observes completed Surefire/Failsafe executions and updates this cache
+  after their standard XML reports are written. Persist `.blastradius/` in CI when you want
+  subsequent builds to calculate a millisecond estimate immediately.
+
+`last-build-report.json` remains the source of truth every console line above renders from —
+audit a specific test's selection outcome without re-running anything.
 
 ## Multi-module reactors
 

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
@@ -19,6 +19,9 @@ import io.github.baokhang83.blastradius.plugin.report.BuildReport;
 import io.github.baokhang83.blastradius.plugin.report.BuildReportWriter;
 import io.github.baokhang83.blastradius.plugin.report.ConsoleSummaryRenderer;
 import io.github.baokhang83.blastradius.plugin.report.ExplainListingRenderer;
+import io.github.baokhang83.blastradius.plugin.report.SurefireReportReader;
+import io.github.baokhang83.blastradius.plugin.report.TestTimingHistoryStore;
+import io.github.baokhang83.blastradius.plugin.report.TimingHistoryRecorder;
 import io.github.baokhang83.blastradius.plugin.track.TrackRunner;
 import java.net.URISyntaxException;
 import java.net.URI;
@@ -29,6 +32,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.execution.AbstractExecutionListener;
+import org.apache.maven.execution.ExecutionListener;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -109,6 +114,8 @@ public final class SelectMojo extends AbstractMojo {
     private final ConsoleSummaryRenderer consoleSummaryRenderer = new ConsoleSummaryRenderer();
     private final ExplainListingRenderer explainListingRenderer = new ExplainListingRenderer();
     private final TrackRunner trackRunner = new TrackRunner();
+    private final TestTimingHistoryStore timingHistoryStore = new TestTimingHistoryStore();
+    private final SurefireReportReader surefireReportReader = new SurefireReportReader();
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -151,12 +158,14 @@ public final class SelectMojo extends AbstractMojo {
                     .orElseGet(IndexApplicability::mergeBaseUnavailable);
 
             BuildReport.Mode resolvedMode = determineMode(changes, applicability, mode);
+            Map<TestIdentity, Long> durationsByTest = timingHistoryStore.load(timingHistoryPath()).durationsByTest();
 
             switch (resolvedMode) {
                 case TRACK -> runTrack(changes, applicability, reactorRoot, indexStore, indexPathKey);
-                case SELECT -> runSelect(changes, applicability);
-                case FALLBACK -> runFallback(applicability);
+                case SELECT -> runSelect(changes, applicability, durationsByTest);
+                case FALLBACK -> runFallback(changes, applicability);
             }
+            registerTimingRecorder();
         } finally {
             close(indexStore);
         }
@@ -217,7 +226,7 @@ public final class SelectMojo extends AbstractMojo {
         indexStore.put(CommitIndexKey.forCommit(indexPathKey, changes.currentCommit()), freshIndex);
 
         int totalCount = discoverProjectTests().size();
-        BuildReport report = BuildReport.forTrack(applicability.status(), totalCount, freshIndex);
+        BuildReport report = BuildReport.forTrack(applicability.status(), totalCount, freshIndex, changes.changedFiles());
         buildReportWriter.write(reportPath(), report);
         renderReport(report, null);
     }
@@ -227,9 +236,9 @@ public final class SelectMojo extends AbstractMojo {
      * safely, but deliberately no track subprocess is forked for this commit (a poor
      * anchor for the shared index) (research.md #1, tasks.md T046).
      */
-    private void runFallback(IndexApplicability applicability) throws MojoExecutionException {
+    private void runFallback(CurrentChanges changes, IndexApplicability applicability) throws MojoExecutionException {
         int totalCount = discoverProjectTests().size();
-        BuildReport report = BuildReport.forFallback(applicability.status(), totalCount);
+        BuildReport report = BuildReport.forFallback(applicability.status(), totalCount, changes.changedFiles());
         buildReportWriter.write(reportPath(), report);
         renderReport(report, null);
     }
@@ -272,7 +281,8 @@ public final class SelectMojo extends AbstractMojo {
      * caught before any filter is applied — the safe fallback below is exactly what Surefire
      * would have done anyway (run everything) had the goal never run at all.
      */
-    private void runSelect(CurrentChanges changes, IndexApplicability applicability) throws MojoExecutionException {
+    private void runSelect(CurrentChanges changes, IndexApplicability applicability,
+            Map<TestIdentity, Long> durationsByTest) throws MojoExecutionException {
         try {
             Set<TestIdentity> allTests = discoverProjectTests();
             List<SelectionDecision> decisions = computeDecisions(allTests, applicability.index(), changes.changedFiles());
@@ -283,14 +293,15 @@ public final class SelectMojo extends AbstractMojo {
 
             surefireFilterApplier.apply(project, selectedTests);
 
-            BuildReport report = BuildReport.forSelect(applicability, decisions);
+            BuildReport report = BuildReport.forSelect(applicability, changes.changedFiles(), decisions, durationsByTest);
             buildReportWriter.write(reportPath(), report);
             renderReport(report, applicability.index());
         } catch (RuntimeException e) {
             getLog().warn("[blastradius] internal error during selection computation — falling back to running "
                     + "the full suite unfiltered rather than risk a crashed build or an unsound selection", e);
             int totalCount = discoverProjectTests().size();
-            BuildReport report = BuildReport.forFallback(IndexApplicability.Status.INTERNAL_ERROR, totalCount);
+            BuildReport report = BuildReport.forFallback(
+                    IndexApplicability.Status.INTERNAL_ERROR, totalCount, changes.changedFiles());
             buildReportWriter.write(reportPath(), report);
             renderReport(report, null);
         }
@@ -305,6 +316,25 @@ public final class SelectMojo extends AbstractMojo {
 
     private Path reportPath() {
         return project.getBasedir().toPath().resolve(".blastradius/last-build-report.json");
+    }
+
+    private Path timingHistoryPath() {
+        return project.getBasedir().toPath().resolve(".blastradius/test-timings.json");
+    }
+
+    /**
+     * Maven resolves its execution listener dynamically for every lifecycle event, so chaining
+     * here lets the already-planned Surefire/Failsafe executions persist timings without asking
+     * adopters to configure a second goal. The wrapper forwards every existing listener event.
+     */
+    private void registerTimingRecorder() {
+        ExecutionListener existing = session.getRequest().getExecutionListener();
+        if (existing instanceof TimingHistoryRecorder) {
+            return;
+        }
+        session.getRequest().setExecutionListener(new TimingHistoryRecorder(
+                existing == null ? new AbstractExecutionListener() : existing,
+                timingHistoryStore, surefireReportReader, getLog()::warn));
     }
 
     /**

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/BuildReport.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/BuildReport.java
@@ -1,9 +1,15 @@
 package io.github.baokhang83.blastradius.plugin.report;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.github.baokhang83.blastradius.core.git.ChangedFile;
 import io.github.baokhang83.blastradius.core.selection.SelectionDecision;
+import io.github.baokhang83.blastradius.core.selection.SelectionReason;
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex;
 import io.github.baokhang83.blastradius.plugin.index.IndexApplicability;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -24,12 +30,61 @@ public record BuildReport(
         List<SelectionDecision> decisions,
         int selectedCount,
         int totalCount,
-        DependencyIndex updatedIndex) {
+        DependencyIndex updatedIndex,
+        List<ChangedFile> changedFiles,
+        Long estimatedTimeSavedMillis,
+        TimingCoverage timingCoverage) {
+
+    public static final int SCHEMA_VERSION = 1;
+
+    public BuildReport {
+        Objects.requireNonNull(mode, "mode");
+        Objects.requireNonNull(indexApplicability, "indexApplicability");
+        decisions = List.copyOf(decisions);
+        changedFiles = List.copyOf(changedFiles);
+        Objects.requireNonNull(timingCoverage, "timingCoverage");
+        if (selectedCount < 0 || totalCount < 0 || selectedCount > totalCount) {
+            throw new IllegalArgumentException("test counts must satisfy 0 <= selectedCount <= totalCount");
+        }
+        if (estimatedTimeSavedMillis != null && estimatedTimeSavedMillis < 0) {
+            throw new IllegalArgumentException("estimatedTimeSavedMillis must not be negative");
+        }
+    }
+
+    /** Preserves the original construction surface for callers that do not provide timing data. */
+    public BuildReport(Mode mode, IndexApplicability.Status indexApplicability, List<SelectionDecision> decisions,
+            int selectedCount, int totalCount, DependencyIndex updatedIndex) {
+        this(mode, indexApplicability, decisions, selectedCount, totalCount, updatedIndex, List.of(), null,
+                TimingCoverage.none());
+    }
 
     public enum Mode {
         TRACK,
         SELECT,
         FALLBACK
+    }
+
+    /** Stable schema marker for CI consumers. */
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public int schemaVersion() {
+        return SCHEMA_VERSION;
+    }
+
+    /** Tests omitted from the Surefire/Failsafe filter for this invocation. */
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public int skippedCount() {
+        return totalCount - selectedCount;
+    }
+
+    /** Includes every enum value so consumers never need to infer absent zero buckets. */
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    public Map<SelectionReason, Integer> reasonCounts() {
+        Map<SelectionReason, Integer> counts = new EnumMap<>(SelectionReason.class);
+        for (SelectionReason reason : SelectionReason.values()) {
+            counts.put(reason, 0);
+        }
+        decisions.forEach(decision -> counts.merge(decision.reason(), 1, Integer::sum));
+        return Map.copyOf(counts);
     }
 
     /**
@@ -39,10 +94,27 @@ public record BuildReport(
      * sync with it (contracts/mojo-and-index-contract.md's invariants).
      */
     public static BuildReport forSelect(IndexApplicability applicability, List<SelectionDecision> decisions) {
+        return forSelect(applicability, List.of(), decisions, Map.of());
+    }
+
+    /**
+     * Builds a SELECT-mode report with the complete changed-file context and a duration-based
+     * savings estimate when each skipped test has a persisted timing sample.
+     */
+    public static BuildReport forSelect(IndexApplicability applicability, List<ChangedFile> changedFiles,
+            List<SelectionDecision> decisions, Map<TestIdentity, Long> durationsByTest) {
         Objects.requireNonNull(applicability, "applicability");
+        Objects.requireNonNull(changedFiles, "changedFiles");
         Objects.requireNonNull(decisions, "decisions");
+        Objects.requireNonNull(durationsByTest, "durationsByTest");
         int selectedCount = (int) decisions.stream().filter(SelectionDecision::selected).count();
-        return new BuildReport(Mode.SELECT, applicability.status(), decisions, selectedCount, decisions.size(), null);
+        List<SelectionDecision> skipped = decisions.stream().filter(decision -> !decision.selected()).toList();
+        int recordedSkippedTests = (int) skipped.stream().filter(decision -> durationsByTest.containsKey(decision.test())).count();
+        Long estimatedTimeSavedMillis = recordedSkippedTests == skipped.size()
+                ? skipped.stream().mapToLong(decision -> durationsByTest.get(decision.test())).sum()
+                : null;
+        return new BuildReport(Mode.SELECT, applicability.status(), decisions, selectedCount, decisions.size(), null,
+                changedFiles, estimatedTimeSavedMillis, new TimingCoverage(recordedSkippedTests, skipped.size()));
     }
 
     /**
@@ -52,9 +124,15 @@ public record BuildReport(
      */
     public static BuildReport forTrack(IndexApplicability.Status indexApplicability, int totalCount,
             DependencyIndex updatedIndex) {
+        return forTrack(indexApplicability, totalCount, updatedIndex, List.of());
+    }
+
+    public static BuildReport forTrack(IndexApplicability.Status indexApplicability, int totalCount,
+            DependencyIndex updatedIndex, List<ChangedFile> changedFiles) {
         Objects.requireNonNull(indexApplicability, "indexApplicability");
         Objects.requireNonNull(updatedIndex, "updatedIndex");
-        return new BuildReport(Mode.TRACK, indexApplicability, List.of(), totalCount, totalCount, updatedIndex);
+        return new BuildReport(Mode.TRACK, indexApplicability, List.of(), totalCount, totalCount, updatedIndex,
+                changedFiles, 0L, TimingCoverage.none());
     }
 
     /**
@@ -62,7 +140,13 @@ public record BuildReport(
      * unconditionally, and deliberately no index is produced or refreshed (research.md #1).
      */
     public static BuildReport forFallback(IndexApplicability.Status indexApplicability, int totalCount) {
+        return forFallback(indexApplicability, totalCount, List.of());
+    }
+
+    public static BuildReport forFallback(IndexApplicability.Status indexApplicability, int totalCount,
+            List<ChangedFile> changedFiles) {
         Objects.requireNonNull(indexApplicability, "indexApplicability");
-        return new BuildReport(Mode.FALLBACK, indexApplicability, List.of(), totalCount, totalCount, null);
+        return new BuildReport(Mode.FALLBACK, indexApplicability, List.of(), totalCount, totalCount, null,
+                changedFiles, 0L, TimingCoverage.none());
     }
 }

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/SurefireReportReader.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/SurefireReportReader.java
@@ -1,0 +1,62 @@
+package io.github.baokhang83.blastradius.plugin.report;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Element;
+
+/** Reads per-test duration data from Surefire/Failsafe's standard JUnit XML reports. */
+public final class SurefireReportReader {
+
+    public Map<TestIdentity, Long> read(Path reportsDirectory) {
+        if (!Files.isDirectory(reportsDirectory)) {
+            return Map.of();
+        }
+        Map<TestIdentity, Long> timings = new LinkedHashMap<>();
+        try (var files = Files.list(reportsDirectory)) {
+            files.filter(path -> path.getFileName().toString().startsWith("TEST-"))
+                    .filter(path -> path.getFileName().toString().endsWith(".xml"))
+                    .sorted()
+                    .forEach(path -> readFile(path, timings));
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to list test reports in " + reportsDirectory, e);
+        }
+        return Map.copyOf(timings);
+    }
+
+    private static void readFile(Path report, Map<TestIdentity, Long> timings) {
+        try {
+            var factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+            factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+            var document = factory.newDocumentBuilder().parse(report.toFile());
+            var testCases = document.getElementsByTagName("testcase");
+            for (int i = 0; i < testCases.getLength(); i++) {
+                Element testCase = (Element) testCases.item(i);
+                String className = testCase.getAttribute("classname");
+                String methodName = testCase.getAttribute("name");
+                if (className.isBlank() || methodName.isBlank()) {
+                    continue;
+                }
+                timings.put(new TestIdentity(className, methodName), milliseconds(testCase.getAttribute("time")));
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("failed to parse test report " + report, e);
+        }
+    }
+
+    private static long milliseconds(String seconds) {
+        try {
+            return Math.round(Double.parseDouble(seconds) * 1_000);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("invalid test duration: " + seconds, e);
+        }
+    }
+}

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/TestTiming.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/TestTiming.java
@@ -1,0 +1,15 @@
+package io.github.baokhang83.blastradius.plugin.report;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import java.util.Objects;
+
+/** One observed test duration retained for a future selection estimate. */
+public record TestTiming(TestIdentity test, long durationMillis) {
+
+    public TestTiming {
+        Objects.requireNonNull(test, "test");
+        if (durationMillis < 0) {
+            throw new IllegalArgumentException("durationMillis must not be negative");
+        }
+    }
+}

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/TestTimingHistory.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/TestTimingHistory.java
@@ -1,0 +1,39 @@
+package io.github.baokhang83.blastradius.plugin.report;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Versioned, cacheable timing samples written independently of selection correctness. */
+public record TestTimingHistory(int formatVersion, List<TestTiming> timings) {
+
+    public static final int FORMAT_VERSION = 1;
+
+    public TestTimingHistory {
+        if (formatVersion != FORMAT_VERSION) {
+            throw new IllegalArgumentException("unsupported timing history format version: " + formatVersion);
+        }
+        timings = List.copyOf(timings);
+    }
+
+    public static TestTimingHistory empty() {
+        return new TestTimingHistory(FORMAT_VERSION, List.of());
+    }
+
+    public static TestTimingHistory from(Map<TestIdentity, Long> durationsByTest) {
+        return new TestTimingHistory(FORMAT_VERSION, durationsByTest.entrySet().stream()
+                .sorted(java.util.Comparator
+                        .comparing((Map.Entry<TestIdentity, Long> entry) -> entry.getKey().className())
+                        .thenComparing(entry -> entry.getKey().methodName(),
+                                java.util.Comparator.nullsFirst(String::compareTo)))
+                .map(entry -> new TestTiming(entry.getKey(), entry.getValue()))
+                .toList());
+    }
+
+    public Map<TestIdentity, Long> durationsByTest() {
+        Map<TestIdentity, Long> durations = new LinkedHashMap<>();
+        timings.forEach(timing -> durations.put(timing.test(), timing.durationMillis()));
+        return Map.copyOf(durations);
+    }
+}

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/TestTimingHistoryStore.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/TestTimingHistoryStore.java
@@ -1,0 +1,34 @@
+package io.github.baokhang83.blastradius.plugin.report;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Reads and writes the optional local timing cache. A bad cache never changes selection. */
+public final class TestTimingHistoryStore {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public TestTimingHistory load(Path file) {
+        if (!Files.isRegularFile(file)) {
+            return TestTimingHistory.empty();
+        }
+        try {
+            return mapper.readValue(file.toFile(), TestTimingHistory.class);
+        } catch (IOException | IllegalArgumentException e) {
+            return TestTimingHistory.empty();
+        }
+    }
+
+    public void save(Path file, TestTimingHistory history) {
+        try {
+            if (file.getParent() != null) {
+                Files.createDirectories(file.getParent());
+            }
+            mapper.writeValue(file.toFile(), history);
+        } catch (IOException e) {
+            throw new IllegalStateException("failed to write timing history to " + file, e);
+        }
+    }
+}

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/TimingCoverage.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/TimingCoverage.java
@@ -1,0 +1,15 @@
+package io.github.baokhang83.blastradius.plugin.report;
+
+/** How much of the skipped set has a persisted execution-duration sample. */
+public record TimingCoverage(int recordedSkippedTests, int totalSkippedTests) {
+
+    public TimingCoverage {
+        if (recordedSkippedTests < 0 || totalSkippedTests < 0 || recordedSkippedTests > totalSkippedTests) {
+            throw new IllegalArgumentException("timing coverage must satisfy 0 <= recorded <= total");
+        }
+    }
+
+    public static TimingCoverage none() {
+        return new TimingCoverage(0, 0);
+    }
+}

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/TimingHistoryRecorder.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/TimingHistoryRecorder.java
@@ -1,0 +1,84 @@
+package io.github.baokhang83.blastradius.plugin.report;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.ExecutionListener;
+
+/**
+ * Chains Maven's session listener and stores standard test-report timings when Surefire or
+ * Failsafe completes. Recording is observational: a timing-cache problem cannot fail a build.
+ */
+public final class TimingHistoryRecorder implements ExecutionListener {
+
+    private final ExecutionListener delegate;
+    private final TestTimingHistoryStore store;
+    private final SurefireReportReader reader;
+    private final Consumer<String> warning;
+
+    public TimingHistoryRecorder(ExecutionListener delegate, TestTimingHistoryStore store,
+            SurefireReportReader reader, Consumer<String> warning) {
+        this.delegate = delegate;
+        this.store = store;
+        this.reader = reader;
+        this.warning = warning;
+    }
+
+    @Override public void projectDiscoveryStarted(ExecutionEvent event) { delegate.projectDiscoveryStarted(event); }
+    @Override public void sessionStarted(ExecutionEvent event) { delegate.sessionStarted(event); }
+    @Override public void sessionEnded(ExecutionEvent event) { delegate.sessionEnded(event); }
+    @Override public void projectSkipped(ExecutionEvent event) { delegate.projectSkipped(event); }
+    @Override public void projectStarted(ExecutionEvent event) { delegate.projectStarted(event); }
+    @Override public void projectSucceeded(ExecutionEvent event) { delegate.projectSucceeded(event); }
+    @Override public void projectFailed(ExecutionEvent event) { delegate.projectFailed(event); }
+    @Override public void mojoSkipped(ExecutionEvent event) { delegate.mojoSkipped(event); }
+    @Override public void mojoStarted(ExecutionEvent event) { delegate.mojoStarted(event); }
+
+    @Override
+    public void mojoSucceeded(ExecutionEvent event) {
+        delegate.mojoSucceeded(event);
+        record(event);
+    }
+
+    @Override
+    public void mojoFailed(ExecutionEvent event) {
+        delegate.mojoFailed(event);
+        record(event);
+    }
+
+    @Override public void forkStarted(ExecutionEvent event) { delegate.forkStarted(event); }
+    @Override public void forkSucceeded(ExecutionEvent event) { delegate.forkSucceeded(event); }
+    @Override public void forkFailed(ExecutionEvent event) { delegate.forkFailed(event); }
+    @Override public void forkedProjectStarted(ExecutionEvent event) { delegate.forkedProjectStarted(event); }
+    @Override public void forkedProjectSucceeded(ExecutionEvent event) { delegate.forkedProjectSucceeded(event); }
+    @Override public void forkedProjectFailed(ExecutionEvent event) { delegate.forkedProjectFailed(event); }
+
+    private synchronized void record(ExecutionEvent event) {
+        if (!isTestEngine(event)) {
+            return;
+        }
+        try {
+            Path buildDir = Path.of(event.getProject().getBuild().getDirectory());
+            String reportsDirectory = "maven-failsafe-plugin".equals(event.getMojoExecution().getArtifactId())
+                    ? "failsafe-reports" : "surefire-reports";
+            Map<TestIdentity, Long> observed = reader.read(buildDir.resolve(reportsDirectory));
+            if (observed.isEmpty()) {
+                return;
+            }
+            Path historyFile = event.getProject().getBasedir().toPath().resolve(".blastradius/test-timings.json");
+            Map<TestIdentity, Long> merged = new LinkedHashMap<>(store.load(historyFile).durationsByTest());
+            merged.putAll(observed);
+            store.save(historyFile, TestTimingHistory.from(merged));
+        } catch (RuntimeException e) {
+            warning.accept("[blastradius] could not record test timings: " + e.getMessage());
+        }
+    }
+
+    private static boolean isTestEngine(ExecutionEvent event) {
+        String artifactId = event.getMojoExecution().getArtifactId();
+        return "maven-surefire-plugin".equals(artifactId) || "maven-failsafe-plugin".equals(artifactId);
+    }
+}

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeEndToEndTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeEndToEndTest.java
@@ -160,9 +160,18 @@ class SelectModeEndToEndTest {
         Path reportFile = projectDir.resolve(".blastradius/last-build-report.json");
         assertTrue(Files.exists(reportFile), "expected a BuildReport to be written to " + reportFile);
         String reportJson = Files.readString(reportFile, StandardCharsets.UTF_8);
+        assertTrue(reportJson.contains("\"schemaVersion\":1"), "expected schema v1 in:\n" + reportJson);
         assertTrue(reportJson.contains("\"mode\":\"SELECT\""), "expected mode=SELECT in:\n" + reportJson);
         assertTrue(reportJson.contains("\"selectedCount\":2"), "expected selectedCount=2 in:\n" + reportJson);
+        assertTrue(reportJson.contains("\"skippedCount\":1"), "expected skippedCount=1 in:\n" + reportJson);
         assertTrue(reportJson.contains("\"totalCount\":3"), "expected totalCount=3 in:\n" + reportJson);
+        assertTrue(reportJson.contains("\"changedFiles\":"), "expected changed files in:\n" + reportJson);
+        assertTrue(reportJson.contains("\"reasonCounts\":"), "expected reason counts in:\n" + reportJson);
+
+        Path timingHistory = projectDir.resolve(".blastradius/test-timings.json");
+        assertTrue(Files.exists(timingHistory), "expected completed Surefire timings at " + timingHistory);
+        assertTrue(Files.readString(timingHistory, StandardCharsets.UTF_8).contains("checksFoo"),
+                "expected the timing cache to include the test that ran");
     }
 
     @Test

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/BuildReportSchemaTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/BuildReportSchemaTest.java
@@ -1,0 +1,63 @@
+package io.github.baokhang83.blastradius.plugin.report;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.baokhang83.blastradius.core.git.ChangedFile;
+import io.github.baokhang83.blastradius.core.git.FileKind;
+import io.github.baokhang83.blastradius.core.selection.SelectionDecision;
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import io.github.baokhang83.blastradius.plugin.index.DependencyIndex;
+import io.github.baokhang83.blastradius.plugin.index.IndexApplicability;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class BuildReportSchemaTest {
+
+    private final BuildReportWriter writer = new BuildReportWriter();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void writesAStableAuditableSchemaWithACompleteTimingEstimate(@TempDir Path tempDir) throws Exception {
+        TestIdentity selected = new TestIdentity("example.FooTest", "checksFoo");
+        TestIdentity skipped = new TestIdentity("example.BarTest", "checksBar");
+        BuildReport report = BuildReport.forSelect(
+                IndexApplicability.applicable(new DependencyIndex("abc123", "2026-07-26T10:00:00Z", List.of())),
+                List.of(new ChangedFile("src/main/java/example/Foo.java", FileKind.JAVA_SOURCE, "example.Foo")),
+                List.of(SelectionDecision.dependencyMatch(selected, "example.Foo"), SelectionDecision.noMatch(skipped)),
+                Map.of(skipped, 1_250L));
+
+        Path output = tempDir.resolve("report.json");
+        writer.write(output, report);
+        JsonNode json = mapper.readTree(Files.readString(output));
+
+        assertEquals(1, json.path("schemaVersion").asInt());
+        assertEquals(1, json.path("changedFiles").size());
+        assertEquals(1, json.path("selectedCount").asInt());
+        assertEquals(1, json.path("skippedCount").asInt());
+        assertEquals(1, json.path("reasonCounts").path("DEPENDENCY_MATCH").asInt());
+        assertEquals(1, json.path("reasonCounts").path("NO_MATCH").asInt());
+        assertEquals(0, json.path("reasonCounts").path("FALLBACK_NON_SOURCE_CHANGE").asInt());
+        assertEquals(1_250L, json.path("estimatedTimeSavedMillis").asLong());
+        assertEquals(1, json.path("timingCoverage").path("recordedSkippedTests").asInt());
+        assertEquals(1, json.path("timingCoverage").path("totalSkippedTests").asInt());
+    }
+
+    @Test
+    void withholdsAnIncompleteTimingEstimateRatherThanGuessing() {
+        TestIdentity skipped = new TestIdentity("example.BarTest", "checksBar");
+        BuildReport report = BuildReport.forSelect(
+                IndexApplicability.applicable(new DependencyIndex("abc123", "2026-07-26T10:00:00Z", List.of())),
+                List.of(), List.of(SelectionDecision.noMatch(skipped)), Map.of());
+
+        assertEquals(1, report.skippedCount());
+        assertEquals(0, report.timingCoverage().recordedSkippedTests());
+        assertTrue(report.estimatedTimeSavedMillis() == null);
+    }
+}

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/SurefireReportReaderTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/SurefireReportReaderTest.java
@@ -1,0 +1,33 @@
+package io.github.baokhang83.blastradius.plugin.report;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SurefireReportReaderTest {
+
+    private final SurefireReportReader reader = new SurefireReportReader();
+
+    @Test
+    void readsPerTestDurationsFromStandardSurefireXml(@TempDir Path tempDir) throws Exception {
+        Path reports = Files.createDirectory(tempDir.resolve("surefire-reports"));
+        Files.writeString(reports.resolve("TEST-example.FooTest.xml"), """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <testsuite name="example.FooTest">
+                  <testcase name="fast" classname="example.FooTest" time="0.006"/>
+                  <testcase name="slow" classname="example.FooTest" time="1.234"/>
+                </testsuite>
+                """);
+
+        Map<TestIdentity, Long> durations = reader.read(reports);
+
+        assertEquals(Map.of(
+                new TestIdentity("example.FooTest", "fast"), 6L,
+                new TestIdentity("example.FooTest", "slow"), 1_234L), durations);
+    }
+}

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/TimingHistoryRecorderTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/TimingHistoryRecorderTest.java
@@ -1,0 +1,53 @@
+package io.github.baokhang83.blastradius.plugin.report;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.maven.execution.ExecutionEvent;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TimingHistoryRecorderTest {
+
+    @Test
+    void capturesSurefireResultsAfterItsMojoCompletes(@TempDir Path tempDir) throws Exception {
+        MavenProject project = new MavenProject();
+        project.setFile(tempDir.resolve("pom.xml").toFile());
+        project.getBuild().setDirectory(tempDir.resolve("target").toString());
+        Path reports = Files.createDirectories(tempDir.resolve("target/surefire-reports"));
+        Files.writeString(reports.resolve("TEST-example.FooTest.xml"), """
+                <testsuite name="example.FooTest">
+                  <testcase name="checksFoo" classname="example.FooTest" time="0.125"/>
+                </testsuite>
+                """);
+
+        Path historyFile = tempDir.resolve(".blastradius/test-timings.json");
+        TestTimingHistoryStore store = new TestTimingHistoryStore();
+        TimingHistoryRecorder recorder = new TimingHistoryRecorder(
+                new org.apache.maven.execution.AbstractExecutionListener(), store, new SurefireReportReader(), ignored -> { });
+        recorder.mojoSucceeded(eventFor(project, "maven-surefire-plugin"));
+
+        assertEquals(125L, store.load(historyFile).durationsByTest()
+                .get(new TestIdentity("example.FooTest", "checksFoo")));
+    }
+
+    private static ExecutionEvent eventFor(MavenProject project, String artifactId) {
+        Plugin plugin = new Plugin();
+        plugin.setGroupId("org.apache.maven.plugins");
+        plugin.setArtifactId(artifactId);
+        MojoExecution execution = new MojoExecution(plugin, "test", "default-test");
+        return new ExecutionEvent() {
+            @Override public Type getType() { return Type.MojoSucceeded; }
+            @Override public MavenSession getSession() { return null; }
+            @Override public MavenProject getProject() { return project; }
+            @Override public MojoExecution getMojoExecution() { return execution; }
+            @Override public Exception getException() { return null; }
+        };
+    }
+}

--- a/docs/fluencyloop/features/json-selection-report-31/design.md
+++ b/docs/fluencyloop/features/json-selection-report-31/design.md
@@ -1,0 +1,165 @@
+# Design: JSON selection report (#31)
+
+started: 2026-07-26
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class SelectMojo {
+    +execute()
+    -runTrack(CurrentChanges, IndexApplicability)
+    -runSelect(CurrentChanges, IndexApplicability)
+    -runFallback(CurrentChanges, IndexApplicability)
+  }
+  class CurrentChanges {
+    +List~ChangedFile~ changedFiles()
+  }
+  class BuildReport {
+    +int schemaVersion
+    +Mode mode
+    +Status indexApplicability
+    +List~ChangedFile~ changedFiles
+    +List~SelectionDecision~ decisions
+    +int selectedCount
+    +int skippedCount
+    +int totalCount
+    +Map~SelectionReason,int~ reasonCounts
+    +Long estimatedTimeSavedMillis
+    +TimingCoverage timingCoverage
+  }
+  class BuildReportWriter {
+    +write(Path, BuildReport)
+  }
+  class TestTimingHistory {
+    +int formatVersion
+    +Map~TestIdentity,long~ durationMillisByTest
+  }
+  class TestTimingHistoryStore {
+    +load(Path) TestTimingHistory
+    +save(Path, TestTimingHistory)
+  }
+  class SurefireReportReader {
+    +read(Path) Map~TestIdentity,long~
+  }
+  class TimingHistoryRecorder {
+    +mojoSucceeded(ExecutionEvent)
+    +mojoFailed(ExecutionEvent)
+  }
+  class TimingCoverage {
+    +int recordedSkippedTests
+    +int totalSkippedTests
+  }
+  class ChangedFile {
+    +String path
+    +FileKind kind
+    +String changedClassName
+  }
+  class SelectionDecision {
+    +TestIdentity test
+    +boolean selected
+    +SelectionReason reason
+    +String matchedChangedClass
+  }
+  SelectMojo --> CurrentChanges : resolves
+  SelectMojo --> BuildReport : creates from all modes
+  SelectMojo --> BuildReportWriter : persists
+  SelectMojo --> SurefireReportReader : imports prior test results
+  SelectMojo --> TestTimingHistoryStore : maintains history
+  SelectMojo --> TimingHistoryRecorder : registers
+  TimingHistoryRecorder --> SurefireReportReader : reads completed reports
+  BuildReport "1" *-- "*" ChangedFile : changedFiles
+  BuildReport "1" *-- "*" SelectionDecision : decisions
+  BuildReport --> TimingCoverage
+  TestTimingHistoryStore --> TestTimingHistory
+```
+
+## Sequence: write one report for every selection mode
+
+```mermaid
+sequenceDiagram
+  participant M as SelectMojo
+  participant C as CurrentChangesResolver
+  participant R as BuildReport
+  participant W as BuildReportWriter
+  participant S as Surefire report reader
+  participant L as Maven execution listener
+  participant H as test-timings.json
+  participant F as .blastradius/last-build-report.json
+
+  M->>C: resolve reactor root and base ref
+  C-->>M: changedFiles and index applicability
+  M->>H: load persisted timing history
+  alt TRACK
+    M->>M: run full suite and refresh index
+  else SELECT
+    M->>M: compute decisions and apply Surefire filter
+  else FALLBACK
+    M->>M: retain the full suite
+  end
+  M->>R: create schema v1 report from selection and timing history
+  Note over R: Include all SelectionReason buckets, changed files,<br/>and a complete skipped-test duration estimate when available
+  M->>W: write report
+  W->>F: serialize JSON
+  M->>L: register timing recorder
+  Note over M,L: Selection completes before test execution
+  M->>M: Maven runs Surefire or Failsafe
+  L->>S: observe completion and read XML reports
+  S-->>L: observed duration per test
+  L->>H: merge and persist timing history
+```
+
+## Report contract
+
+`BuildReport` remains the single source of truth; the console renderer continues to derive
+its output from it. Every invocation writes schema version `1` at
+`.blastradius/last-build-report.json`, with these stable fields:
+
+```json
+{
+  "schemaVersion": 1,
+  "mode": "SELECT",
+  "indexApplicability": "APPLICABLE",
+  "changedFiles": [
+    { "path": "src/main/java/example/Foo.java", "kind": "JAVA_SOURCE", "changedClassName": "example.Foo" }
+  ],
+  "decisions": [
+    { "test": { "className": "example.FooTest", "methodName": "works" }, "selected": true,
+      "reason": "DEPENDENCY_MATCH", "matchedChangedClass": "example.Foo" }
+  ],
+  "selectedCount": 1,
+  "skippedCount": 4,
+  "totalCount": 5,
+  "reasonCounts": {
+    "DEPENDENCY_MATCH": 1,
+    "FALLBACK_NON_SOURCE_CHANGE": 0,
+    "NEW_OR_MODIFIED_TEST": 0,
+    "NO_MATCH": 4
+  },
+  "estimatedTimeSavedMillis": 2430,
+  "timingCoverage": { "recordedSkippedTests": 4, "totalSkippedTests": 4 }
+}
+```
+
+`selectedCount` is the test set the goal tells Surefire/Failsafe to run; `skippedCount` is
+the remaining discovered set. The goal executes before the test engines, so the report does not
+claim final execution results. At the beginning of each build, the goal loads the versioned
+per-test durations in `.blastradius/test-timings.json`. A Maven execution listener registered by
+the goal observes Surefire/Failsafe completion, reads those standard XML reports, and merges the
+fresh durations immediately - even when the build began with `clean`. For a SELECT build,
+`estimatedTimeSavedMillis` is the sum of the persisted durations for every skipped test. It is
+`null` until every skipped test has timing history; `timingCoverage` makes that status
+machine-readable. TRACK and FALLBACK report zero skipped tests and zero estimated savings. All four
+`SelectionReason` keys appear even when a mode has no per-test decisions, so CI consumers do not
+need mode-specific missing-key handling.
+
+## Key choice
+
+The report extends the existing `BuildReport` rather than adding a parallel report model. That
+keeps JSON, console rendering, and selection behavior tied to one immutable value and preserves
+the existing output fields. A small versioned timing-history file is the second durable artifact:
+it contains only test identity and last observed duration, is updated from Surefire/Failsafe's
+standard XML reports immediately after the test engine completes, and remains useful when CI
+restores `.blastradius/` as a cache. A listener injected into the test runtime was rejected
+because it would add a second execution integration and risk changing the build; a synthetic
+equal-cost percentage was rejected because it is not the milliseconds estimate requested here.

--- a/docs/fluencyloop/features/json-selection-report-31/sessions/capture-completed-test-timings-without-changing-selection-be.md
+++ b/docs/fluencyloop/features/json-selection-report-31/sessions/capture-completed-test-timings-without-changing-selection-be.md
@@ -1,0 +1,18 @@
+# Session: capture completed test timings without changing selection behavior
+
+- **intent:** capture completed test timings without changing selection behavior
+- **started:** 2026-07-26
+
+## Knowledge transfer
+
+- **TimingHistoryRecorder:** A session-level listener wrapper forwards all Maven events to the original listener. On Surefire/Failsafe completion, it reads the emitted JUnit XML and updates a project-local timing cache; cache errors only warn and never alter the build result.
+- **TestTimingHistory:** The cache has its own format version and stores a stable test identity with its most recently observed duration in milliseconds. SELECT estimates savings only when every skipped test has a sample, while TRACK and FALLBACK report zero savings.
+
+## Decision: chain Maven execution listeners to record completed test timings
+
+- **where:** `blastradius-maven-plugin mojo/SelectMojo and report/TimingHistoryRecorder`
+- **why:** The select goal runs before tests, so it wraps Maven's dynamic session listener and records standard Surefire/Failsafe XML only after the test engine completes, preserving existing listener behavior and keeping the timing cache observational.
+- **alternative:** Require a second post-test goal — rejected: every adopter would need additional lifecycle configuration; inject a test-runtime listener — rejected: it adds execution risk without changing selection.
+- **design:** ../design.md#sequence-write-one-report-for-every-selection-mode
+- **constitution:** §II
+- **trust:** ✓ verified

--- a/docs/fluencyloop/features/json-selection-report-31/sessions/define-the-versioned-report-schema-and-safe-surefire-timing.md
+++ b/docs/fluencyloop/features/json-selection-report-31/sessions/define-the-versioned-report-schema-and-safe-surefire-timing.md
@@ -1,0 +1,27 @@
+# Session: define the versioned report schema and safe Surefire timing reader
+
+- **intent:** define the versioned report schema and safe Surefire timing reader
+- **started:** 2026-07-26
+
+## Knowledge transfer
+
+- **BuildReport schema:** The machine-readable artifact remains the source for console rendering and CI. It exposes schema version, changed files, every `SelectionReason` count, selected/skipped totals, and timing coverage; `estimatedTimeSavedMillis` is absent until the timing history covers every skipped test.
+- **SurefireReportReader:** Standard Surefire/Failsafe XML provides the class name, method name, and seconds duration per testcase. The reader converts those to milliseconds and blocks external DTD/schema resolution because timing extraction never needs XML to load external resources.
+
+## Decision: extend BuildReport as the single versioned report schema
+
+- **where:** `blastradius-maven-plugin report package`
+- **why:** The existing immutable report already feeds console output, so adding schema fields, changed-file context, reason buckets, and guarded timing estimates preserves one source of truth for CI and humans.
+- **alternative:** Parallel JSON report model — rejected: it would duplicate selection state and allow the machine report to drift from console output.
+- **design:** ../design.md#key-choice
+- **constitution:** §II
+- **trust:** ✓ verified
+
+## Decision: disable external XML resolution while reading Surefire reports
+
+- **where:** `blastradius-maven-plugin report/SurefireReportReader`
+- **why:** Timing import needs only local testcase attributes, so secure processing and blocked external DTD/schema access prevent report data from causing local-file or network access.
+- **alternative:** Default DOM parser configuration — rejected: it leaves external entity resolution enabled without serving the timing use case.
+- **design:** ../design.md#class-diagram
+- **constitution:** §VI
+- **trust:** ✓ verified

--- a/specs/002-ci-gating-plugin/contracts/mojo-and-index-contract.md
+++ b/specs/002-ci-gating-plugin/contracts/mojo-and-index-contract.md
@@ -73,10 +73,23 @@ human-readable summary to the build's own console output (FR-008, FR-009):
 
 ```json
 {
+  "schemaVersion": 1,
   "mode": "TRACK | SELECT | FALLBACK",
   "indexApplicability": "APPLICABLE | MISSING | UNREADABLE | ANCHOR_UNREACHABLE",
+  "changedFiles": [
+    { "path": "string", "kind": "JAVA_SOURCE | NON_SOURCE | INERT", "changedClassName": "string | null" }
+  ],
   "totalCount": "integer",
   "selectedCount": "integer",
+  "skippedCount": "integer",
+  "reasonCounts": {
+    "DEPENDENCY_MATCH": "integer",
+    "FALLBACK_NON_SOURCE_CHANGE": "integer",
+    "NEW_OR_MODIFIED_TEST": "integer",
+    "NO_MATCH": "integer"
+  },
+  "estimatedTimeSavedMillis": "integer | null",
+  "timingCoverage": { "recordedSkippedTests": "integer", "totalSkippedTests": "integer" },
   "decisions": [
     {
       "test": { "className": "string", "methodName": "string | null" },
@@ -90,8 +103,17 @@ human-readable summary to the build's own console output (FR-008, FR-009):
 
 `decisions` is empty when `mode = TRACK` or `mode = FALLBACK` — both run everything
 unconditionally (neither is computing a per-test selection); `totalCount`/`selectedCount` are
-still populated (`selectedCount = totalCount` in both cases). Only `TRACK` also forks a
-subprocess and populates a fresh index; `FALLBACK` does neither (research.md #1).
+still populated (`selectedCount = totalCount` in both cases). `skippedCount = totalCount -
+selectedCount`, and `reasonCounts` always includes all four enum values, even if each count is
+zero. Only `TRACK` also forks a subprocess and populates a fresh index; `FALLBACK` does neither
+(research.md #1).
+
+`estimatedTimeSavedMillis` is the sum of persisted durations for every skipped test. It is
+`null` instead of a guess until `timingCoverage.recordedSkippedTests` equals
+`timingCoverage.totalSkippedTests`. The plugin stores duration history in the versioned local
+cache `.blastradius/test-timings.json`, populated from completed Surefire/Failsafe XML reports.
+The report is written before those test engines execute, so selected/skipped counts are the
+planned execution set, not their final pass/fail result.
 
 ## Console summary (rendered, not authoritative)
 
@@ -109,6 +131,10 @@ has to its `AnalysisReport` (spec 001's contract) — a rendering, not a second 
 
 - `selectedCount = totalCount` whenever `mode = TRACK` or `mode = FALLBACK` (FR-007 — both run
   everything).
+- `skippedCount = totalCount - selectedCount`; `estimatedTimeSavedMillis = 0` for TRACK and
+  FALLBACK, and is non-null for SELECT only when timing coverage is complete.
+- `reasonCounts` contains exactly one zero-or-positive bucket for every `SelectionReason`; the
+  bucket sum equals `decisions.size()`.
 - `decisions` is non-empty if and only if `mode = SELECT`.
 - `updatedIndex` (data-model.md) is present if and only if `mode = TRACK` — `FALLBACK` never
   produces or refreshes an index (research.md #1).

--- a/specs/002-ci-gating-plugin/data-model.md
+++ b/specs/002-ci-gating-plugin/data-model.md
@@ -56,8 +56,14 @@ The plugin's per-build output (Key Entity: Build Report; FR-008, FR-009).
 | `mode` | enum: `TRACK`, `SELECT`, `FALLBACK` | Which path this invocation took (research.md #1). `TRACK`: `isBaseRefBuild` (or explicit `-Dblastradius.mode=track`) — full suite runs, and a subprocess refreshes the index. `SELECT`: a valid index applies — narrowed to the selected subset. `FALLBACK`: no valid index and *not* a base-ref build — full suite runs, same as `TRACK`, but no subprocess is forked (research.md #1's "why not track on every miss") |
 | `indexApplicability` | IndexApplicability | Why `SELECT` was or wasn't chosen |
 | `decisions` | list\<SelectionDecision\> | One per test in the suite; empty for `TRACK`/`FALLBACK`, where the *entire* suite ran unconditionally rather than per-test decisions being computed |
-| `selectedCount` | int | Tests that actually ran |
+| `schemaVersion` | int | Stable machine-readable report contract version; the initial version is `1` |
+| `changedFiles` | list\<ChangedFile\> | The complete classified git diff used for this selection |
+| `selectedCount` | int | Tests selected to run by the Surefire/Failsafe filter (the report is written before test execution completes) |
+| `skippedCount` | int | `totalCount - selectedCount` |
 | `totalCount` | int | Tests in the full suite |
+| `reasonCounts` | map\<SelectionReason, int\> | Every reason enum bucket, including zeros, for stable CI aggregation |
+| `estimatedTimeSavedMillis` | long, nullable | Sum of persisted durations for every skipped test; absent when timing coverage is incomplete |
+| `timingCoverage` | `{ recordedSkippedTests, totalSkippedTests }` | States whether the duration estimate has a complete baseline |
 | `updatedIndex` | DependencyIndex, nullable | Present only when `mode = TRACK` — the freshly (re)built index this run produced, now persisted for future `SELECT` runs. Always absent for `FALLBACK`, which deliberately does not attempt an index refresh (research.md #1) |
 
 ## Relationships


### PR DESCRIPTION
## Summary

Adds schema-versioned JSON output for `blastradius:select`, including changed files, selected/skipped counts, zero-filled `SelectionReason` buckets, and timing coverage.

Persists per-test durations after completed Surefire/Failsafe executions and reports estimated milliseconds saved only when every skipped test has history. Timing-cache failures are observational and do not affect selection or the build result.

## Decisions

- Extended `BuildReport` rather than adding a parallel report model, preserving one source of truth for console output and CI. (`blastradius-maven-plugin` report package)
- Chained Maven execution listeners rather than requiring a second post-test goal or injecting a test-runtime listener. (`SelectMojo`, `TimingHistoryRecorder`)
- Disabled external XML resolution while reading test reports. (`SurefireReportReader`)

## Verification

- `mvn -pl blastradius-maven-plugin test`
- `mvn -pl blastradius-maven-plugin -Dtest=SelectModeEndToEndTest#reportAndConsoleSummaryReflectTheDecisions test`

## Design and FluencyLoop record

- `docs/fluencyloop/features/json-selection-report-31/design.md`
- Two journal sessions with verified decisions; no unjournaled commits.

## Constitution check

Aligned with Principle II (one concrete report model) and Principle VI (secure, maintained Java XML processing). No conflicts identified.