### PR TITLE
CI: self-host Blastradius test selection

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "github-actions-job-summary-and-pr-comment-33",
-  "branch": "feature/github-actions-job-summary-and-pr-comment-33",
+  "feature": "self-host-blastradius-test-selection-in-ci",
+  "branch": "feature/self-host-blastradius-test-selection-in-ci",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/github-actions-job-summary-and-pr-comment-33/sessions/publish-selection-feedback-in-github-actions.md",
+  "last_session": "docs/fluencyloop/features/self-host-blastradius-test-selection-in-ci/sessions/self-host-the-maven-reactor-in-ci.md",
   "base_ref": "main",
   "updated": "2026-07-26"
 }

--- a/.github/actions/blastradius-selection-summary/action.yml
+++ b/.github/actions/blastradius-selection-summary/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Path to the JSON report emitted by blastradius:select.
     required: false
     default: .blastradius/last-build-report.json
+  report-paths:
+    description: Newline-separated report paths to combine for a multi-module build.
+    required: false
+    default: ''
   comment:
     description: Whether to update the pull-request comment for same-repository pull requests.
     required: false
@@ -24,13 +28,18 @@ runs:
       uses: actions/github-script@v8
       env:
         REPORT_PATH: ${{ inputs.report-path }}
+        REPORT_PATHS: ${{ inputs.report-paths }}
       with:
         github-token: ${{ inputs.github-token }}
         script: |
           const fs = require('fs');
           const path = require('path');
-          const { renderSelectionSummary } = require(path.join(process.env.GITHUB_ACTION_PATH, 'render-summary.cjs'));
-          const reportPath = process.env.REPORT_PATH;
+          const { combineSelectionReports, renderSelectionSummary } = require(path.join(process.env.GITHUB_ACTION_PATH, 'render-summary.cjs'));
+          const reportPaths = process.env.REPORT_PATHS
+            .split(/\r?\n/)
+            .map((reportPath) => reportPath.trim())
+            .filter(Boolean);
+          if (reportPaths.length === 0) reportPaths.push(process.env.REPORT_PATH);
 
           async function writeNeutralSummary(message) {
             await core.summary
@@ -39,14 +48,16 @@ runs:
               .write();
           }
 
-          if (!fs.existsSync(reportPath)) {
+          const missingReportPaths = reportPaths.filter((reportPath) => !fs.existsSync(reportPath));
+          if (missingReportPaths.length > 0) {
             await writeNeutralSummary('No selection report was produced by this build.');
             core.setOutput('report-found', 'false');
             return;
           }
 
           try {
-            const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+            const reports = reportPaths.map((reportPath) => JSON.parse(fs.readFileSync(reportPath, 'utf8')));
+            const report = combineSelectionReports(reports);
             const body = renderSelectionSummary(report);
             const bodyPath = path.join(process.env.RUNNER_TEMP, 'blastradius-selection-summary.md');
             fs.writeFileSync(bodyPath, body);

--- a/.github/actions/blastradius-selection-summary/render-summary.cjs
+++ b/.github/actions/blastradius-selection-summary/render-summary.cjs
@@ -46,6 +46,42 @@ function formatDuration(milliseconds) {
   return minutes === 0 ? `~${remainderSeconds}s` : `~${minutes}m ${remainderSeconds}s`;
 }
 
+function combineSelectionReports(reports) {
+  if (!Array.isArray(reports) || reports.length === 0) {
+    throw new Error('reports must be a non-empty array');
+  }
+
+  const reasonCountTotals = {};
+  let selectedCount = 0;
+  let totalCount = 0;
+  let estimatedTimeSavedMillis = 0;
+  let hasIncompleteEstimate = false;
+
+  for (const report of reports) {
+    selectedCount += readCount(report, 'selectedCount', true);
+    totalCount += readCount(report, 'totalCount', true);
+    const estimate = report.estimatedTimeSavedMillis;
+    if (estimate === undefined || estimate === null) {
+      hasIncompleteEstimate = true;
+    } else if (!Number.isSafeInteger(estimate) || estimate < 0) {
+      throw new Error('estimatedTimeSavedMillis must be a non-negative integer or null');
+    } else {
+      estimatedTimeSavedMillis += estimate;
+    }
+    for (const [reason, count] of reasonCounts(report)) {
+      reasonCountTotals[reason] = (reasonCountTotals[reason] ?? 0) + count;
+    }
+  }
+
+  return {
+    selectedCount,
+    totalCount,
+    skippedCount: totalCount - selectedCount,
+    estimatedTimeSavedMillis: hasIncompleteEstimate ? null : estimatedTimeSavedMillis,
+    reasonCounts: reasonCountTotals,
+  };
+}
+
 function renderSelectionSummary(report) {
   if (typeof report !== 'object' || report === null || Array.isArray(report)) {
     throw new Error('report must be an object');
@@ -87,4 +123,4 @@ function renderSelectionSummary(report) {
   return `${lines.join('\n')}\n`;
 }
 
-module.exports = { COMMENT_MARKER, renderSelectionSummary };
+module.exports = { COMMENT_MARKER, combineSelectionReports, renderSelectionSummary };

--- a/.github/actions/blastradius-selection-summary/render-summary.test.cjs
+++ b/.github/actions/blastradius-selection-summary/render-summary.test.cjs
@@ -1,7 +1,30 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { renderSelectionSummary } = require('./render-summary.cjs');
+const { combineSelectionReports, renderSelectionSummary } = require('./render-summary.cjs');
+
+test('combines the module reports for a reactor-wide summary', () => {
+  assert.deepEqual(combineSelectionReports([
+    {
+      selectedCount: 2,
+      totalCount: 5,
+      estimatedTimeSavedMillis: 1200,
+      reasonCounts: { DEPENDENCY_MATCH: 2, NO_MATCH: 3 },
+    },
+    {
+      selectedCount: 1,
+      totalCount: 4,
+      estimatedTimeSavedMillis: 800,
+      reasonCounts: { NEW_OR_MODIFIED_TEST: 1, NO_MATCH: 3 },
+    },
+  ]), {
+    selectedCount: 3,
+    totalCount: 9,
+    skippedCount: 6,
+    estimatedTimeSavedMillis: 2000,
+    reasonCounts: { DEPENDENCY_MATCH: 2, NO_MATCH: 6, NEW_OR_MODIFIED_TEST: 1 },
+  });
+});
 
 test('renders the selection result, timing estimate, and non-zero reasons', () => {
   const rendered = renderSelectionSummary({

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,44 @@ jobs:
       - uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.9.6
-      - run: mvn -B --no-transfer-progress clean verify
+      - name: Restore Blastradius index
+        id: blastradius-index
+        uses: actions/cache/restore@v4
+        with:
+          path: .blastradius
+          key: blastradius-index-${{ runner.os }}-jdk${{ matrix.java }}-${{ github.sha }}
+          restore-keys: |
+            blastradius-index-${{ runner.os }}-jdk${{ matrix.java }}-
+      - name: Bootstrap Blastradius plugin
+        run: |
+          mvn -B --no-transfer-progress -DskipTests -Dinvoker.skip=true -pl blastradius-maven-plugin -am package
+          mkdir -p target/self-host/META-INF/maven
+          cp blastradius-maven-plugin/target/blastradius-maven-plugin-0.1.0.jar target/blastradius-maven-plugin-0.1.0-selfhost.jar
+          unzip -p blastradius-maven-plugin/target/blastradius-maven-plugin-0.1.0.jar META-INF/maven/plugin.xml \
+            | perl -0pe 's{(<artifactId>blastradius-maven-plugin</artifactId>\s*<version>)0\.1\.0(</version>)}{$1 . "0.1.0-selfhost" . $2}e' \
+            > target/self-host/META-INF/maven/plugin.xml
+          (cd target/self-host && jar uf ../blastradius-maven-plugin-0.1.0-selfhost.jar META-INF/maven/plugin.xml)
+          mvn -B --no-transfer-progress org.apache.maven.plugins:maven-install-plugin:3.1.2:install-file \
+            -Dfile=target/blastradius-maven-plugin-0.1.0-selfhost.jar \
+            -DgroupId=io.github.baokhang83.blastradius \
+            -DartifactId=blastradius-maven-plugin \
+            -Dversion=0.1.0-selfhost \
+            -Dpackaging=maven-plugin \
+            -DgeneratePom=true
+      - run: mvn -B --no-transfer-progress -Pself-host-blastradius clean verify
+      - name: Save Blastradius index from main
+        if: ${{ github.ref == 'refs/heads/main' && success() && steps.blastradius-index.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: .blastradius
+          key: blastradius-index-${{ runner.os }}-jdk${{ matrix.java }}-${{ github.sha }}
       - name: Publish Blastradius selection feedback
         if: ${{ always() }}
         uses: ./.github/actions/blastradius-selection-summary
         with:
+          report-paths: |
+            blastradius-core/.blastradius/last-build-report.json
+            blastradius-s3-index-store/.blastradius/last-build-report.json
+            blastradius-validator/.blastradius/last-build-report.json
+            blastradius-maven-plugin/.blastradius/last-build-report.json
           github-token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ SHA, so its exact lookup misses; `restore-keys` then restores the newest compati
 `main` snapshot. Do not put credentials or other secrets under `.blastradius/` because GitHub
 Actions caches are readable by pull-request workflows.
 
+### This repository's CI
+
+This repository self-hosts Blastradius in its own Maven workflow: CI first builds and installs
+the plugin from the checkout, then runs the normal reactor with an internal CI-only Maven
+profile. Successful `main` runs refresh the cached index; pull requests restore it and use the
+same plugin code under review to select tests. The bootstrap and multi-module reporting mechanics
+are intentionally kept in the workflow and feature design, not the adoption quick start above.
+
 ```bash
 git clone https://github.com/baokhang83/blastradius.git
 cd blastradius

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/ReactorTrackingGate.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/ReactorTrackingGate.java
@@ -1,0 +1,22 @@
+package io.github.baokhang83.blastradius.plugin.mojo;
+
+import java.util.Properties;
+
+/** Claims the one tracking subprocess permitted for a reactor and commit in one Maven session. */
+final class ReactorTrackingGate {
+
+    private static final String PROPERTY_PREFIX = "blastradius.reactor-track.";
+
+    private ReactorTrackingGate() {}
+
+    static boolean claim(Properties sessionProperties, String reactorRoot, String commit) {
+        String key = PROPERTY_PREFIX + Integer.toHexString((reactorRoot + "@" + commit).hashCode());
+        synchronized (sessionProperties) {
+            if (sessionProperties.containsKey(key)) {
+                return false;
+            }
+            sessionProperties.setProperty(key, "claimed");
+            return true;
+        }
+    }
+}

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
@@ -124,6 +124,10 @@ public final class SelectMojo extends AbstractMojo {
                     + "collecting dependency data; the ambient gated build's own Surefire execution is untouched)");
             return;
         }
+        if (isAggregatorOnlyProject(project.getPackaging())) {
+            getLog().info("[blastradius] skipping select goal for aggregator-only project " + project.getArtifactId());
+            return;
+        }
 
         // Anchored at the reactor root (not project.getBasedir()), which for a
         // multi-module reactor differs per module: the git repository only exists at the
@@ -213,6 +217,10 @@ public final class SelectMojo extends AbstractMojo {
         return BuildReport.Mode.FALLBACK;
     }
 
+    static boolean isAggregatorOnlyProject(String packaging) {
+        return "pom".equals(packaging);
+    }
+
     /**
      * The current build IS the base reference — its own Surefire execution runs
      * completely full and unfiltered, and separately, a subprocess {@code mvn test} (agent
@@ -221,9 +229,18 @@ public final class SelectMojo extends AbstractMojo {
      */
     private void runTrack(CurrentChanges changes, IndexApplicability applicability, Path reactorRoot,
             IndexStore<DependencyIndex> indexStore, String indexPathKey) throws MojoExecutionException {
-        Path agentJar = locateCoreAgentJar();
-        DependencyIndex freshIndex = trackRunner.track(reactorRoot, agentJar, changes.currentCommit());
-        indexStore.put(CommitIndexKey.forCommit(indexPathKey, changes.currentCommit()), freshIndex);
+        String indexKey = CommitIndexKey.forCommit(indexPathKey, changes.currentCommit());
+        DependencyIndex freshIndex;
+        if (ReactorTrackingGate.claim(session.getUserProperties(), reactorRoot.toAbsolutePath().toString(), changes.currentCommit())) {
+            Path agentJar = locateCoreAgentJar();
+            freshIndex = trackRunner.track(reactorRoot, agentJar, changes.currentCommit());
+            indexStore.put(indexKey, freshIndex);
+        } else {
+            freshIndex = indexStore.get(indexKey).orElse(null);
+            if (freshIndex == null) {
+                throw new MojoExecutionException("the reactor tracking index was not available after another module claimed TRACK");
+            }
+        }
 
         int totalCount = discoverProjectTests().size();
         BuildReport report = BuildReport.forTrack(applicability.status(), totalCount, freshIndex, changes.changedFiles());

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/TestDiscoverer.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/TestDiscoverer.java
@@ -28,9 +28,11 @@ import org.junit.platform.launcher.core.LauncherFactory;
  */
 public final class TestDiscoverer {
 
+    private static final String BLASTRADIUS_PACKAGE = "io.github.baokhang83.blastradius.";
+
     public Set<TestIdentity> discoverAllTests(Path testClassesDir, List<String> testClasspathElements) {
         URL[] urls = testClasspathElements.stream().map(TestDiscoverer::toUrl).toArray(URL[]::new);
-        ClassLoader discoveryClassLoader = new URLClassLoader(urls, Thread.currentThread().getContextClassLoader());
+        ClassLoader discoveryClassLoader = new ProjectFirstClassLoader(urls, Thread.currentThread().getContextClassLoader());
 
         ClassLoader previous = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(discoveryClassLoader);
@@ -73,6 +75,38 @@ public final class TestDiscoverer {
             return Path.of(path).toUri().toURL();
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException("invalid classpath element: " + path, e);
+        }
+    }
+
+    /**
+     * The packaged plugin shades Blastradius classes, which is normally isolated behind Maven's
+     * plugin realm. Self-hosting intentionally runs against a project with the same package, so
+     * discovery must prefer that project's compiled classes rather than the shaded copies.
+     */
+    static final class ProjectFirstClassLoader extends URLClassLoader {
+
+        ProjectFirstClassLoader(URL[] urls, ClassLoader parent) {
+            super(urls, parent);
+        }
+
+        @Override
+        protected synchronized Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (!name.startsWith(BLASTRADIUS_PACKAGE)) {
+                return super.loadClass(name, resolve);
+            }
+
+            Class<?> loaded = findLoadedClass(name);
+            if (loaded == null) {
+                try {
+                    loaded = findClass(name);
+                } catch (ClassNotFoundException ignored) {
+                    loaded = super.loadClass(name, false);
+                }
+            }
+            if (resolve) {
+                resolveClass(loaded);
+            }
+            return loaded;
         }
     }
 }

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/ReactorTrackingGateTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/ReactorTrackingGateTest.java
@@ -1,0 +1,27 @@
+package io.github.baokhang83.blastradius.plugin.mojo;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class ReactorTrackingGateTest {
+
+    @Test
+    void allowsOnlyTheFirstModuleInOneReactorToTrackACommit() {
+        Properties sessionProperties = new Properties();
+
+        assertTrue(ReactorTrackingGate.claim(sessionProperties, "/workspace/blastradius", "abc123"));
+        assertFalse(ReactorTrackingGate.claim(sessionProperties, "/workspace/blastradius", "abc123"));
+    }
+
+    @Test
+    void keepsIndependentReactorsAndCommitsIndependent() {
+        Properties sessionProperties = new Properties();
+
+        assertTrue(ReactorTrackingGate.claim(sessionProperties, "/workspace/one", "abc123"));
+        assertTrue(ReactorTrackingGate.claim(sessionProperties, "/workspace/two", "abc123"));
+        assertTrue(ReactorTrackingGate.claim(sessionProperties, "/workspace/one", "def456"));
+    }
+}

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojoModeRoutingTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojoModeRoutingTest.java
@@ -1,6 +1,8 @@
 package io.github.baokhang83.blastradius.plugin.mojo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.baokhang83.blastradius.plugin.diff.CurrentChanges;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex;
@@ -11,6 +13,12 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class SelectMojoModeRoutingTest {
+
+    @Test
+    void skipsAggregatorOnlyProjects() {
+        assertTrue(SelectMojo.isAggregatorOnlyProject("pom"));
+        assertFalse(SelectMojo.isAggregatorOnlyProject("jar"));
+    }
 
     private static final CurrentChanges BASE_REF_BUILD =
             new CurrentChanges("main", "abc123", Optional.of("abc123"), "abc123", true, List.of());

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/TestDiscovererTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/TestDiscovererTest.java
@@ -3,6 +3,7 @@ package io.github.baokhang83.blastradius.plugin.mojo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
@@ -30,5 +31,16 @@ class TestDiscovererTest {
                 "writtenIndexRoundTripsThroughAFile");
         assertTrue(discovered.contains(knownTest),
                 "expected to discover " + knownTest + " among " + discovered.size() + " discovered tests");
+    }
+
+    @Test
+    void prefersSelfHostedProjectClassesOverThePluginsShadedCopies() throws Exception {
+        URL projectClasses = Path.of("target", "classes").toAbsolutePath().toUri().toURL();
+        try (TestDiscoverer.ProjectFirstClassLoader loader = new TestDiscoverer.ProjectFirstClassLoader(
+                new URL[] {projectClasses}, getClass().getClassLoader())) {
+            Class<?> loaded = loader.loadClass(TestDiscoverer.class.getName());
+
+            assertTrue(loaded.getClassLoader() == loader);
+        }
     }
 }

--- a/docs/fluencyloop/features/self-host-blastradius-test-selection-in-ci/design.md
+++ b/docs/fluencyloop/features/self-host-blastradius-test-selection-in-ci/design.md
@@ -13,7 +13,7 @@ classDiagram
     +save main index cache
   }
   class SelfHostProfile {
-    +baseRef = main
+    +baseRef = origin/main
     +bind select in every module
   }
   class SelectMojo {

--- a/docs/fluencyloop/features/self-host-blastradius-test-selection-in-ci/design.md
+++ b/docs/fluencyloop/features/self-host-blastradius-test-selection-in-ci/design.md
@@ -1,0 +1,96 @@
+# Design: Self-host Blastradius test selection in CI
+
+started: 2026-07-26
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class BuildWorkflow {
+    +restore index cache
+    +bootstrap plugin locally
+    +run selected reactor verification
+    +save main index cache
+  }
+  class SelfHostProfile {
+    +baseRef = main
+    +bind select in every module
+  }
+  class SelectMojo {
+    +skip aggregator-only projects
+    +select or track module tests
+  }
+  class ReactorTrackingGate {
+    +claim one TRACK run per session
+  }
+  class GitHubCache {
+    +restore matching main index
+    +save main index by JDK and commit
+  }
+  class SelectionSummaryAction {
+    +combine module reports
+    +publish job and PR summary
+  }
+  BuildWorkflow --> GitHubCache : restores and saves
+  BuildWorkflow --> SelectionSummaryAction : supplies module reports
+  BuildWorkflow --> SelfHostProfile : activates
+  SelfHostProfile --> SelectMojo : configures every module
+  SelectMojo --> ReactorTrackingGate : tracks once on main
+```
+
+## Rationale
+
+The CI job bootstraps the plugin built from the current checkout under a temporary
+`0.1.0-selfhost` coordinate, then activates an opt-in Maven profile for the real verification
+run. The bootstrap step updates only the copied plugin descriptor so Maven accepts that external
+coordinate; published project POMs remain at their normal version. The verification reactor also
+remains at its normal version, avoiding a cycle with the plugin module being built. This exercises
+the code under review instead of a previously published version.
+
+Selection remains module-local because each module reaches `process-test-classes` only after its
+own tests are compiled. A reactor-scoped gate permits one TRACK subprocess on `main`, while every
+other module reuses the resulting index.
+
+The root `pom` project is an aggregator, not a test-bearing module, so the selector skips it.
+This prevents an empty parent from trying to start JUnit tracking; the first child module claims
+the reactor-wide TRACK run instead.
+
+Each module writes its existing local report. The selection-summary action combines the known
+module reports after the reactor completes, which keeps feedback aggregation in CI presentation
+rather than adding another Maven lifecycle listener.
+
+GitHub Actions restores a JDK-specific index cache before the build and saves a new immutable
+snapshot only after a successful `main` run. A missing or invalid snapshot leaves every module in
+safe FALLBACK mode.
+
+## Sequence: PR selection against a cached main index
+
+```mermaid
+sequenceDiagram
+  participant W as Build workflow
+  participant C as GitHub cache
+  participant B as Bootstrap build
+  participant S as Selected Maven reactor
+  participant G as Reactor tracking gate
+  participant A as Selection summary action
+
+  W->>C: restore index for JDK and commit prefix
+  W->>B: install current plugin at temporary revision
+  W->>S: run clean verify with self-host profile
+  alt main build
+    S->>G: first module claims TRACK
+    G->>S: run one agent-backed full test subprocess
+    S-->>A: emit module reports
+    A-->>W: publish aggregate result
+    W->>C: save index for main commit
+  else pull request with matching index
+    S->>G: no tracking needed
+    S->>S: filter each module before its tests
+    S-->>A: emit module reports
+    A-->>W: publish aggregate result
+  else cache miss or unsafe index
+    S->>S: run full suite in FALLBACK mode
+    S-->>A: emit module reports
+    A-->>W: publish aggregate result
+  end
+```

--- a/docs/fluencyloop/features/self-host-blastradius-test-selection-in-ci/sessions/self-host-the-maven-reactor-in-ci.md
+++ b/docs/fluencyloop/features/self-host-blastradius-test-selection-in-ci/sessions/self-host-the-maven-reactor-in-ci.md
@@ -1,0 +1,69 @@
+# Session: Self-host the Maven reactor in CI
+
+- **intent:** Self-host the Maven reactor in CI
+- **started:** 2026-07-26
+
+## Knowledge transfer
+
+- **Bootstrap coordinate:** CI packages the checked-out plugin, copies it to a private
+  `0.1.0-selfhost` coordinate, and changes that copy's plugin descriptor to the same coordinate.
+  Maven validates descriptor and requested versions, so relabelling only the repository artifact
+  is not enough. Status: documented.
+- **Reactor tracking:** the profile is inherited by modules but skips the aggregator POM. The
+  first test-bearing module starts the agent-backed track subprocess; later module executions
+  reuse its shared index while still writing their own reports. Status: documented.
+- **Self-hosted discovery:** the plugin shades Blastradius classes. During self-hosting, project
+  test discovery loads the project's Blastradius package before the shaded plugin copy, avoiding
+  duplicate-class linkage failures. Status: documented.
+- **CI feedback:** the composite action combines explicit module report paths after the reactor,
+  then writes the job summary and updates the same-repository pull-request comment. Status:
+  documented.
+
+
+## Decision: bootstrap and coordinate self-hosted selection
+
+- **where:** `root Maven profile and CI workflow`
+- **why:** Bootstrap the plugin from the current checkout, run one TRACK subprocess per Maven session, and aggregate module reports so CI uses the reviewed code without multiplying the full reactor run.
+- **alternative:** Bind the plugin independently in every module without coordination
+- **design:** ../design.md#rationale
+- **trust:** ⚠ not independently verified
+
+## Decision: bootstrap the plugin under a temporary reactor-safe revision
+
+- **where:** `root POM version properties and CI bootstrap workflow`
+- **why:** Maven rejects a plugin whose coordinate matches a reactor module, and it verifies the plugin descriptor version; building the current checkout at 0.1.0-selfhost gives the bootstrap artifact a valid descriptor while the verification reactor stays at 0.1.0.
+- **alternative:** Install the normal plugin coordinate or relabel its JAR — rejected: the former creates a reactor cycle and the latter fails Maven's descriptor-version validation.
+- **design:** ../design.md#rationale
+- **trust:** ⚠ not independently verified
+
+## Decision: combine existing module reports in the CI summary action
+
+- **where:** `selection-summary action and build workflow`
+- **why:** Each Maven module already emits a local report. Combining explicit module paths after the reactor completes produces one accurate CI and pull-request summary without adding Maven lifecycle listener coordination solely for presentation.
+- **alternative:** Write an aggregate report from a Maven session listener — rejected: it couples CI presentation to lifecycle internals despite the needed module data already existing.
+- **design:** ../design.md#rationale
+- **trust:** ✓ verified
+
+## Decision: skip aggregator-only projects before selector mode routing
+
+- **where:** `SelectMojo execution entry point`
+- **why:** The root POM participates in the inherited profile but has no test engine. Skipping packaging pom lets the first test-bearing child claim the one reactor-wide TRACK process and prevents an empty parent from failing CI.
+- **alternative:** Allow the aggregator to run TRACK — rejected: it attempts to create a JUnit launcher with no engine and stops the reactor before any test module runs.
+- **design:** ../design.md#rationale
+- **trust:** ✓ verified
+
+## Decision: prefer self-hosted project classes during test discovery
+
+- **where:** `TestDiscoverer class loader`
+- **why:** A Maven plugin normally delegates to its shaded classes first. During self-hosting, the project contains the same Blastradius packages, so discovery loads that project namespace child-first and avoids linking tests against the plugin's copies.
+- **alternative:** Use ordinary parent-first URLClassLoader delegation — rejected: the S3 test implementation linked to the shaded interface and failed JUnit discovery.
+- **design:** ../design.md#rationale
+- **trust:** ✓ verified
+
+## Decision: relabel only the copied bootstrap plugin descriptor
+
+- **where:** `CI bootstrap workflow`
+- **why:** Maven requires the plugin descriptor version to match the external bootstrap coordinate, but propagating a revision property into parent POMs leaves standalone consumers unresolved. Updating the copied JAR descriptor creates a valid self-host coordinate without changing published metadata.
+- **alternative:** Use a reactor-wide Maven revision property — rejected: installed module POMs retained an unresolved parent revision when consumed outside the reactor.
+- **design:** ../design.md#rationale
+- **trust:** ✓ verified

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
         <central.skip.publishing>true</central.skip.publishing>
+        <blastradius.self.host.version>0.1.0-selfhost</blastradius.self.host.version>
 
         <jgit.version>7.7.0.202606012155-r</jgit.version>
         <jackson.version>2.17.1</jackson.version>
@@ -134,6 +135,28 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>self-host-blastradius</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.github.baokhang83.blastradius</groupId>
+                        <artifactId>blastradius-maven-plugin</artifactId>
+                        <version>${blastradius.self.host.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>select</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <baseRef>main</baseRef>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>release</id>
             <build>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <baseRef>main</baseRef>
+                            <baseRef>origin/main</baseRef>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
## Summary
- bootstrap the checked-out Maven plugin and run CI with test selection enabled
- persist the main-branch index in GitHub Actions cache and publish a combined multi-module PR summary
- harden self-hosted reactor tracking and test discovery
- clarify the repository CI behavior in the root README

## Validation
- `node --test .github/actions/blastradius-selection-summary/render-summary.test.cjs`
- `mvn -B --no-transfer-progress -pl blastradius-maven-plugin -Dtest=TestDiscovererTest,SelectMojoModeRoutingTest,ReactorTrackingGateTest test`
- bootstrap descriptor copy + `mvn -B --no-transfer-progress -Pself-host-blastradius -pl blastradius-core test`
- complete self-hosted reactor verification: `mvn -B --no-transfer-progress -Pself-host-blastradius clean verify`

## Reviewer notes
- The session contains two unverified early design decisions; later implementation choices and regression tests are verified.
- [Feature design](docs/fluencyloop/features/self-host-blastradius-test-selection-in-ci/design.md)