### PR TITLE
Aggregate Blastradius feedback across JDK jobs

### DIFF
--- a/.github/actions/blastradius-selection-summary/render-summary.cjs
+++ b/.github/actions/blastradius-selection-summary/render-summary.cjs
@@ -82,7 +82,7 @@ function combineSelectionReports(reports) {
   };
 }
 
-function renderSelectionSummary(report) {
+function selectionStats(report) {
   if (typeof report !== 'object' || report === null || Array.isArray(report)) {
     throw new Error('report must be an object');
   }
@@ -100,6 +100,18 @@ function renderSelectionSummary(report) {
     throw new Error('estimatedTimeSavedMillis must be a non-negative integer or null');
   }
 
+  return {
+    selectedCount,
+    totalCount,
+    skippedCount,
+    estimatedTimeSavedMillis: estimate ?? null,
+    reasons: reasonCounts(report),
+  };
+}
+
+function renderSelectionSummary(report) {
+  const { selectedCount, totalCount, skippedCount, estimatedTimeSavedMillis, reasons } = selectionStats(report);
+  const estimate = estimatedTimeSavedMillis;
   const savings = estimate === undefined || estimate === null ? null : formatDuration(estimate);
   const lines = [
     COMMENT_MARKER,
@@ -112,7 +124,6 @@ function renderSelectionSummary(report) {
 
   if (!savings) lines.push('', 'Timing history is incomplete, so no time-saved estimate is shown.');
 
-  const reasons = reasonCounts(report);
   if (reasons.length > 0) {
     lines.push('', '### Reasons', '');
     for (const [reason, count] of reasons.sort(([left], [right]) => left.localeCompare(right))) {
@@ -123,4 +134,45 @@ function renderSelectionSummary(report) {
   return `${lines.join('\n')}\n`;
 }
 
-module.exports = { COMMENT_MARKER, combineSelectionReports, renderSelectionSummary };
+function renderMatrixSelectionSummary(jdkReports) {
+  if (!Array.isArray(jdkReports) || jdkReports.length === 0) {
+    throw new Error('jdkReports must be a non-empty array');
+  }
+
+  const summaries = jdkReports.map(({ jdk, report }) => {
+    if (typeof jdk !== 'string' || !/^\d+$/.test(jdk)) {
+      throw new Error('jdk must be a numeric version string');
+    }
+    return { jdk, ...selectionStats(report) };
+  }).sort((left, right) => Number(left.jdk) - Number(right.jdk));
+
+  const lines = [
+    COMMENT_MARKER,
+    '## Blastradius selection',
+    '',
+    '| JDK | Ran | Skipped | Estimated time saved |',
+    '| --- | ---: | ---: | ---: |',
+  ];
+
+  for (const summary of summaries) {
+    const savings = summary.estimatedTimeSavedMillis === null
+      ? 'Timing history incomplete'
+      : formatDuration(summary.estimatedTimeSavedMillis);
+    lines.push(`| ${summary.jdk} | ${summary.selectedCount}/${summary.totalCount} | ${summary.skippedCount} | ${savings} |`);
+  }
+
+  const summariesWithReasons = summaries.filter((summary) => summary.reasons.length > 0);
+  if (summariesWithReasons.length > 0) {
+    lines.push('', '### Reasons');
+    for (const summary of summariesWithReasons) {
+      lines.push('', `#### JDK ${summary.jdk}`, '');
+      for (const [reason, count] of summary.reasons.sort(([left], [right]) => left.localeCompare(right))) {
+        lines.push(`- ${displayReason(reason)}: ${count}`);
+      }
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+module.exports = { COMMENT_MARKER, combineSelectionReports, renderMatrixSelectionSummary, renderSelectionSummary };

--- a/.github/actions/blastradius-selection-summary/render-summary.test.cjs
+++ b/.github/actions/blastradius-selection-summary/render-summary.test.cjs
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { combineSelectionReports, renderSelectionSummary } = require('./render-summary.cjs');
+const { combineSelectionReports, renderMatrixSelectionSummary, renderSelectionSummary } = require('./render-summary.cjs');
 
 test('combines the module reports for a reactor-wide summary', () => {
   assert.deepEqual(combineSelectionReports([
@@ -66,4 +66,34 @@ test('rejects an invalid report rather than publishing misleading counts', () =>
     () => renderSelectionSummary({ selectedCount: 4, totalCount: 3 }),
     /selectedCount must not exceed totalCount/,
   );
+});
+
+test('renders one labelled row per JDK instead of combining matrix jobs', () => {
+  const rendered = renderMatrixSelectionSummary([
+    {
+      jdk: '25',
+      report: {
+        selectedCount: 12,
+        totalCount: 20,
+        skippedCount: 8,
+        estimatedTimeSavedMillis: null,
+        reasonCounts: { DEPENDENCY_MATCH: 12, NO_MATCH: 8 },
+      },
+    },
+    {
+      jdk: '21',
+      report: {
+        selectedCount: 10,
+        totalCount: 20,
+        skippedCount: 10,
+        estimatedTimeSavedMillis: 65000,
+        reasonCounts: { DEPENDENCY_MATCH: 10, NO_MATCH: 10 },
+      },
+    },
+  ]);
+
+  assert.match(rendered, /\| 21 \| 10\/20 \| 10 \| ~1m 5s \|/);
+  assert.match(rendered, /\| 25 \| 12\/20 \| 8 \| Timing history incomplete \|/);
+  assert.match(rendered, /#### JDK 21/);
+  assert.match(rendered, /#### JDK 25/);
 });

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:
@@ -78,4 +78,93 @@ jobs:
             blastradius-s3-index-store/.blastradius/last-build-report.json
             blastradius-validator/.blastradius/last-build-report.json
             blastradius-maven-plugin/.blastradius/last-build-report.json
+          comment: false
           github-token: ${{ github.token }}
+      - name: Upload Blastradius selection reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: blastradius-selection-report-jdk${{ matrix.java }}
+          path: |
+            blastradius-core/.blastradius/last-build-report.json
+            blastradius-s3-index-store/.blastradius/last-build-report.json
+            blastradius-validator/.blastradius/last-build-report.json
+            blastradius-maven-plugin/.blastradius/last-build-report.json
+          include-hidden-files: true
+          if-no-files-found: ignore
+          retention-days: 1
+
+  selection-feedback:
+    name: Publish Blastradius selection feedback
+    needs: verify
+    if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Download Blastradius selection reports
+        uses: actions/download-artifact@v7
+        with:
+          pattern: blastradius-selection-report-jdk*
+          path: selection-reports
+      - name: Publish one selection comment for all JDKs
+        uses: actions/github-script@v8
+        env:
+          REPORT_ROOT: selection-reports
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const {
+              COMMENT_MARKER,
+              combineSelectionReports,
+              renderMatrixSelectionSummary,
+            } = require(path.join(process.env.GITHUB_WORKSPACE, '.github/actions/blastradius-selection-summary/render-summary.cjs'));
+            const requiredReportPaths = [
+              'blastradius-core/.blastradius/last-build-report.json',
+              'blastradius-s3-index-store/.blastradius/last-build-report.json',
+              'blastradius-validator/.blastradius/last-build-report.json',
+              'blastradius-maven-plugin/.blastradius/last-build-report.json',
+            ];
+            const reportRoot = path.join(process.env.GITHUB_WORKSPACE, process.env.REPORT_ROOT);
+            const reports = [];
+
+            if (fs.existsSync(reportRoot)) {
+              for (const entry of fs.readdirSync(reportRoot, { withFileTypes: true })) {
+                const match = /^blastradius-selection-report-jdk(\d+)$/.exec(entry.name);
+                if (!entry.isDirectory() || !match) continue;
+
+                const artifactRoot = path.join(reportRoot, entry.name);
+                const missingPaths = requiredReportPaths.filter((reportPath) => !fs.existsSync(path.join(artifactRoot, reportPath)));
+                if (missingPaths.length > 0) {
+                  core.warning(`JDK ${match[1]} did not produce all selection reports.`);
+                  continue;
+                }
+
+                try {
+                  const moduleReports = requiredReportPaths.map((reportPath) => JSON.parse(fs.readFileSync(path.join(artifactRoot, reportPath), 'utf8')));
+                  reports.push({ jdk: match[1], report: combineSelectionReports(moduleReports) });
+                } catch (error) {
+                  core.warning(`Could not read the JDK ${match[1]} selection reports: ${error.message}`);
+                }
+              }
+            }
+
+            const body = reports.length > 0
+              ? renderMatrixSelectionSummary(reports)
+              : `${COMMENT_MARKER}\n## Blastradius selection\n\nNo selection report was produced by this build.\n`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const priorComment = comments.find((comment) => comment.user.type === 'Bot' && comment.body?.includes(COMMENT_MARKER));
+
+            if (priorComment) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: priorComment.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }


### PR DESCRIPTION
## Summary
- publish each JDK selection result as a short-lived artifact
- add one post-matrix PR feedback job that renders labelled JDK rows
- keep per-JDK job summaries while eliminating the competing comment upserts

## Validation
- `node --test .github/actions/blastradius-selection-summary/render-summary.test.cjs`
- `git diff --check`

Left unmerged for CI and follow-up testing.