### PR TITLE
fix: fall back when CI tracking fails

### DIFF
--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
@@ -232,13 +232,22 @@ public final class SelectMojo extends AbstractMojo {
         String indexKey = CommitIndexKey.forCommit(indexPathKey, changes.currentCommit());
         DependencyIndex freshIndex;
         if (ReactorTrackingGate.claim(session.getUserProperties(), reactorRoot.toAbsolutePath().toString(), changes.currentCommit())) {
-            Path agentJar = locateCoreAgentJar();
-            freshIndex = trackRunner.track(reactorRoot, agentJar, changes.currentCommit());
-            indexStore.put(indexKey, freshIndex);
+            try {
+                Path agentJar = locateCoreAgentJar();
+                freshIndex = trackRunner.track(reactorRoot, agentJar, changes.currentCommit());
+                indexStore.put(indexKey, freshIndex);
+            } catch (MojoExecutionException | RuntimeException e) {
+                getLog().warn("[blastradius] tracking failed; discarding its incomplete dependency data and "
+                        + "falling back to the full suite", e);
+                runFallback(changes, IndexApplicability.internalError());
+                return;
+            }
         } else {
             freshIndex = indexStore.get(indexKey).orElse(null);
             if (freshIndex == null) {
-                throw new MojoExecutionException("the reactor tracking index was not available after another module claimed TRACK");
+                getLog().warn("[blastradius] no reactor tracking index was produced; falling back to the full suite");
+                runFallback(changes, IndexApplicability.internalError());
+                return;
             }
         }
 

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/track/TrackRunner.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/track/TrackRunner.java
@@ -6,6 +6,9 @@ import io.github.baokhang83.blastradius.plugin.index.DependencyIndex;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex.TestDependencyEntry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -23,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 public final class TrackRunner {
 
     private static final long TIMEOUT_MINUTES = 20;
+    private static final int FAILURE_OUTPUT_TAIL_BYTES = 12 * 1024;
 
     private final DependencyRecordReader recordReader = new DependencyRecordReader();
 
@@ -89,7 +93,8 @@ public final class TrackRunner {
             }
             if (process.exitValue() != 0) {
                 throw new IllegalStateException("track run failed against " + projectDir + " with exit code "
-                        + process.exitValue() + "; refusing to persist a partial dependency index");
+                        + process.exitValue() + "; refusing to persist a partial dependency index.\n"
+                        + "Last output from the tracking build:\n" + readOutputTail(outputFile));
             }
         } catch (IOException e) {
             throw new UncheckedIOException("failed to invoke mvn test against " + projectDir, e);
@@ -102,6 +107,21 @@ public final class TrackRunner {
             } catch (IOException ignored) {
                 // Best-effort cleanup; a stray temp log is not worth failing the build over.
             }
+        }
+    }
+
+    private static String readOutputTail(Path outputFile) {
+        try (SeekableByteChannel channel = Files.newByteChannel(outputFile)) {
+            long size = channel.size();
+            int length = (int) Math.min(size, FAILURE_OUTPUT_TAIL_BYTES);
+            channel.position(Math.max(0, size - length));
+            ByteBuffer buffer = ByteBuffer.allocate(length);
+            while (buffer.hasRemaining() && channel.read(buffer) != -1) {
+                // Continue until the requested tail is fully read or the file ends.
+            }
+            return StandardCharsets.UTF_8.decode(buffer.flip()).toString();
+        } catch (IOException e) {
+            return "(could not read tracking build output: " + e.getMessage() + ")";
         }
     }
 }

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/TrackModeFailureFallbackTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/TrackModeFailureFallbackTest.java
@@ -1,0 +1,87 @@
+package io.github.baokhang83.blastradius.plugin.mojo;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.baokhang83.blastradius.core.index.CommitIndexKey;
+import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TrackModeFailureFallbackTest {
+
+    @BeforeAll
+    static void installThisPluginOnce() throws Exception {
+        EndToEndTestSupport.installThisPluginOnce();
+    }
+
+    @Test
+    void aTrackingFailureDiscardsTheIndexAndLetsTheAmbientBuildRunAllTests(@TempDir Path projectDir)
+            throws Exception {
+        FixtureProjectBuilder fixture = EndToEndTestSupport.seedFooBarFixture(projectDir);
+        fixture.writeTest("com.example.TrackChildOnlyFailureTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.fail;
+                class TrackChildOnlyFailureTest {
+                    @Test
+                    void failsOnlyInsideTheTrackingSubprocess() {
+                        if (Boolean.getBoolean("blastradius.trackChild")) {
+                            fail("intentional tracking-child failure");
+                        }
+                    }
+                }
+                """);
+        String anchorCommit = fixture.commit("initial");
+        fixture.addBuildPlugin(null, EndToEndTestSupport.pluginXml(anchorCommit));
+
+        String output = EndToEndTestSupport.runMvnTest(projectDir);
+
+        assertTrue(output.contains("BUILD SUCCESS"), "expected the ambient build to succeed:\n" + output);
+        assertTrue(output.contains("[blastradius] FALLBACK"),
+                "expected failed tracking to report FALLBACK mode:\n" + output);
+        Path indexFile = projectDir.resolve(CommitIndexKey.forCommit(".blastradius/index.json", anchorCommit));
+        assertFalse(Files.exists(indexFile), "a failed tracking subprocess must not leave an index behind");
+    }
+
+    @Test
+    void everyReactorModuleFallsBackWhenTheSingleTrackingRunFails(@TempDir Path projectDir) throws Exception {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.twoModuleReactor(projectDir);
+        fixture.ignoreTargetDirectory();
+        fixture.writeClassInModule("moduleA", "com.example.a.Foo",
+                "package com.example.a; public class Foo { public int value() { return 1; } }");
+        fixture.writeTestInModule("moduleA", "com.example.a.TrackChildOnlyFailureTest", """
+                package com.example.a;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.fail;
+                class TrackChildOnlyFailureTest {
+                    @Test
+                    void failsOnlyInsideTheTrackingSubprocess() {
+                        if (Boolean.getBoolean("blastradius.trackChild")) {
+                            fail("intentional tracking-child failure");
+                        }
+                    }
+                }
+                """);
+        fixture.writeTestInModule("moduleB", "com.example.b.DownstreamTest", """
+                package com.example.b;
+                import org.junit.jupiter.api.Test;
+                class DownstreamTest { @Test void passes() {} }
+                """);
+        String anchorCommit = fixture.commit("initial");
+        String pluginXml = EndToEndTestSupport.pluginXml(anchorCommit);
+        fixture.addBuildPlugin("moduleA", pluginXml);
+        fixture.addBuildPlugin("moduleB", pluginXml);
+
+        String output = EndToEndTestSupport.runMvnTest(projectDir);
+
+        assertTrue(output.contains("BUILD SUCCESS"), "expected the reactor build to succeed:\n" + output);
+        assertTrue(output.contains("Running com.example.b.DownstreamTest"),
+                "expected the later module to run unfiltered after tracking failed:\n" + output);
+        Path indexFile = projectDir.resolve(CommitIndexKey.forCommit(".blastradius/index.json", anchorCommit));
+        assertFalse(Files.exists(indexFile), "a failed tracking subprocess must not leave an index behind");
+    }
+}

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/track/TrackRunnerTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/track/TrackRunnerTest.java
@@ -98,7 +98,10 @@ class TrackRunnerTest {
                 """);
         String anchorCommit = fixture.commit("initial");
 
-        assertThrows(IllegalStateException.class, () -> trackRunner.track(projectDir, agentJar, anchorCommit));
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class, () -> trackRunner.track(projectDir, agentJar, anchorCommit));
+        assertTrue(exception.getMessage().contains("intentional"),
+                "expected the tracking subprocess output in the failure diagnostic: " + exception.getMessage());
     }
 
     private static Path findOwnAgentJar() throws IOException {


### PR DESCRIPTION
Fixes the post-merge CI failure in both JDK 21 and JDK 25 jobs.

A failed tracking subprocess now discards partial dependency data and lets the ambient build run its full test suite. Later modules in the same reactor also safely fall back when no index was produced. The tracking error includes the final child Maven output for diagnosis.

Tests cover failed tracking in single-module and multi-module reactors, plus the failure diagnostic.