### PR TITLE
Add JaCoCo coverage aggregation and README badge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,17 @@ jobs:
             -Dpackaging=maven-plugin \
             -DgeneratePom=true
       - run: mvn -B --no-transfer-progress -Pself-host-blastradius clean verify
+      - name: Generate JaCoCo badge
+        if: matrix.java == '21'
+        uses: cicirello/jacoco-badge-generator@v2
+        with:
+          jacoco-csv-file: coverage/target/site/jacoco-aggregate/jacoco.csv
+          badges-directory: coverage/target/site/jacoco-aggregate/badges
+      - name: Publish coverage report to GitHub Pages
+        if: matrix.java == '21' && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: coverage/target/site/jacoco-aggregate
       - name: Save Blastradius index from main
         if: ${{ github.ref == 'refs/heads/main' && success() && steps.blastradius-index.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Blastradius
 
+[![coverage](https://raw.githubusercontent.com/baokhang83/blastradius/refs/heads/gh-pages/badges/jacoco.svg)](https://baokhang83.github.io/blastradius/)
+
 Most "test impact analysis" tools guess from a static, per-module dependency graph, or
 train something probabilistic on historical flakiness. Blastradius does neither: a
 `-javaagent` observes every class *actually loaded* while each test runs, records it, and

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.github.baokhang83.blastradius</groupId>
+        <artifactId>blastradius-parent</artifactId>
+        <version>0.3.0</version>
+    </parent>
+
+    <artifactId>coverage</artifactId>
+    <name>coverage</name>
+    <description>Aggregates JaCoCo coverage across the other modules into one report. No product code.</description>
+
+    <!--
+        report-aggregate reads the exec data of THIS module's dependencies, so every measured
+        module is listed here. Built last (after all of them) so their jacoco.exec files already
+        exist.
+    -->
+    <dependencies>
+        <dependency>
+            <groupId>io.github.baokhang83.blastradius</groupId>
+            <artifactId>blastradius-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.baokhang83.blastradius</groupId>
+            <artifactId>blastradius-s3-index-store</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.baokhang83.blastradius</groupId>
+            <artifactId>blastradius-validator</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.baokhang83.blastradius</groupId>
+            <artifactId>blastradius-maven-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <configuration>
+                            <!-- CSV is what the badge generator reads; HTML for humans. -->
+                            <formats>
+                                <format>HTML</format>
+                                <format>CSV</format>
+                            </formats>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -11,6 +11,7 @@
     </parent>
 
     <artifactId>coverage</artifactId>
+    <packaging>pom</packaging>
     <name>coverage</name>
     <description>Aggregates JaCoCo coverage across the other modules into one report. No product code.</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
         <module>blastradius-s3-index-store</module>
         <module>blastradius-validator</module>
         <module>blastradius-maven-plugin</module>
+        <module>coverage</module>
     </modules>
 
     <properties>
@@ -78,6 +79,7 @@
         <invoker.plugin.version>3.10.1</invoker.plugin.version>
         <aws.sdk.version>2.41.33</aws.sdk.version>
         <slf4j.version>2.0.18</slf4j.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -128,6 +130,24 @@
                                 <dependencyConvergence />
                             </rules>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco-maven-plugin.version}</version>
+                <configuration>
+                    <includes>
+                        <include>io/github/baokhang83/blastradius/**</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -227,6 +247,7 @@
                                 <excludeArtifact>blastradius-parent</excludeArtifact>
                                 <excludeArtifact>blastradius-core</excludeArtifact>
                                 <excludeArtifact>blastradius-validator</excludeArtifact>
+                                <excludeArtifact>coverage</excludeArtifact>
                             </excludeArtifacts>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
## Summary
- Adds a `coverage` aggregator module (no product code) that runs JaCoCo's `report-aggregate` across `blastradius-core`, `blastradius-s3-index-store`, `blastradius-validator`, and `blastradius-maven-plugin` — mirrors the setup used in `mnemo-jvm-warden`.
- Wires the root `pom.xml` with `jacoco-maven-plugin`'s `prepare-agent`, scoped to `io/github/baokhang83/blastradius/**`.
- CI (`build.yml`) now generates a coverage badge from the aggregate CSV and publishes the HTML report to `gh-pages` on pushes to `main` (JDK 21 leg only, to avoid duplicate publishes across the matrix).
- README links the coverage badge from `gh-pages`.

## Test plan
- [x] `mvn clean verify` passes locally and produces `coverage/target/site/jacoco-aggregate/jacoco.csv` with per-module coverage data
- [ ] First CI run on `main` creates the `gh-pages` branch and the badge renders in the README