### PR TITLE
fix: cache module timing histories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,10 @@ jobs:
         id: blastradius-index
         uses: actions/cache/restore@v4
         with:
-          path: .blastradius
+          path: |
+            .blastradius
+            **/.blastradius
+            !**/target/**/.blastradius
           key: blastradius-index-v2-${{ runner.os }}-jdk${{ matrix.java }}-${{ github.sha }}
           restore-keys: |
             blastradius-index-v2-${{ runner.os }}-jdk${{ matrix.java }}-
@@ -61,7 +64,10 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' && success() && steps.blastradius-index.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
-          path: .blastradius
+          path: |
+            .blastradius
+            **/.blastradius
+            !**/target/**/.blastradius
           key: blastradius-index-v2-${{ runner.os }}-jdk${{ matrix.java }}-${{ github.sha }}
       - name: Publish Blastradius selection feedback
         if: ${{ always() }}


### PR DESCRIPTION
## Summary
- restore each module’s `.blastradius` directory with the root dependency index
- save the same directories after successful main builds
- preserve test timings so PR selection summaries can estimate time saved

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml")'`\n- `git diff --check`