### PR TITLE
fix: retain empty test dependency baselines

### DIFF
--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
@@ -91,6 +91,25 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
         return null;
     }
 
+    /**
+     * Records that a test executed even if it never causes a class-load event while it is active.
+     *
+     * <p>An empty dependency map is meaningful: it is a baseline for an existing test, not an
+     * absent baseline for a newly added test. Selection must preserve that distinction or it
+     * conservatively re-runs every test whose dependencies happened to be loaded before the test
+     * began.
+     */
+    static void recordTestStarted(TestIdentity test) {
+        DependencyTrackingAgent currentAgent = installedAgent;
+        if (currentAgent != null) {
+            currentAgent.recordTestExecution(test);
+        }
+    }
+
+    void recordTestExecution(TestIdentity test) {
+        checksumsByTest.computeIfAbsent(test, ignored -> new ConcurrentHashMap<>());
+    }
+
     /** An immutable snapshot of {@code test -> {className -> tracking token}} recorded so far. */
     public Map<TestIdentity, Map<String, String>> recordedDependencies() {
         return checksumsByTest.entrySet().stream()

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/TestBoundaryListener.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/TestBoundaryListener.java
@@ -28,7 +28,12 @@ public final class TestBoundaryListener implements TestExecutionListener {
     @Override
     public void executionStarted(TestIdentifier testIdentifier) {
         if (testIdentifier.isTest()) {
-            CURRENT_TEST.set(toTestIdentity(testIdentifier));
+            TestIdentity test = toTestIdentity(testIdentifier);
+            // Register before publishing this identity to the agent. Computing the record's
+            // generated hash code may load JVM support classes; while no test is current those
+            // loads are intentionally ignored instead of recursively recording themselves.
+            DependencyTrackingAgent.recordTestStarted(test);
+            CURRENT_TEST.set(test);
             CLASSES_AT_TEST_START.set(DependencyTrackingAgent.loadedClasses());
         }
     }

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
@@ -67,6 +67,13 @@ class DependencyTrackingAgentTest {
     }
 
     @Test
+    void executedTestWithNoClassLoadsHasAnEmptyBaseline() {
+        agent.recordTestExecution(FOO_TEST);
+
+        assertEquals(Map.of(), agent.recordedDependencies().get(FOO_TEST));
+    }
+
+    @Test
     void newlyCreatedHiddenClassUsesItsStableSourceName() throws Exception {
         currentTest.set(FOO_TEST);
         byte[] classFile;

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingIntegrationTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingIntegrationTest.java
@@ -96,6 +96,33 @@ class DependencyTrackingIntegrationTest {
     }
 
     @Test
+    void testWithNoApplicationClassLoadsStillHasABaseline(@TempDir Path projectDir, @TempDir Path outDir)
+            throws Exception {
+        Path agentJar = findOwnAgentJar();
+        Path recordFile = outDir.resolve("deps.json");
+
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.addSystemDependency(null, agentJar);
+        fixture.writeTest("com.example.EmptyTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                class EmptyTest {
+                    @Test
+                    void doesNothing() {}
+                }
+                """);
+        fixture.commit("initial");
+
+        runMvnTest(projectDir, agentJar, recordFile);
+
+        Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(recordFile);
+        TestIdentity emptyTest = new TestIdentity("com.example.EmptyTest", "doesNothing");
+
+        assertTrue(recorded.containsKey(emptyTest),
+                "an executed test must have a baseline even without application class loads: " + recorded.keySet());
+    }
+
+    @Test
     void virtualThreadAttributionIncludesSealedAndHiddenClassLoadsOnJdk25(
             @TempDir Path projectDir, @TempDir Path outDir) throws Exception {
         Path agentJar = findOwnAgentJar();

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeSelectionTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeSelectionTest.java
@@ -1,6 +1,7 @@
 package io.github.baokhang83.blastradius.plugin.mojo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.baokhang83.blastradius.core.git.ChangedFile;
@@ -52,5 +53,18 @@ class SelectModeSelectionTest {
         assertEquals(1, decisions.size());
         assertTrue(decisions.get(0).selected());
         assertEquals(SelectionReason.NEW_OR_MODIFIED_TEST, decisions.get(0).reason());
+    }
+
+    @Test
+    void aTestWithAnEmptyTrackedBaselineIsNotTreatedAsNew() {
+        TestIdentity existingTest = new TestIdentity("com.example.EmptyTest", "doesNothing");
+        DependencyIndex index = new DependencyIndex("abc123", "2026-07-09T10:00:00Z", List.of(
+                new TestDependencyEntry(existingTest, Set.of())));
+
+        List<SelectionDecision> decisions = SelectMojo.computeDecisions(Set.of(existingTest), index, List.of());
+
+        assertEquals(1, decisions.size());
+        assertFalse(decisions.get(0).selected());
+        assertEquals(SelectionReason.NO_MATCH, decisions.get(0).reason());
     }
 }


### PR DESCRIPTION
## Summary
- persist an empty dependency baseline for every test that starts
- avoid agent re-entrancy while registering the test identity
- cover empty-baseline persistence and selection behavior

## Validation
- `mvn -B --no-transfer-progress -pl blastradius-core test`
- `mvn -B --no-transfer-progress -pl blastradius-maven-plugin -Dtest=SelectModeSelectionTest test`

After merge, the next successful `main` run refreshes the cached dependency index. Later PRs will no longer classify tests with no dynamic loads as new.