### PR TITLE
feat: add GitHub Actions selection feedback

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "json-selection-report-31",
-  "branch": "feature/json-selection-report-31",
+  "feature": "github-actions-job-summary-and-pr-comment-33",
+  "branch": "feature/github-actions-job-summary-and-pr-comment-33",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/json-selection-report-31/sessions/capture-completed-test-timings-without-changing-selection-be.md",
+  "last_session": "docs/fluencyloop/features/github-actions-job-summary-and-pr-comment-33/sessions/publish-selection-feedback-in-github-actions.md",
   "base_ref": "main",
   "updated": "2026-07-26"
 }

--- a/.github/actions/blastradius-selection-summary/action.yml
+++ b/.github/actions/blastradius-selection-summary/action.yml
@@ -1,0 +1,88 @@
+name: Blastradius selection summary
+description: Publish a Blastradius build report to the job summary and, by default, the pull request.
+
+inputs:
+  report-path:
+    description: Path to the JSON report emitted by blastradius:select.
+    required: false
+    default: .blastradius/last-build-report.json
+  comment:
+    description: Whether to update the pull-request comment for same-repository pull requests.
+    required: false
+    default: 'true'
+  github-token:
+    description: "Token with pull-requests: write when pull-request comments are enabled."
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - id: summary
+      name: Write selection summary
+      continue-on-error: true
+      uses: actions/github-script@v8
+      env:
+        REPORT_PATH: ${{ inputs.report-path }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+          const { renderSelectionSummary } = require(path.join(process.env.GITHUB_ACTION_PATH, 'render-summary.cjs'));
+          const reportPath = process.env.REPORT_PATH;
+
+          async function writeNeutralSummary(message) {
+            await core.summary
+              .addHeading('Blastradius selection')
+              .addRaw(message)
+              .write();
+          }
+
+          if (!fs.existsSync(reportPath)) {
+            await writeNeutralSummary('No selection report was produced by this build.');
+            core.setOutput('report-found', 'false');
+            return;
+          }
+
+          try {
+            const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+            const body = renderSelectionSummary(report);
+            const bodyPath = path.join(process.env.RUNNER_TEMP, 'blastradius-selection-summary.md');
+            fs.writeFileSync(bodyPath, body);
+            await core.summary.addRaw(body).write();
+            core.setOutput('comment-body-path', bodyPath);
+            core.setOutput('report-found', 'true');
+          } catch (error) {
+            core.warning(`Could not render the Blastradius report: ${error.message}`);
+            await writeNeutralSummary('The selection report could not be read, so no result was published.');
+            core.setOutput('report-found', 'false');
+          }
+
+    - name: Update pull request comment
+      if: inputs.comment == 'true' && steps.summary.outputs.report-found == 'true' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+      continue-on-error: true
+      uses: actions/github-script@v8
+      env:
+        COMMENT_BODY_PATH: ${{ steps.summary.outputs.comment-body-path }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const fs = require('fs');
+          const { COMMENT_MARKER } = require(`${process.env.GITHUB_ACTION_PATH}/render-summary.cjs`);
+          const body = fs.readFileSync(process.env.COMMENT_BODY_PATH, 'utf8');
+          const { owner, repo } = context.repo;
+          const issue_number = context.payload.pull_request.number;
+          const comments = await github.paginate(github.rest.issues.listComments, {
+            owner,
+            repo,
+            issue_number,
+            per_page: 100,
+          });
+          const priorComment = comments.find((comment) => comment.user.type === 'Bot' && comment.body?.includes(COMMENT_MARKER));
+
+          if (priorComment) {
+            await github.rest.issues.updateComment({ owner, repo, comment_id: priorComment.id, body });
+          } else {
+            await github.rest.issues.createComment({ owner, repo, issue_number, body });
+          }

--- a/.github/actions/blastradius-selection-summary/render-summary.cjs
+++ b/.github/actions/blastradius-selection-summary/render-summary.cjs
@@ -1,0 +1,90 @@
+const COMMENT_MARKER = '<!-- blastradius-selection-summary -->';
+
+function readCount(report, key, required = false) {
+  const value = report[key];
+  if (value === undefined && !required) return undefined;
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${key} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function displayReason(reason) {
+  const knownReasons = {
+    DEPENDENCY_MATCH: 'Dependency match',
+    NO_MATCH: 'No match',
+    NEW_OR_MODIFIED_TEST: 'New or modified test',
+    FALLBACK_NON_SOURCE_CHANGE: 'Fallback non-source change',
+  };
+  return knownReasons[reason]
+    ?? reason.toLowerCase().split('_').map((word) => word[0].toUpperCase() + word.slice(1)).join(' ');
+}
+
+function reasonCounts(report) {
+  if (report.reasonCounts !== undefined) {
+    if (typeof report.reasonCounts !== 'object' || report.reasonCounts === null || Array.isArray(report.reasonCounts)) {
+      throw new Error('reasonCounts must be an object');
+    }
+    return Object.entries(report.reasonCounts)
+      .map(([reason, count]) => [reason, readCount(report.reasonCounts, reason, true)])
+      .filter(([, count]) => count > 0);
+  }
+
+  const counts = new Map();
+  for (const decision of report.decisions ?? []) {
+    if (typeof decision?.reason === 'string') {
+      counts.set(decision.reason, (counts.get(decision.reason) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()];
+}
+
+function formatDuration(milliseconds) {
+  const seconds = Math.round(milliseconds / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const remainderSeconds = seconds % 60;
+  return minutes === 0 ? `~${remainderSeconds}s` : `~${minutes}m ${remainderSeconds}s`;
+}
+
+function renderSelectionSummary(report) {
+  if (typeof report !== 'object' || report === null || Array.isArray(report)) {
+    throw new Error('report must be an object');
+  }
+
+  const selectedCount = readCount(report, 'selectedCount', true);
+  const totalCount = readCount(report, 'totalCount', true);
+  if (selectedCount > totalCount) throw new Error('selectedCount must not exceed totalCount');
+
+  const derivedSkippedCount = totalCount - selectedCount;
+  const skippedCount = readCount(report, 'skippedCount') ?? derivedSkippedCount;
+  if (skippedCount !== derivedSkippedCount) throw new Error('skippedCount must equal totalCount minus selectedCount');
+
+  const estimate = report.estimatedTimeSavedMillis;
+  if (estimate !== undefined && estimate !== null && (!Number.isSafeInteger(estimate) || estimate < 0)) {
+    throw new Error('estimatedTimeSavedMillis must be a non-negative integer or null');
+  }
+
+  const savings = estimate === undefined || estimate === null ? null : formatDuration(estimate);
+  const lines = [
+    COMMENT_MARKER,
+    '## Blastradius selection',
+    '',
+    savings
+      ? `Ran ${selectedCount}/${totalCount}, skipped ${skippedCount}, ${savings} saved.`
+      : `Ran ${selectedCount}/${totalCount}, skipped ${skippedCount}.`,
+  ];
+
+  if (!savings) lines.push('', 'Timing history is incomplete, so no time-saved estimate is shown.');
+
+  const reasons = reasonCounts(report);
+  if (reasons.length > 0) {
+    lines.push('', '### Reasons', '');
+    for (const [reason, count] of reasons.sort(([left], [right]) => left.localeCompare(right))) {
+      lines.push(`- ${displayReason(reason)}: ${count}`);
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+module.exports = { COMMENT_MARKER, renderSelectionSummary };

--- a/.github/actions/blastradius-selection-summary/render-summary.test.cjs
+++ b/.github/actions/blastradius-selection-summary/render-summary.test.cjs
@@ -1,0 +1,46 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { renderSelectionSummary } = require('./render-summary.cjs');
+
+test('renders the selection result, timing estimate, and non-zero reasons', () => {
+  const rendered = renderSelectionSummary({
+    selectedCount: 42,
+    totalCount: 310,
+    skippedCount: 268,
+    estimatedTimeSavedMillis: 365000,
+    reasonCounts: {
+      DEPENDENCY_MATCH: 42,
+      NO_MATCH: 268,
+      NEW_OR_MODIFIED_TEST: 0,
+    },
+  });
+
+  assert.match(rendered, /Ran 42\/310, skipped 268, ~6m 5s saved\./);
+  assert.match(rendered, /Dependency match: 42/);
+  assert.match(rendered, /No match: 268/);
+  assert.doesNotMatch(rendered, /New or modified test/);
+});
+
+test('derives skipped tests for an older report and withholds an incomplete estimate', () => {
+  const rendered = renderSelectionSummary({
+    selectedCount: 2,
+    totalCount: 5,
+    decisions: [
+      { reason: 'DEPENDENCY_MATCH' },
+      { reason: 'NO_MATCH' },
+    ],
+  });
+
+  assert.match(rendered, /Ran 2\/5, skipped 3\./);
+  assert.match(rendered, /Timing history is incomplete, so no time-saved estimate is shown\./);
+  assert.match(rendered, /Dependency match: 1/);
+  assert.match(rendered, /No match: 1/);
+});
+
+test('rejects an invalid report rather than publishing misleading counts', () => {
+  assert.throws(
+    () => renderSelectionSummary({ selectedCount: 4, totalCount: 3 }),
+    /selectedCount must not exceed totalCount/,
+  );
+});

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   verify:
@@ -29,3 +30,8 @@ jobs:
         with:
           maven-version: 3.9.6
       - run: mvn -B --no-transfer-progress clean verify
+      - name: Publish Blastradius selection feedback
+        if: ${{ always() }}
+        uses: ./.github/actions/blastradius-selection-summary
+        with:
+          github-token: ${{ github.token }}

--- a/blastradius-maven-plugin/README.md
+++ b/blastradius-maven-plugin/README.md
@@ -19,6 +19,7 @@ fail, only how many tests get the chance to.
 - [Install](#install)
 - [Generated goal reference](#generated-goal-reference)
 - [Configuration reference](#configuration-reference)
+- [GitHub Actions feedback](#github-actions-feedback)
 - [What you'll see in the Maven output](#what-youll-see-in-the-maven-output)
 - [The files it writes](#the-files-it-writes)
 - [Multi-module reactors](#multi-module-reactors)
@@ -120,6 +121,32 @@ module's own goal execution resolves the same commit-keyed path.
   restored between CI runs the same way you already cache `~/.m2` — it has to survive
   between the trunk job that wrote it and the PR job that reads it, or every PR build stays
   in `FALLBACK` forever (see below).
+
+### GitHub Actions feedback
+
+After the Maven command that runs `blastradius:select`, add the composite action below. It
+always adds the result to the run's job summary. On same-repository pull requests it also
+updates one Blastradius comment by default, so repeated CI runs do not add noise.
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+
+steps:
+  - run: mvn -B --no-transfer-progress verify
+  - name: Publish Blastradius selection feedback
+    if: ${{ always() }}
+    uses: baokhang83/blastradius/.github/actions/blastradius-selection-summary@main
+    with:
+      github-token: ${{ github.token }}
+```
+
+The action reads `.blastradius/last-build-report.json` by default. A missing, incomplete,
+or unreadable report produces a neutral job-summary entry and never changes the Maven job's
+result. Forked pull requests receive the job summary but intentionally do not receive a
+comment, because their workflow token must not be granted write access. To keep the job
+summary while disabling comments, set `comment: 'false'`.
 
 ### Shared S3 index store
 

--- a/docs/fluencyloop/features/github-actions-job-summary-and-pr-comment-33/design.md
+++ b/docs/fluencyloop/features/github-actions-job-summary-and-pr-comment-33/design.md
@@ -1,0 +1,83 @@
+# Design: GitHub Actions job summary and PR comment (#33)
+
+started: 2026-07-26
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class BuildWorkflow {
+    +mvn clean verify
+    +publish selection summary
+  }
+  class SelectionSummaryAction {
+    +report-path input
+    +comment input = true
+    +github-token input
+  }
+  class SummaryRenderer {
+    +read report JSON
+    +write Markdown
+  }
+  class GitHubJobSummary {
+    +GITHUB_STEP_SUMMARY
+  }
+  class PullRequestCommenter {
+    +upsert marked comment
+  }
+  class BuildReport {
+    +selectedCount
+    +totalCount
+    +skippedCount
+    +estimatedTimeSavedMillis
+    +reasonCounts
+  }
+  BuildWorkflow --> SelectionSummaryAction : invokes after build
+  SelectionSummaryAction --> SummaryRenderer : parses
+  SummaryRenderer --> BuildReport : reads
+  SummaryRenderer --> GitHubJobSummary : appends Markdown
+  SelectionSummaryAction --> PullRequestCommenter : internal PRs only
+  PullRequestCommenter --> BuildReport : summarizes
+```
+
+## Sequence: publish CI feedback without affecting verification
+
+```mermaid
+sequenceDiagram
+  participant B as Build workflow
+  participant A as Selection summary action
+  participant R as last-build-report.json
+  participant J as GITHUB_STEP_SUMMARY
+  participant G as GitHub API
+
+  B->>B: run Maven verification
+  B->>A: invoke after build
+  A->>R: read selection report
+  alt report exists
+    A->>J: append Markdown summary
+    alt internal pull request and comment enabled
+      A->>G: create or update marked PR comment
+      G-->>A: comment result
+    else forked pull request or comment disabled
+      A->>A: skip PR comment
+    end
+  else report missing
+    A->>J: state that no report was produced
+  end
+  A-->>B: never change verification result
+```
+
+## Rationale
+
+The publisher is a composite GitHub Action rather than Maven-plugin code. Maven
+produces a portable local report; GitHub Actions owns the event context, token,
+job-summary surface, and pull-request permission boundary. This makes the
+integration reusable by every workflow that runs `blastradius:select`.
+
+The action always writes a job-summary entry, including when no report was
+produced. PR comments are enabled by default for same-repository pull requests,
+where the workflow grants `pull-requests: write`. They are intentionally skipped
+for forks and are non-fatal, so feedback can never change the build result.
+
+One stable HTML marker identifies the comment to update. This preserves a single
+current result per pull request instead of adding a comment on every CI run.

--- a/docs/fluencyloop/features/github-actions-job-summary-and-pr-comment-33/sessions/publish-selection-feedback-in-github-actions.md
+++ b/docs/fluencyloop/features/github-actions-job-summary-and-pr-comment-33/sessions/publish-selection-feedback-in-github-actions.md
@@ -1,0 +1,20 @@
+# Session: Publish selection feedback in GitHub Actions
+
+- **intent:** Publish selection feedback in GitHub Actions
+- **started:** 2026-07-26
+
+## Decision: publish feedback from a composite action
+
+- **where:** `.github/actions/blastradius-selection-summary`
+- **why:** GitHub Actions owns event context, tokens, summary rendering, and pull-request permissions while Maven keeps producing a portable local report.
+- **alternative:** Call the GitHub API from the Maven plugin — rejected because it couples the plugin to GitHub credentials and cannot safely reason about forked pull-request permissions.
+- **design:** `../design.md#rationale`
+- **trust:** ⚠ not independently verified
+
+## Decision: validate report data before publishing it
+
+- **where:** `renderer validation`
+- **why:** Validate report counts and timing estimates before rendering so malformed or incomplete local JSON cannot publish misleading CI savings; the action will warn and write a neutral summary instead of failing verification.
+- **alternative:** Trust every report as the current schema — rejected because the action must be safe for reports from older plugin versions and interrupted writes.
+- **design:** `../design.md#rationale`
+- **trust:** ⚠ not independently verified


### PR DESCRIPTION
Closes #33

## Intent
Publish each Blastradius selection report in its GitHub Actions job summary, with a default-on, one-comment PR update for same-repository pull requests.

## Reviewer decisions
- **Unverified — composite action:** Keep Maven report production portable and place GitHub event, token, and permission handling in a reusable composite action; direct GitHub API calls from Maven were rejected.
- **Unverified — renderer validation:** Validate report counts and timing estimates before publishing so malformed, old, or incomplete JSON cannot make misleading claims; publish a neutral summary instead of changing verification outcome.

## Constitution check
No conflict found. The renderer was written test-first, remains a small concrete module, and preserves explainable per-reason output.

## Verification
- `node --test .github/actions/blastradius-selection-summary/render-summary.test.cjs`
- `mvn -B --no-transfer-progress -pl blastradius-maven-plugin test` (27 test reports, no failures)
- YAML parsing and `git diff --check`