### PR TITLE
Fix CI test-selection cache integrity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .blastradius
-          key: blastradius-index-${{ runner.os }}-jdk${{ matrix.java }}-${{ github.sha }}
+          key: blastradius-index-v2-${{ runner.os }}-jdk${{ matrix.java }}-${{ github.sha }}
           restore-keys: |
-            blastradius-index-${{ runner.os }}-jdk${{ matrix.java }}-
+            blastradius-index-v2-${{ runner.os }}-jdk${{ matrix.java }}-
       - name: Bootstrap Blastradius plugin
         run: |
           RELEASE_VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
@@ -62,7 +62,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: .blastradius
-          key: blastradius-index-${{ runner.os }}-jdk${{ matrix.java }}-${{ github.sha }}
+          key: blastradius-index-v2-${{ runner.os }}-jdk${{ matrix.java }}-${{ github.sha }}
       - name: Publish Blastradius selection feedback
         if: ${{ always() }}
         uses: ./.github/actions/blastradius-selection-summary

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
@@ -92,7 +92,7 @@ public final class SelectMojo extends AbstractMojo {
      * this guard the subprocess's own {@code execute()} would resolve {@code TRACK} again
      * (same commit, same {@code baseRef}) and fork another subprocess, recursing without
      * bound. The tracking data comes entirely from the {@code -javaagent} attached via
-     * {@code JAVA_TOOL_OPTIONS}, not from this goal, so skipping is safe and correct.
+     * Surefire's {@code argLine}, not from this goal, so skipping is safe and correct.
      */
     @Parameter(property = "blastradius.trackChild", defaultValue = "false")
     private boolean trackChild;

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SurefireFilterApplier.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SurefireFilterApplier.java
@@ -16,6 +16,13 @@ import org.apache.maven.project.MavenProject;
 public final class SurefireFilterApplier {
 
     public void apply(MavenProject project, Set<TestIdentity> selectedTests) {
+        if (selectedTests.isEmpty()) {
+            // Surefire interprets an empty `test` property as no filter and runs every test.
+            // `skipTests` is the explicit Maven switch for a genuinely empty selection.
+            project.getProperties().remove("test");
+            project.getProperties().setProperty("skipTests", "true");
+            return;
+        }
         String filter = selectedTests.stream()
                 .map(SurefireFilterApplier::toSurefirePattern)
                 .collect(Collectors.joining(","));

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/track/TrackRunner.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/track/TrackRunner.java
@@ -14,8 +14,8 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Forks the target project's own {@code mvn test} as an independent subprocess, agent
- * attached via {@code JAVA_TOOL_OPTIONS}, to (re)build a {@link DependencyIndex} —
+ * Forks the target project's own {@code mvn test} as an independent subprocess, with the agent
+ * attached to Surefire via {@code argLine}, to (re)build a {@link DependencyIndex} —
  * reusing {@code blastradius-core}'s proven tracking mechanism unchanged (unique-file-
  * per-JVM, merge-on-read, {@code TestIdentity.baselineKey()} normalization). Deliberately
  * never instruments the live, currently-running build being gated (research.md #1).
@@ -35,15 +35,19 @@ public final class TrackRunner {
         }
 
         String agentOption = "-javaagent:" + agentJar.toAbsolutePath() + "=" + outputFile.toAbsolutePath();
+        String existingArgLine = System.getProperty("argLine");
+        String trackedArgLine = existingArgLine == null || existingArgLine.isBlank()
+                ? agentOption
+                : agentOption + " " + existingArgLine;
         // -Dblastradius.trackChild=true: this subprocess runs against the same pom that
         // binds this very goal, so without the flag its own SelectMojo execution would
         // resolve TRACK again (same commit, same baseRef) and recurse without bound — see
         // SelectMojo.trackChild's javadoc.
         ProcessBuilder processBuilder = new ProcessBuilder(
-                "mvn", "-B", "--no-transfer-progress", "-Dblastradius.trackChild=true", "clean", "test")
+                "mvn", "-B", "--no-transfer-progress", "-Dblastradius.trackChild=true",
+                "-DargLine=" + trackedArgLine, "clean", "test")
                 .directory(projectDir.toFile())
                 .redirectErrorStream(true);
-        processBuilder.environment().merge("JAVA_TOOL_OPTIONS", agentOption, (existing, added) -> existing + " " + added);
 
         runToCompletion(processBuilder, projectDir);
 
@@ -83,11 +87,10 @@ public final class TrackRunner {
                 throw new IllegalStateException(
                         "track run timed out against " + projectDir + " after " + TIMEOUT_MINUTES + "m");
             }
-            // A nonzero exit here typically means some tests failed, not that the build
-            // itself is broken — the agent still wrote whatever it observed regardless of
-            // pass/fail, so that data remains valid to track. A genuine build failure
-            // (e.g. a compile error) instead surfaces naturally: no dependency record file
-            // is ever produced, and DependencyRecordReader.readAll fails loudly for it.
+            if (process.exitValue() != 0) {
+                throw new IllegalStateException("track run failed against " + projectDir + " with exit code "
+                        + process.exitValue() + "; refusing to persist a partial dependency index");
+            }
         } catch (IOException e) {
             throw new UncheckedIOException("failed to invoke mvn test against " + projectDir, e);
         } catch (InterruptedException e) {

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SurefireFilterApplierTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SurefireFilterApplierTest.java
@@ -1,6 +1,7 @@
 package io.github.baokhang83.blastradius.plugin.mojo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
@@ -38,5 +39,16 @@ class SurefireFilterApplierTest {
         applier.apply(project, Set.of(classLevel));
 
         assertEquals("com.example.FooTest", project.getProperties().getProperty("test"));
+    }
+
+    @Test
+    void anEmptySelectionSkipsSurefireInsteadOfSettingAnEmptyTestFilter() {
+        MavenProject project = new MavenProject(new Model());
+        project.getProperties().setProperty("test", "previous.filter");
+
+        applier.apply(project, Set.of());
+
+        assertEquals("true", project.getProperties().getProperty("skipTests"));
+        assertNull(project.getProperties().getProperty("test"));
     }
 }

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/track/TrackRunnerTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/track/TrackRunnerTest.java
@@ -50,8 +50,8 @@ class TrackRunnerTest {
     }
 
     @Test
-    void tracksDownstreamModuleTestsWhenUsingTheShadedPluginAsTheAgent(@TempDir Path projectDir) throws Exception {
-        Path pluginJar = findOwnPluginJar();
+    void tracksDownstreamModuleTests(@TempDir Path projectDir) throws Exception {
+        Path agentJar = findOwnAgentJar();
         FixtureProjectBuilder fixture = FixtureProjectBuilder.twoModuleReactor(projectDir);
         fixture.writeClassInModule("moduleA", "com.example.a.Foo",
                 "package com.example.a; public class Foo { public int value() { return 42; } }");
@@ -73,7 +73,7 @@ class TrackRunnerTest {
                 """);
         String anchorCommit = fixture.commit("initial");
 
-        DependencyIndex index = trackRunner.track(projectDir, pluginJar, anchorCommit);
+        DependencyIndex index = trackRunner.track(projectDir, agentJar, anchorCommit);
 
         TestIdentity consumerTest = new TestIdentity("com.example.b.ConsumerTest", "checksValue");
         assertTrue(index.testDependenciesByTest().containsKey(consumerTest),
@@ -113,17 +113,6 @@ class TrackRunnerTest {
                     .orElseThrow(() -> new IllegalStateException(
                             "blastradius-core agent jar not found in ../blastradius-core/target — "
                                     + "expected the process-test-classes-phase jar execution to have produced it"));
-        }
-    }
-
-    private static Path findOwnPluginJar() throws IOException {
-        try (var stream = Files.list(Path.of("target"))) {
-            return stream
-                    .filter(p -> p.getFileName().toString().matches("blastradius-maven-plugin-.*\\.jar"))
-                    .filter(p -> !p.getFileName().toString().contains("sources"))
-                    .filter(p -> !p.getFileName().toString().contains("javadoc"))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalStateException("shaded blastradius plugin jar not found in target"));
         }
     }
 }

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/track/TrackRunnerTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/track/TrackRunnerTest.java
@@ -1,6 +1,7 @@
 package io.github.baokhang83.blastradius.plugin.track;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
@@ -48,6 +49,58 @@ class TrackRunnerTest {
                 "FooTest's tracked dependencies must include com.example.Foo");
     }
 
+    @Test
+    void tracksDownstreamModuleTestsWhenUsingTheShadedPluginAsTheAgent(@TempDir Path projectDir) throws Exception {
+        Path pluginJar = findOwnPluginJar();
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.twoModuleReactor(projectDir);
+        fixture.writeClassInModule("moduleA", "com.example.a.Foo",
+                "package com.example.a; public class Foo { public int value() { return 42; } }");
+        fixture.writeClassInModule("moduleB", "com.example.b.Consumer", """
+                package com.example.b;
+                import com.example.a.Foo;
+                public class Consumer {
+                    public int value() { return new Foo().value(); }
+                }
+                """);
+        fixture.writeTestInModule("moduleB", "com.example.b.ConsumerTest", """
+                package com.example.b;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class ConsumerTest {
+                    @Test
+                    void checksValue() { assertEquals(42, new Consumer().value()); }
+                }
+                """);
+        String anchorCommit = fixture.commit("initial");
+
+        DependencyIndex index = trackRunner.track(projectDir, pluginJar, anchorCommit);
+
+        TestIdentity consumerTest = new TestIdentity("com.example.b.ConsumerTest", "checksValue");
+        assertTrue(index.testDependenciesByTest().containsKey(consumerTest),
+                "expected downstream test in tracked index: " + index.testDependenciesByTest().keySet());
+        assertTrue(index.testDependenciesByTest().get(consumerTest).contains("com.example.a.Foo"),
+                "downstream test must retain its cross-module dependency");
+    }
+
+    @Test
+    void rejectsAPartialIndexWhenTheTrackedBuildFails(@TempDir Path projectDir) throws Exception {
+        Path agentJar = findOwnAgentJar();
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.addSystemDependency(null, agentJar);
+        fixture.writeTest("com.example.FailingTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.fail;
+                class FailingTest {
+                    @Test
+                    void fails() { fail("intentional"); }
+                }
+                """);
+        String anchorCommit = fixture.commit("initial");
+
+        assertThrows(IllegalStateException.class, () -> trackRunner.track(projectDir, agentJar, anchorCommit));
+    }
+
     private static Path findOwnAgentJar() throws IOException {
         Path targetDir = Path.of("..", "blastradius-core", "target");
         try (var stream = Files.list(targetDir)) {
@@ -60,6 +113,17 @@ class TrackRunnerTest {
                     .orElseThrow(() -> new IllegalStateException(
                             "blastradius-core agent jar not found in ../blastradius-core/target — "
                                     + "expected the process-test-classes-phase jar execution to have produced it"));
+        }
+    }
+
+    private static Path findOwnPluginJar() throws IOException {
+        try (var stream = Files.list(Path.of("target"))) {
+            return stream
+                    .filter(p -> p.getFileName().toString().matches("blastradius-maven-plugin-.*\\.jar"))
+                    .filter(p -> !p.getFileName().toString().contains("sources"))
+                    .filter(p -> !p.getFileName().toString().contains("javadoc"))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("shaded blastradius plugin jar not found in target"));
         }
     }
 }


### PR DESCRIPTION
## What changed

- Attach the tracking agent only to Surefire test forks through the Maven argLine property, preventing it from leaking into nested Maven processes.
- Reject a failed tracking subprocess instead of persisting a partial dependency index.
- Skip Surefire explicitly for an empty selection, rather than setting an empty test filter.
- Move CI index caches to the v2 namespace so the known partial cache is not restored.

## Root cause

The previous baseline cache was not overwritten or missing. A JAVA_TOOL_OPTIONS agent propagated into a nested Maven fixture during tracking; that fixture failed, but the tracker accepted its nonzero exit and persisted a partial baseline.

## Validation

- mvn -B --no-transfer-progress -pl blastradius-maven-plugin -Dtest=SurefireFilterApplierTest,TrackRunnerTest test
- mvn -B --no-transfer-progress -pl blastradius-maven-plugin -Dtest=TrackModeFirstBuildTest,IndexReuseAcrossBuildsTest test
- YAML parse and git diff --check