### PR TITLE
Normalize Surefire timings for selection estimates

### DIFF
--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/BuildReport.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/BuildReport.java
@@ -8,6 +8,7 @@ import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex;
 import io.github.baokhang83.blastradius.plugin.index.IndexApplicability;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -107,11 +108,19 @@ public record BuildReport(
         Objects.requireNonNull(changedFiles, "changedFiles");
         Objects.requireNonNull(decisions, "decisions");
         Objects.requireNonNull(durationsByTest, "durationsByTest");
+        Map<TestIdentity, Long> durationsByBaselineTest = durationsByTest.entrySet().stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        entry -> entry.getKey().baselineKey(),
+                        Map.Entry::getValue,
+                        Long::sum,
+                        HashMap::new));
         int selectedCount = (int) decisions.stream().filter(SelectionDecision::selected).count();
         List<SelectionDecision> skipped = decisions.stream().filter(decision -> !decision.selected()).toList();
-        int recordedSkippedTests = (int) skipped.stream().filter(decision -> durationsByTest.containsKey(decision.test())).count();
+        int recordedSkippedTests = (int) skipped.stream()
+                .filter(decision -> durationsByBaselineTest.containsKey(decision.test().baselineKey()))
+                .count();
         Long estimatedTimeSavedMillis = recordedSkippedTests == skipped.size()
-                ? skipped.stream().mapToLong(decision -> durationsByTest.get(decision.test())).sum()
+                ? skipped.stream().mapToLong(decision -> durationsByBaselineTest.get(decision.test().baselineKey())).sum()
                 : null;
         return new BuildReport(Mode.SELECT, applicability.status(), decisions, selectedCount, decisions.size(), null,
                 changedFiles, estimatedTimeSavedMillis, new TimingCoverage(recordedSkippedTests, skipped.size()));

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/BuildReportPopulationTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/BuildReportPopulationTest.java
@@ -8,6 +8,7 @@ import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex;
 import io.github.baokhang83.blastradius.plugin.index.IndexApplicability;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -49,5 +50,24 @@ class BuildReportPopulationTest {
 
         assertEquals(0, report.totalCount());
         assertEquals(0, report.selectedCount());
+    }
+
+    @Test
+    void normalizesSurefireMethodSignaturesBeforeEstimatingSkippedTestTime() {
+        TestIdentity pathInjection = new TestIdentity("com.example.PathTest", "writesToTempDirectory");
+        TestIdentity parameterized = new TestIdentity("com.example.ParameterizedTest", "handlesInput");
+        List<SelectionDecision> decisions = List.of(
+                SelectionDecision.noMatch(pathInjection),
+                SelectionDecision.noMatch(parameterized));
+        IndexApplicability applicability = IndexApplicability.applicable(
+                new DependencyIndex("abc123", "2026-07-09T10:00:00Z", List.of()));
+
+        BuildReport report = BuildReport.forSelect(applicability, List.of(), decisions, Map.of(
+                new TestIdentity("com.example.PathTest", "writesToTempDirectory(Path)"), 125L,
+                new TestIdentity("com.example.ParameterizedTest", "handlesInput(String)[1]"), 25L,
+                new TestIdentity("com.example.ParameterizedTest", "handlesInput(String)[2]"), 35L));
+
+        assertEquals(185L, report.estimatedTimeSavedMillis());
+        assertEquals(new TimingCoverage(2, 2), report.timingCoverage());
     }
 }


### PR DESCRIPTION
## Summary
- normalize Surefire method signatures such as `method(Path)` before timing lookup
- combine parameterized-invocation durations under their discovered test method
- allow a complete timing history to yield a savings estimate

## Evidence
PR #99 restored the cache but reported only 46/70 core, 25/61 validator, and 30/70 plugin skipped tests with matching timings. Surefire includes injected parameter types in XML method names while JUnit discovery does not.

## Validation
- `mvn -B --no-transfer-progress -pl blastradius-maven-plugin -am -Dtest=BuildReportPopulationTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`