### PR TITLE
release: prepare 0.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,18 +39,21 @@ jobs:
             blastradius-index-${{ runner.os }}-jdk${{ matrix.java }}-
       - name: Bootstrap Blastradius plugin
         run: |
+          RELEASE_VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
+          SELF_HOST_VERSION="${RELEASE_VERSION}-selfhost"
+          export SELF_HOST_VERSION
           mvn -B --no-transfer-progress -DskipTests -Dinvoker.skip=true -pl blastradius-maven-plugin -am package
           mkdir -p target/self-host/META-INF/maven
-          cp blastradius-maven-plugin/target/blastradius-maven-plugin-0.1.0.jar target/blastradius-maven-plugin-0.1.0-selfhost.jar
-          unzip -p blastradius-maven-plugin/target/blastradius-maven-plugin-0.1.0.jar META-INF/maven/plugin.xml \
-            | perl -0pe 's{(<artifactId>blastradius-maven-plugin</artifactId>\s*<version>)0\.1\.0(</version>)}{$1 . "0.1.0-selfhost" . $2}e' \
+          cp "blastradius-maven-plugin/target/blastradius-maven-plugin-${RELEASE_VERSION}.jar" "target/blastradius-maven-plugin-${SELF_HOST_VERSION}.jar"
+          unzip -p "blastradius-maven-plugin/target/blastradius-maven-plugin-${RELEASE_VERSION}.jar" META-INF/maven/plugin.xml \
+            | perl -0pe 's{(<artifactId>blastradius-maven-plugin</artifactId>\s*<version>)[^<]+(</version>)}{$1 . $ENV{SELF_HOST_VERSION} . $2}e' \
             > target/self-host/META-INF/maven/plugin.xml
-          (cd target/self-host && jar uf ../blastradius-maven-plugin-0.1.0-selfhost.jar META-INF/maven/plugin.xml)
+          (cd target/self-host && jar uf "../blastradius-maven-plugin-${SELF_HOST_VERSION}.jar" META-INF/maven/plugin.xml)
           mvn -B --no-transfer-progress org.apache.maven.plugins:maven-install-plugin:3.1.2:install-file \
-            -Dfile=target/blastradius-maven-plugin-0.1.0-selfhost.jar \
+            -Dfile="target/blastradius-maven-plugin-${SELF_HOST_VERSION}.jar" \
             -DgroupId=io.github.baokhang83.blastradius \
             -DartifactId=blastradius-maven-plugin \
-            -Dversion=0.1.0-selfhost \
+            -Dversion="${SELF_HOST_VERSION}" \
             -Dpackaging=maven-plugin \
             -DgeneratePom=true
       - run: mvn -B --no-transfer-progress -Pself-host-blastradius clean verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.3.0] - 2026-07-26
+
+### Added
+
+- Self-hosted Blastradius test selection in this repository's GitHub Actions workflow,
+  including main-branch index caching and multi-module pull-request feedback.
+
+### Fixed
+
+- Maven reactor tracking now runs once per session, skips aggregator-only projects, and avoids
+  shaded-class collisions while discovering self-hosted tests.
+
 ## [0.1.0] - 2026-07-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ no heuristics, no opaque score.
 <plugin>
   <groupId>io.github.baokhang83.blastradius</groupId>
   <artifactId>blastradius-maven-plugin</artifactId>
-  <version>0.1.0</version>
+  <version>0.3.0</version>
   <executions>
     <execution>
       <phase>process-test-classes</phase>
@@ -65,7 +65,7 @@ store is a better fit for your runners:
 
 ```groovy
 plugins {
-  id 'io.github.baokhang83.blastradius' version '0.1.0'
+  id 'io.github.baokhang83.blastradius' version '0.3.0'
 }
 
 blastradius {

--- a/blastradius-core/pom.xml
+++ b/blastradius-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>blastradius-core</artifactId>

--- a/blastradius-maven-plugin/README.md
+++ b/blastradius-maven-plugin/README.md
@@ -63,7 +63,7 @@ Requires a Maven/JUnit 5 project and a resolvable repository for the plugin arti
 <plugin>
   <groupId>io.github.baokhang83.blastradius</groupId>
   <artifactId>blastradius-maven-plugin</artifactId>
-  <version>0.1.0</version>
+  <version>0.3.0</version>
   <executions>
     <execution>
       <phase>process-test-classes</phase>
@@ -261,7 +261,7 @@ jobs. Never place those values in the POM, Gradle build file, repository, or cac
 **`TRACK`** — a base-branch build, building/refreshing the index:
 
 ```
-[INFO] --- blastradius:0.1.0:select (default) @ your-project ---
+[INFO] --- blastradius:0.3.0:select (default) @ your-project ---
 [INFO] [blastradius] TRACK — building a fresh index
 [INFO] [blastradius] 2 / 2 tests selected (0.0% skipped)
 ```
@@ -272,7 +272,7 @@ computes a selection at all, it just reports how big the suite it ran full was.
 **`SELECT`** — a PR build, narrowed by a real index:
 
 ```
-[INFO] --- blastradius:0.1.0:select (default) @ your-project ---
+[INFO] --- blastradius:0.3.0:select (default) @ your-project ---
 [INFO] [blastradius] SELECT — index built from 4e02156 (2026-07-10T03:03:04Z)
 [INFO] [blastradius] 1 / 2 tests selected (50.0% skipped)
 [INFO] [blastradius]   dependency-matched: 1, new-or-modified: 0, fallback: 0
@@ -289,7 +289,7 @@ Add `-Dblastradius.explain=true` for the per-test breakdown that line is pointin
 **`FALLBACK`** — no usable index, running safe:
 
 ```
-[INFO] --- blastradius:0.1.0:select (default) @ your-project ---
+[INFO] --- blastradius:0.3.0:select (default) @ your-project ---
 [INFO] [blastradius] FALLBACK — no persisted index found (MISSING)
 [INFO] [blastradius] 2 / 2 tests selected (0.0% skipped)
 ```

--- a/blastradius-maven-plugin/pom.xml
+++ b/blastradius-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>blastradius-maven-plugin</artifactId>
@@ -22,7 +22,7 @@
         <connection>scm:git:https://github.com/baokhang83/blastradius.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/baokhang83/blastradius.git</developerConnection>
         <url>https://github.com/baokhang83/blastradius</url>
-        <tag>v0.1.0</tag>
+        <tag>v0.3.0</tag>
     </scm>
 
     <properties>

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
@@ -73,7 +73,7 @@ final class EndToEndTestSupport {
                         <plugin>
                             <groupId>io.github.baokhang83.blastradius</groupId>
                             <artifactId>blastradius-maven-plugin</artifactId>
-                            <version>0.1.0</version>
+                            <version>0.3.0</version>
                             <executions>
                                 <execution>
                                     <phase>process-test-classes</phase>
@@ -93,7 +93,7 @@ final class EndToEndTestSupport {
                         <plugin>
                             <groupId>io.github.baokhang83.blastradius</groupId>
                             <artifactId>blastradius-maven-plugin</artifactId>
-                            <version>0.1.0</version>
+                            <version>0.3.0</version>
                             <executions>
                                 <execution>
                                     <phase>process-test-classes</phase>
@@ -110,7 +110,7 @@ final class EndToEndTestSupport {
                         <plugin>
                             <groupId>io.github.baokhang83.blastradius</groupId>
                             <artifactId>blastradius-maven-plugin</artifactId>
-                            <version>0.1.0</version>
+                            <version>0.3.0</version>
                             <executions>
                                 <execution>
                                     <phase>process-test-classes</phase>

--- a/blastradius-s3-index-store/pom.xml
+++ b/blastradius-s3-index-store/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.3.0</version>
     </parent>
     <artifactId>blastradius-s3-index-store</artifactId>
     <name>blastradius S3 index store</name>

--- a/blastradius-validator/pom.xml
+++ b/blastradius-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.1.0</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>blastradius-validator</artifactId>

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
 allprojects {
     group = 'io.github.baokhang83.blastradius'
-    version = '0.1.0'
+    version = '0.3.0'
 }

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -3,7 +3,7 @@
 This repository publishes only:
 
 ```text
-io.github.baokhang83.blastradius:blastradius-maven-plugin:0.1.0
+io.github.baokhang83.blastradius:blastradius-maven-plugin:0.3.0
 ```
 
 `blastradius-core` and `blastradius-validator` are internal reactor modules. The plugin
@@ -61,16 +61,16 @@ unset MAVEN_GPG_PASSPHRASE
    mvn -B --no-transfer-progress -Prelease -Dgpg.skip=true clean verify
    ```
 
-2. Ensure the release commit is on `main`, its version is `0.1.0`, and the changelog is
+2. Ensure the release commit is on `main`, its version is `0.3.0`, and the changelog is
    final.
-3. Create and push the annotated `v0.1.0` tag. The tag workflow verifies that its commit
+3. Create and push the annotated `v0.3.0` tag. The tag workflow verifies that its commit
    is reachable from `main`, then runs `mvn -Prelease clean deploy`.
 4. Wait for Central Portal to report the deployment as published, then verify from a clean
    directory:
 
    ```bash
    mvn -B --no-transfer-progress \
-     io.github.baokhang83.blastradius:blastradius-maven-plugin:0.1.0:help
+     io.github.baokhang83.blastradius:blastradius-maven-plugin:0.3.0:help
    ```
 
 5. Copy the plugin configuration in the root [README](../README.md) into a small Git

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.baokhang83.blastradius</groupId>
     <artifactId>blastradius-parent</artifactId>
-    <version>0.1.0</version>
+    <version>0.3.0</version>
     <packaging>pom</packaging>
 
     <name>Blastradius parent</name>
@@ -38,7 +38,7 @@
         <connection>scm:git:https://github.com/baokhang83/blastradius.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/baokhang83/blastradius.git</developerConnection>
         <url>https://github.com/baokhang83/blastradius</url>
-        <tag>v0.1.0</tag>
+        <tag>v0.3.0</tag>
     </scm>
 
     <issueManagement>
@@ -60,7 +60,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.deploy.skip>true</maven.deploy.skip>
         <central.skip.publishing>true</central.skip.publishing>
-        <blastradius.self.host.version>0.1.0-selfhost</blastradius.self.host.version>
+        <blastradius.self.host.version>${project.version}-selfhost</blastradius.self.host.version>
 
         <jgit.version>7.7.0.202606012155-r</jgit.version>
         <jackson.version>2.17.1</jackson.version>


### PR DESCRIPTION
## Release 0.3.0

- updates Maven, Gradle, documentation, SCM, and plugin integration-test versions
- adds release notes for the self-hosted CI/test-selection work
- derives CI bootstrap artifact coordinates from the release version

## Validation
- `mvn -B --no-transfer-progress -Prelease -Dgpg.skip=true clean verify`
- dynamic self-host bootstrap followed by `mvn -B --no-transfer-progress -Pself-host-blastradius -pl blastradius-core test`

After this PR merges and its required checks pass, I will run the signing-only release workflow and tag `v0.3.0` to publish to Maven Central.