### PR TITLE
docs: clarify CI index persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ blastradius {
 }
 ```
 
+There is no separate Gradle `select` task. Applying the plugin configures every Java `Test`
+task, so run the normal `./gradlew test`: it tracks on `main` and selects the relevant tests on
+other branches when a saved index is available.
+
 For separate CI runners, first persist and restore `.blastradius/` with your CI cache. S3 is
 optional; configure the same shared S3 index store only when needed:
 
@@ -109,9 +113,9 @@ on a first build or cache miss — Blastradius safely runs the full suite instea
 
 ### GitHub Actions cache example
 
-In the workflow that runs `blastradius:select`, put the restore step after checkout and before
-Maven. Save only successful `main` builds, after Maven, so pull requests always read a map made
-by the trusted base branch:
+In the workflow that runs Blastradius-enabled tests, put the restore step after checkout and
+before `mvn verify` or `./gradlew test`. Save only successful `main` builds, after the test
+command, so pull requests always read a map made by the trusted base branch:
 
 ```yaml
 steps:

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ no heuristics, no opaque score.
 </plugin>
 ```
 
-For separate CI runners, add the shared S3 index-store settings inside the Maven plugin's
-`<configuration>` block:
+For separate CI runners, first persist and restore the workspace's `.blastradius/` directory
+with your CI cache. S3 is optional; use these Maven settings only when an S3-compatible shared
+store is a better fit for your runners:
 
 ```xml
 <indexStore>s3</indexStore>
@@ -72,7 +73,8 @@ blastradius {
 }
 ```
 
-For separate CI runners, configure the same shared S3 index store:
+For separate CI runners, first persist and restore `.blastradius/` with your CI cache. S3 is
+optional; configure the same shared S3 index store only when needed:
 
 ```groovy
 blastradius {
@@ -92,12 +94,18 @@ to set it up in CI.
 
 ### Sharing indexes across CI runners
 
-By default, indexes stay under the workspace's `.blastradius/` directory. If a trunk `TRACK`
-job and PR `SELECT` job run on separate workers, configure the Maven plugin or Gradle extension
-with `indexStore = s3`, a bucket, and a region. The shared object store lets the PR job read the
-same commit-keyed index that the trunk job wrote. Credentials come from the standard AWS
-credential chain; do not put access keys in build files. Missing or inaccessible remote indexes
-still run the full suite safely. See the [Maven S3 configuration reference](blastradius-maven-plugin/README.md#shared-s3-index-store).
+By default, indexes stay under the workspace's `.blastradius/` directory. That directory is a
+saved map of which production classes each test used. A trunk `TRACK` job writes the map; a PR
+`SELECT` job restores it, compares the PR's changed classes to it, and runs only matching tests.
+
+On fresh CI workers, preserve `.blastradius/` between the trunk and PR jobs with the CI cache
+alongside your usual Maven dependency cache. **S3 is not required.** It is an alternative when
+your runners cannot share a reliable cache: configure the Maven plugin or Gradle extension with
+`indexStore = s3`, a bucket, and a region. The shared object store lets the PR job read the same
+commit-keyed index that the trunk job wrote. Credentials come from the standard AWS credential
+chain; do not put access keys in build files. If no saved index can be restored — for example,
+on a first build or cache miss — Blastradius safely runs the full suite instead. See the
+[Maven S3 configuration reference](blastradius-maven-plugin/README.md#shared-s3-index-store).
 
 ```bash
 git clone https://github.com/baokhang83/blastradius.git

--- a/README.md
+++ b/README.md
@@ -107,6 +107,40 @@ chain; do not put access keys in build files. If no saved index can be restored 
 on a first build or cache miss — Blastradius safely runs the full suite instead. See the
 [Maven S3 configuration reference](blastradius-maven-plugin/README.md#shared-s3-index-store).
 
+### GitHub Actions cache example
+
+In the workflow that runs `blastradius:select`, put the restore step after checkout and before
+Maven. Save only successful `main` builds, after Maven, so pull requests always read a map made
+by the trusted base branch:
+
+```yaml
+steps:
+  - uses: actions/checkout@v7
+
+  - name: Restore Blastradius index
+    id: blastradius-index
+    uses: actions/cache/restore@v4
+    with:
+      path: .blastradius
+      key: blastradius-index-${{ runner.os }}-${{ github.sha }}
+      restore-keys: |
+        blastradius-index-${{ runner.os }}-
+
+  - run: mvn -B --no-transfer-progress verify
+
+  - name: Save Blastradius index from main
+    if: ${{ github.ref == 'refs/heads/main' && success() && steps.blastradius-index.outputs.cache-hit != 'true' }}
+    uses: actions/cache/save@v4
+    with:
+      path: .blastradius
+      key: blastradius-index-${{ runner.os }}-${{ github.sha }}
+```
+
+The key includes the commit SHA so a `main` build saves an immutable snapshot. A PR has a new
+SHA, so its exact lookup misses; `restore-keys` then restores the newest compatible
+`main` snapshot. Do not put credentials or other secrets under `.blastradius/` because GitHub
+Actions caches are readable by pull-request workflows.
+
 ```bash
 git clone https://github.com/baokhang83/blastradius.git
 cd blastradius

--- a/blastradius-maven-plugin/README.md
+++ b/blastradius-maven-plugin/README.md
@@ -116,11 +116,23 @@ module's own goal execution resolves the same commit-keyed path.
 
 ### CI setup
 
-- **Trunk/post-merge job**: run as normal — no extra flags needed, `TRACK` is automatic.
-- **PR job**: run as normal too. Just make sure `.blastradius/` is cached and
-  restored between CI runs the same way you already cache `~/.m2` — it has to survive
-  between the trunk job that wrote it and the PR job that reads it, or every PR build stays
-  in `FALLBACK` forever (see below).
+Blastradius needs one piece of saved information before it can narrow a PR build: a map of
+which production classes each test actually used. For example, a `main` build may record that
+`CalculatorTest` used `Calculator`, while `InvoiceTest` used `InvoiceService`.
+
+1. The **trunk/post-merge job** runs the full suite and writes that map under
+   `.blastradius/` (`TRACK` is automatic).
+2. The **PR job** restores `.blastradius/`, compares its changed classes with the saved map,
+   and runs only the matching tests (`SELECT`). A change to `Calculator` can therefore run
+   `CalculatorTest` without also running `InvoiceTest`.
+
+GitHub-hosted runners are fresh for every job, so cache `.blastradius/` between the trunk job
+that writes it and the PR job that reads it, just as you cache `~/.m2`. **An S3 bucket is not
+required**: the default file store plus a GitHub Actions cache is enough. S3 is an alternative
+when your runners cannot share a reliable workspace cache.
+
+If the PR job cannot restore the map — for example, on its first run or after a cache miss —
+Blastradius does not guess. It uses safe `FALLBACK` mode and runs the full suite.
 
 ### GitHub Actions feedback
 

--- a/blastradius-maven-plugin/README.md
+++ b/blastradius-maven-plugin/README.md
@@ -181,6 +181,81 @@ keys in the POM. For MinIO or another S3-compatible service, add `s3Endpoint`; i
 still required for request signing. A missing, unreadable, unauthorized, or malformed remote
 index remains a safe `FALLBACK` that runs the full suite.
 
+#### S3 credentials
+
+The plugin explicitly uses the AWS SDK's `DefaultCredentialsProvider`. It therefore accepts,
+without any Blastradius-specific secret configuration, AWS Java system properties, environment
+variables, GitHub Actions OIDC credentials, a local `~/.aws/config` / `~/.aws/credentials`
+profile, and ECS or EC2 instance-role credentials. The first complete source in that standard
+chain wins.
+
+For GitHub Actions, use OIDC and a short-lived IAM role rather than long-lived access keys. Add
+GitHub's `https://token.actions.githubusercontent.com` OIDC provider to the AWS account with
+audience `sts.amazonaws.com`, then create a role trusted by the repository's `main` branch:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+        "token.actions.githubusercontent.com:sub": "repo:<OWNER>/<REPOSITORY>:ref:refs/heads/main"
+      }
+    }
+  }]
+}
+```
+
+For repositories using GitHub's immutable OIDC subjects, use the subject format shown in
+GitHub's OIDC settings instead: `repo:<OWNER>@<OWNER_ID>/<REPOSITORY>@<REPOSITORY_ID>:ref:refs/heads/main`.
+
+Attach a permissions policy scoped to the index prefix. Blastradius reads and writes known object
+keys, so it does **not** need to list the bucket:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["s3:GetObject", "s3:PutObject"],
+    "Resource": "arn:aws:s3:::<BUCKET>/<PREFIX>/*"
+  }]
+}
+```
+
+A PR needs only `s3:GetObject`; give it a separate read-only role if it is allowed to read the
+shared store. Do not grant either role to untrusted fork pull requests — let those builds fall
+back to the full suite instead.
+
+In a trusted `main` workflow, configure the role before Maven:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+steps:
+  - uses: actions/checkout@v7
+  - name: Configure AWS credentials
+    uses: aws-actions/configure-aws-credentials@v6.1.0
+    with:
+      role-to-assume: arn:aws:iam::<ACCOUNT_ID>:role/blastradius-index-writer
+      aws-region: eu-central-1
+  - run: mvn -B --no-transfer-progress verify
+```
+
+The action exports the temporary AWS environment variables that the plugin reads. For local
+development, use `aws configure sso` (or an equivalent profile) and set `AWS_PROFILE` before
+running Maven. If OIDC is unavailable, store `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and
+for temporary credentials `AWS_SESSION_TOKEN`, as CI secrets and expose them only to trusted
+jobs. Never place those values in the POM, Gradle build file, repository, or cache.
+
 ## What you'll see in the Maven output
 
 **`TRACK`** — a base-branch build, building/refreshing the index:


### PR DESCRIPTION
Updates the repository-root README with an explicit GitHub Actions cache pattern and the Maven-plugin README with S3 credential details: AWS SDK provider chain, least-privilege S3 policy, GitHub Actions OIDC trust and workflow setup, local profiles, and safe handling of pull requests.