### PR TITLE
Reuse reachable stale dependency indexes

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "self-host-blastradius-test-selection-in-ci",
-  "branch": "feature/self-host-blastradius-test-selection-in-ci",
+  "feature": "use-a-reachable-stale-dependency-index-as-a-conservative-tes",
+  "branch": "feature/use-a-reachable-stale-dependency-index-as-a-conservative-tes",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/self-host-blastradius-test-selection-in-ci/sessions/self-host-the-maven-reactor-in-ci.md",
-  "base_ref": "main",
+  "last_session": "docs/fluencyloop/features/use-a-reachable-stale-dependency-index-as-a-conservative-tes/sessions/specify-conservative-stale-baseline-selection.md",
+  "base_ref": "origin/main",
   "updated": "2026-07-26"
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/index/CommitIndexKey.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/index/CommitIndexKey.java
@@ -5,6 +5,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 /** Derives a stable, root-relative index key for one full Git commit ID. */
@@ -33,6 +34,23 @@ public final class CommitIndexKey {
         parts.add(commit.toLowerCase(Locale.ROOT));
         parts.add(indexPath.getFileName().toString());
         return String.join("/", parts);
+    }
+
+    /** Extracts the commit segment when {@code indexKey} has this index path's commit-keyed shape. */
+    public static Optional<String> commitFromKey(String indexPathKey, String indexKey) {
+        Path indexPath = relativeIndexPath(indexPathKey);
+        Path keyPath = relativeIndexPath(indexKey);
+        Path indexParent = indexPath.getParent();
+        Path keyParent = keyPath.getParent();
+        if (keyParent == null || !keyPath.getFileName().equals(indexPath.getFileName())) {
+            return Optional.empty();
+        }
+        Path keyGrandparent = keyParent.getParent();
+        if (indexParent == null ? keyGrandparent != null : !indexParent.equals(keyGrandparent)) {
+            return Optional.empty();
+        }
+        String commit = keyParent.getFileName().toString();
+        return FULL_COMMIT_ID.matcher(commit).matches() ? Optional.of(commit.toLowerCase(Locale.ROOT)) : Optional.empty();
     }
 
     private static Path relativeIndexPath(String indexPathKey) {

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/index/FileIndexStore.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/index/FileIndexStore.java
@@ -5,7 +5,9 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /** A JSON-backed {@link IndexStore} whose keys are constrained to one project directory. */
 public final class FileIndexStore<T> implements IndexStore<T> {
@@ -33,6 +35,24 @@ public final class FileIndexStore<T> implements IndexStore<T> {
             return Optional.of(value);
         } catch (IOException e) {
             throw new UncheckedIOException("failed to read dependency index from " + indexFile, e);
+        }
+    }
+
+    @Override
+    public List<String> keys(String prefix) {
+        Path prefixDirectory = prefix == null || prefix.isBlank() ? rootDirectory : resolveKey(prefix);
+        if (Files.notExists(prefixDirectory)) {
+            return List.of();
+        }
+        try (Stream<Path> paths = Files.walk(prefixDirectory)) {
+            return paths.filter(Files::isRegularFile)
+                    .map(rootDirectory::relativize)
+                    .map(Path::toString)
+                    .map(path -> path.replace('\\', '/'))
+                    .sorted()
+                    .toList();
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to list dependency indexes below " + prefix, e);
         }
     }
 

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/index/IndexStore.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/index/IndexStore.java
@@ -1,6 +1,7 @@
 package io.github.baokhang83.blastradius.core.index;
 
 import java.util.Optional;
+import java.util.List;
 
 /**
  * Stores dependency indexes under caller-defined, stable keys.
@@ -14,6 +15,9 @@ public interface IndexStore<T> {
 
     /** Returns the value for {@code key}, or empty when no value has been stored for it. */
     Optional<T> get(String key);
+
+    /** Returns stored keys below {@code prefix}, relative to the store root. */
+    List<String> keys(String prefix);
 
     /** Stores {@code value} under {@code key}, replacing a value previously stored for that key. */
     void put(String key, T value);

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/index/CommitIndexKeyTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/index/CommitIndexKeyTest.java
@@ -2,6 +2,7 @@ package io.github.baokhang83.blastradius.core.index;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -26,5 +27,17 @@ class CommitIndexKeyTest {
     @Test
     void rejectsAnAbbreviatedCommit() {
         assertThrows(IllegalArgumentException.class, () -> CommitIndexKey.forCommit(".blastradius/index.json", "0123456"));
+    }
+
+    @Test
+    void extractsOnlyACommitKeyForTheConfiguredIndexPath() {
+        assertEquals(
+                COMMIT,
+                CommitIndexKey.commitFromKey(
+                                ".blastradius/index.json", ".blastradius/" + COMMIT + "/index.json")
+                        .orElseThrow());
+        assertTrue(CommitIndexKey.commitFromKey(".blastradius/index.json", ".blastradius/" + COMMIT + "/other.json")
+                .isEmpty());
+        assertTrue(CommitIndexKey.commitFromKey(".blastradius/index.json", ".blastradius/index.json").isEmpty());
     }
 }

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/index/FileIndexStoreTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/index/FileIndexStoreTest.java
@@ -35,6 +35,28 @@ class FileIndexStoreTest {
     }
 
     @Test
+    void listsOnlyKeysBelowTheRequestedPrefixInStableOrder() {
+        IndexStore<StoredIndex> store = new FileIndexStore<>(rootDirectory, StoredIndex.class);
+        store.put(".blastradius/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/index.json", new StoredIndex("b", List.of()));
+        store.put(".blastradius/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/index.json", new StoredIndex("a", List.of()));
+        store.put("other/index.json", new StoredIndex("other", List.of()));
+
+        assertEquals(
+                List.of(
+                        ".blastradius/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/index.json",
+                        ".blastradius/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/index.json"),
+                store.keys(".blastradius"));
+    }
+
+    @Test
+    void listsFromTheStoreRootWhenThePrefixIsEmpty() {
+        IndexStore<StoredIndex> store = new FileIndexStore<>(rootDirectory, StoredIndex.class);
+        store.put("index.json", new StoredIndex("root", List.of()));
+
+        assertEquals(List.of("index.json"), store.keys(""));
+    }
+
+    @Test
     void rejectsKeyThatEscapesConfiguredRoot() {
         IndexStore<StoredIndex> store = new FileIndexStore<>(rootDirectory, StoredIndex.class);
 

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/diff/CurrentChangesResolver.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/diff/CurrentChangesResolver.java
@@ -35,4 +35,15 @@ public final class CurrentChangesResolver {
                 comparison.baseReferenceBuild(),
                 changedFiles);
     }
+
+    /** Recomputes the changed files from a validated stale index anchor through the current HEAD. */
+    public CurrentChanges resolveFromAnchor(Path projectDir, CurrentChanges changes, String anchorCommit) {
+        return new CurrentChanges(
+                changes.baseReference(),
+                changes.resolvedBaseCommit(),
+                java.util.Optional.of(anchorCommit),
+                changes.currentCommit(),
+                false,
+                changedFileClassifier.classify(projectDir, anchorCommit, changes.currentCommit()));
+    }
 }

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicability.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicability.java
@@ -10,6 +10,7 @@ public record IndexApplicability(Status status, DependencyIndex index) {
 
     public enum Status {
         APPLICABLE,
+        STALE_BASELINE,
         MISSING,
         UNREADABLE,
         FORMAT_VERSION_MISMATCH,
@@ -28,6 +29,10 @@ public record IndexApplicability(Status status, DependencyIndex index) {
 
     public static IndexApplicability applicable(DependencyIndex index) {
         return new IndexApplicability(Status.APPLICABLE, index);
+    }
+
+    public static IndexApplicability staleBaseline(DependencyIndex index) {
+        return new IndexApplicability(Status.STALE_BASELINE, index);
     }
 
     public static IndexApplicability missing() {

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolver.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolver.java
@@ -1,8 +1,11 @@
 package io.github.baokhang83.blastradius.plugin.index;
 
 import io.github.baokhang83.blastradius.core.index.IndexStore;
+import io.github.baokhang83.blastradius.core.index.CommitIndexKey;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.Optional;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevWalk;
@@ -39,6 +42,77 @@ public final class IndexApplicabilityResolver {
 
         return IndexApplicability.applicable(index);
     }
+
+    /**
+     * Resolves the exact comparison-base index first. When that exact key is absent, an older
+     * index is usable only if its anchor is an ancestor of the commit being tested. Callers must
+     * then expand their change set from that anchor through the tested commit.
+     */
+    public IndexApplicability resolve(
+            IndexStore<DependencyIndex> store,
+            String exactIndexKey,
+            String indexPathKey,
+            String expectedAnchorCommit,
+            String currentCommit,
+            Path projectDir) {
+        IndexApplicability exact = resolve(store, exactIndexKey, expectedAnchorCommit, projectDir);
+        if (exact.status() != IndexApplicability.Status.MISSING) {
+            return exact;
+        }
+
+        try {
+            return store.keys(parentPrefix(indexPathKey)).stream()
+                    .map(key -> CommitIndexKey.commitFromKey(indexPathKey, key)
+                            .flatMap(commit -> readCandidate(store, key, commit, currentCommit, projectDir)))
+                    .flatMap(Optional::stream)
+                .min(Comparator.comparingInt(Candidate::distanceFromHead))
+                    .map(candidate -> IndexApplicability.staleBaseline(candidate.index()))
+                    .orElseGet(IndexApplicability::missing);
+        } catch (UncheckedIOException e) {
+            return IndexApplicability.unreadable();
+        }
+    }
+
+    private static Optional<Candidate> readCandidate(IndexStore<DependencyIndex> store, String key, String keyCommit,
+            String currentCommit, Path projectDir) {
+        DependencyIndex index = store.get(key).orElse(null);
+        if (index == null || !index.hasCurrentFormat() || !index.anchorCommit().equals(keyCommit)) {
+            return Optional.empty();
+        }
+        return distanceFromHead(index.anchorCommit(), currentCommit, projectDir)
+                .map(distance -> new Candidate(index, distance));
+    }
+
+    private static String parentPrefix(String indexPathKey) {
+        Path parent = Path.of(indexPathKey).normalize().getParent();
+        return parent == null ? "" : parent.toString().replace('\\', '/');
+    }
+
+    private static Optional<Integer> distanceFromHead(String anchorCommit, String currentCommit, Path projectDir) {
+        try (org.eclipse.jgit.api.Git git = org.eclipse.jgit.api.Git.open(projectDir.toFile())) {
+            Repository repository = git.getRepository();
+            ObjectId anchorId = repository.resolve(anchorCommit);
+            ObjectId headId = repository.resolve(currentCommit);
+            if (anchorId == null || headId == null) {
+                return Optional.empty();
+            }
+            try (RevWalk walk = new RevWalk(repository)) {
+                var anchor = walk.parseCommit(anchorId);
+                var head = walk.parseCommit(headId);
+                if (!walk.isMergedInto(anchor, head)) {
+                    return Optional.empty();
+                }
+            }
+            try (RevWalk walk = new RevWalk(repository)) {
+                return Optional.of(org.eclipse.jgit.revwalk.RevWalkUtils.count(
+                        walk, walk.parseCommit(headId), walk.parseCommit(anchorId)));
+            }
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    private record Candidate(DependencyIndex index, int distanceFromHead) {}
 
     private static boolean anchorIsReachable(String anchorCommit, Path projectDir) {
         try (org.eclipse.jgit.api.Git git = org.eclipse.jgit.api.Git.open(projectDir.toFile())) {

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
@@ -153,13 +153,20 @@ public final class SelectMojo extends AbstractMojo {
             } catch (IllegalStateException e) {
                 throw new MojoExecutionException("invalid configuration: " + e.getMessage(), e);
             }
-            IndexApplicability applicability = changes.comparisonBaseCommit()
+            CurrentChanges initialChanges = changes;
+            IndexApplicability applicability = initialChanges.comparisonBaseCommit()
                     .map(comparisonBase -> indexApplicabilityResolver.resolve(
                             indexStore,
                             CommitIndexKey.forCommit(indexPathKey, comparisonBase),
+                            indexPathKey,
                             comparisonBase,
+                            initialChanges.currentCommit(),
                             reactorRoot))
                     .orElseGet(IndexApplicability::mergeBaseUnavailable);
+            if (applicability.status() == IndexApplicability.Status.STALE_BASELINE) {
+                changes = currentChangesResolver.resolveFromAnchor(
+                        reactorRoot, changes, applicability.index().anchorCommit());
+            }
 
             BuildReport.Mode resolvedMode = determineMode(changes, applicability, mode);
             Map<TestIdentity, Long> durationsByTest = timingHistoryStore.load(timingHistoryPath()).durationsByTest();
@@ -211,7 +218,8 @@ public final class SelectMojo extends AbstractMojo {
         if (changes.isBaseRefBuild() || "track".equalsIgnoreCase(explicitMode)) {
             return BuildReport.Mode.TRACK;
         }
-        if (applicability.status() == IndexApplicability.Status.APPLICABLE) {
+        if (applicability.status() == IndexApplicability.Status.APPLICABLE
+                || applicability.status() == IndexApplicability.Status.STALE_BASELINE) {
             return BuildReport.Mode.SELECT;
         }
         return BuildReport.Mode.FALLBACK;

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/ConsoleSummaryRenderer.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/ConsoleSummaryRenderer.java
@@ -40,7 +40,9 @@ public final class ConsoleSummaryRenderer {
 
     private static String headerLine(BuildReport report, DependencyIndex usedIndex) {
         return switch (report.mode()) {
-            case SELECT -> "SELECT — index built from " + shortSha(usedIndex.anchorCommit()) + " (" + usedIndex.builtAt() + ")";
+            case SELECT -> report.indexApplicability() == IndexApplicability.Status.STALE_BASELINE
+                    ? "SELECT — stale baseline index built from " + shortSha(usedIndex.anchorCommit()) + " (" + usedIndex.builtAt() + ")"
+                    : "SELECT — index built from " + shortSha(usedIndex.anchorCommit()) + " (" + usedIndex.builtAt() + ")";
             case TRACK -> "TRACK — building a fresh index";
             case FALLBACK -> "FALLBACK — " + fallbackReason(report.indexApplicability());
         };
@@ -55,7 +57,7 @@ public final class ConsoleSummaryRenderer {
             case ANCHOR_MISMATCH -> "persisted index does not match the resolved comparison base (ANCHOR_MISMATCH)";
             case MERGE_BASE_UNAVAILABLE -> "Git could not establish a common comparison base (MERGE_BASE_UNAVAILABLE)";
             case INTERNAL_ERROR -> "an internal error occurred during selection computation (INTERNAL_ERROR)";
-            case APPLICABLE -> throw new IllegalStateException("FALLBACK mode never has an APPLICABLE index");
+            case APPLICABLE, STALE_BASELINE -> throw new IllegalStateException("FALLBACK mode never has an applicable index");
         };
     }
 

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/diff/CurrentChangesResolverTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/diff/CurrentChangesResolverTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.github.baokhang83.blastradius.core.git.FileKind;
 import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
 import java.nio.file.Path;
+import java.util.List;
 import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -84,5 +85,25 @@ class CurrentChangesResolverTest {
         assertEquals(branchPoint, changes.comparisonBaseCommit().orElseThrow());
         assertEquals(1, changes.changedFiles().size());
         assertEquals("com.example.FeatureOnly", changes.changedFiles().get(0).changedClassName());
+    }
+
+    @Test
+    void widensAnExistingComparisonToAReachableStaleAnchor(@TempDir Path projectDir) {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        String staleAnchor = fixture.commit("initial");
+        fixture.writeClass("com.example.Intervening", "package com.example; class Intervening {}");
+        String currentBase = fixture.commit("intervening main change");
+        fixture.writeClass("com.example.FeatureOnly", "package com.example; class FeatureOnly {}");
+        fixture.commit("feature change");
+
+        CurrentChanges initiallyResolved = resolver.resolve(projectDir, currentBase);
+        CurrentChanges widened = resolver.resolveFromAnchor(projectDir, initiallyResolved, staleAnchor);
+
+        assertEquals(staleAnchor, widened.comparisonBaseCommit().orElseThrow());
+        assertEquals(initiallyResolved.currentCommit(), widened.currentCommit());
+        assertFalse(widened.isBaseRefBuild());
+        assertEquals(
+                List.of("com.example.FeatureOnly", "com.example.Intervening"),
+                widened.changedFiles().stream().map(change -> change.changedClassName()).sorted().toList());
     }
 }

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolverTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolverTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.github.baokhang83.blastradius.core.index.FileIndexStore;
+import io.github.baokhang83.blastradius.core.index.CommitIndexKey;
 import io.github.baokhang83.blastradius.core.index.DependencyIndexFormat;
 import io.github.baokhang83.blastradius.core.index.IndexStore;
 import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
@@ -87,6 +88,35 @@ class IndexApplicabilityResolverTest {
 
         assertEquals(IndexApplicability.Status.ANCHOR_MISMATCH, applicability.status());
         assertNull(applicability.index());
+    }
+
+    @Test
+    void usesNearestReachableAncestorWhenTheExactBaselineIsMissing(@TempDir Path projectDir) {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        String oldestAnchor = fixture.commit("oldest baseline");
+        fixture.writeClass("com.example.Stale", "package com.example; class Stale {}");
+        String staleAnchor = fixture.commit("stale baseline");
+        fixture.writeClass("com.example.Expected", "package com.example; class Expected {}");
+        String expectedBase = fixture.commit("expected base without an index");
+        fixture.writeClass("com.example.Feature", "package com.example; class Feature {}");
+        String head = fixture.commit("feature change");
+
+        DependencyIndex olderIndex = new DependencyIndex(oldestAnchor, "2026-07-09T10:00:00Z", List.of());
+        DependencyIndex staleIndex = new DependencyIndex(staleAnchor, "2026-07-09T10:00:00Z", List.of());
+        IndexStore<DependencyIndex> store = store(projectDir);
+        store.put(CommitIndexKey.forCommit(INDEX_KEY, oldestAnchor), olderIndex);
+        store.put(CommitIndexKey.forCommit(INDEX_KEY, staleAnchor), staleIndex);
+
+        IndexApplicability applicability = resolver.resolve(
+                store,
+                CommitIndexKey.forCommit(INDEX_KEY, expectedBase),
+                INDEX_KEY,
+                expectedBase,
+                head,
+                projectDir);
+
+        assertEquals(IndexApplicability.Status.STALE_BASELINE, applicability.status());
+        assertEquals(staleIndex, applicability.index());
     }
 
     @Test

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeEndToEndTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeEndToEndTest.java
@@ -225,4 +225,60 @@ class SelectModeEndToEndTest {
         assertTrue(output.contains("Running com.example.FooTest"), "expected FooTest to run:\n" + output);
         assertFalse(output.contains("Running com.example.BarTest"), "expected BarTest to remain skipped:\n" + output);
     }
+
+    @Test
+    void usesAReachableStaleBaselineAndWidensTheDiffToCoverInterveningMainChanges(@TempDir Path projectDir)
+            throws Exception {
+        FixtureProjectBuilder fixture = EndToEndTestSupport.seedFooBarFixture(projectDir);
+        String staleAnchor = fixture.commit("initial");
+        DependencyIndex index = EndToEndTestSupport.trackDependencies(projectDir, staleAnchor);
+        EndToEndTestSupport.writeIndex(projectDir, index);
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setCreateBranch(true).setName("feature").call();
+        }
+        fixture.writeClass("com.example.Foo",
+                "package com.example; public class Foo { public int value() { return 99; } }");
+        fixture.writeTest("com.example.FooTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class FooTest {
+                    @Test
+                    void checksFoo() { assertEquals(99, new Foo().value()); }
+                }
+                """);
+        fixture.commit("feature changes Foo");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setName("main").call();
+        }
+        fixture.writeClass("com.example.Bar",
+                "package com.example; public class Bar { public int value() { return 7; } }");
+        fixture.writeTest("com.example.BarTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class BarTest {
+                    @Test
+                    void checksBar() { assertEquals(7, new Bar().value()); }
+                }
+                """);
+        fixture.commit("main changes Bar without a new index");
+
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setCreateBranch(true).setName("merge-result").call();
+            git.merge().include(git.getRepository().resolve("feature")).call();
+        }
+        fixture.addBuildPlugin(null, EndToEndTestSupport.pluginXml("main"));
+
+        String output = EndToEndTestSupport.runMvnTest(projectDir);
+
+        assertTrue(output.contains("BUILD SUCCESS"), "expected the build to succeed:\n" + output);
+        assertTrue(output.contains("SELECT — stale baseline index built from " + staleAnchor.substring(0, 7)), output);
+        assertTrue(output.contains("[blastradius] 2 / 2 tests selected"), output);
+        assertTrue(output.contains("Running com.example.FooTest"), "expected FooTest to run:\n" + output);
+        assertTrue(output.contains("Running com.example.BarTest"),
+                "expected BarTest to run because the stale baseline widens the diff:\n" + output);
+    }
 }

--- a/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/AwsS3ObjectStore.java
+++ b/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/AwsS3ObjectStore.java
@@ -3,6 +3,7 @@ package io.github.baokhang83.blastradius.s3;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Optional;
+import java.util.List;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -10,6 +11,7 @@ import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -43,6 +45,20 @@ final class AwsS3ObjectStore implements S3ObjectStore {
             throw unavailable("read", key, e);
         } catch (SdkException e) {
             throw unavailable("read", key, e);
+        }
+    }
+
+    @Override
+    public List<String> keys(String prefix) {
+        try {
+            return client.listObjectsV2Paginator(ListObjectsV2Request.builder().bucket(bucket).prefix(prefix).build())
+                    .stream()
+                    .flatMap(response -> response.contents().stream())
+                    .map(object -> object.key())
+                    .sorted()
+                    .toList();
+        } catch (SdkException e) {
+            throw unavailable("list", prefix, e);
         }
     }
 

--- a/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/S3IndexStore.java
+++ b/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/S3IndexStore.java
@@ -7,6 +7,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.List;
 
 /** A JSON-backed {@link IndexStore} whose values live under an S3 object-key prefix. */
 public final class S3IndexStore<T> implements IndexStore<T>, AutoCloseable {
@@ -25,6 +26,12 @@ public final class S3IndexStore<T> implements IndexStore<T>, AutoCloseable {
     @Override
     public Optional<T> get(String key) {
         return objects.get(objectKey(key)).map(this::deserialize);
+    }
+
+    @Override
+    public List<String> keys(String prefix) {
+        String objectPrefix = objectPrefix(prefix);
+        return objects.keys(objectPrefix).stream().map(this::relativeKey).toList();
     }
 
     @Override
@@ -67,6 +74,24 @@ public final class S3IndexStore<T> implements IndexStore<T>, AutoCloseable {
         } catch (InvalidPathException e) {
             throw new IllegalArgumentException("invalid index key: " + key, e);
         }
+    }
+
+    private String objectPrefix(String relativePrefix) {
+        if (relativePrefix == null || relativePrefix.isBlank()) {
+            return prefix;
+        }
+        return objectKey(relativePrefix);
+    }
+
+    private String relativeKey(String objectKey) {
+        if (prefix.isEmpty()) {
+            return objectKey;
+        }
+        String prefixWithSeparator = prefix + "/";
+        if (!objectKey.startsWith(prefixWithSeparator)) {
+            throw new IllegalArgumentException("S3 object key is outside the configured prefix: " + objectKey);
+        }
+        return objectKey.substring(prefixWithSeparator.length());
     }
 
     private static String normalizePrefix(String prefix) {

--- a/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/S3ObjectStore.java
+++ b/blastradius-s3-index-store/src/main/java/io/github/baokhang83/blastradius/s3/S3ObjectStore.java
@@ -1,11 +1,14 @@
 package io.github.baokhang83.blastradius.s3;
 
 import java.util.Optional;
+import java.util.List;
 
 /** Byte-oriented object operations needed by {@link S3IndexStore}. */
 interface S3ObjectStore extends AutoCloseable {
 
     Optional<byte[]> get(String key);
+
+    List<String> keys(String prefix);
 
     void put(String key, byte[] value);
 

--- a/blastradius-s3-index-store/src/test/java/io/github/baokhang83/blastradius/s3/S3IndexStoreTest.java
+++ b/blastradius-s3-index-store/src/test/java/io/github/baokhang83/blastradius/s3/S3IndexStoreTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,24 @@ class S3IndexStoreTest {
     }
 
     @Test
+    void listsRelativeKeysBelowTheConfiguredPrefix() {
+        S3IndexStore<StoredIndex> store = new S3IndexStore<>(new InMemoryObjectStore(), "ci", StoredIndex.class);
+        store.put(".blastradius/one/index.json", new StoredIndex("one"));
+        store.put(".blastradius/two/index.json", new StoredIndex("two"));
+
+        assertEquals(List.of(".blastradius/one/index.json", ".blastradius/two/index.json"),
+                store.keys(".blastradius"));
+    }
+
+    @Test
+    void listsFromTheConfiguredStoreRootWhenThePrefixIsEmpty() {
+        S3IndexStore<StoredIndex> store = new S3IndexStore<>(new InMemoryObjectStore(), "ci", StoredIndex.class);
+        store.put("index.json", new StoredIndex("root"));
+
+        assertEquals(List.of("index.json"), store.keys(""));
+    }
+
+    @Test
     void rejectsObjectKeysThatEscapeTheConfiguredPrefix() {
         S3IndexStore<StoredIndex> store = new S3IndexStore<>(new InMemoryObjectStore(), "ci", StoredIndex.class);
 
@@ -45,6 +64,11 @@ class S3IndexStoreTest {
         @Override
         public Optional<byte[]> get(String key) {
             return Optional.ofNullable(values.get(key));
+        }
+
+        @Override
+        public List<String> keys(String prefix) {
+            return values.keySet().stream().filter(key -> key.startsWith(prefix)).sorted().toList();
         }
 
         @Override

--- a/docs/fluencyloop/features/use-a-reachable-stale-dependency-index-as-a-conservative-tes/design.md
+++ b/docs/fluencyloop/features/use-a-reachable-stale-dependency-index-as-a-conservative-tes/design.md
@@ -1,0 +1,73 @@
+# Design: Use a reachable stale dependency index as a conservative test-selection baseline
+
+started: 2026-07-26
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class IndexStore~T~ {
+    +get(key) Optional~T~
+    +put(key, value)
+    +keys(prefix) List~String~
+  }
+  class FileIndexStore~T~
+  class S3IndexStore~T~
+  class BaselineIndexResolver {
+    +resolve(store, exactKey, prefix, expectedBase, head) BaselineResolution
+  }
+  class BaselineResolution {
+    +index DependencyIndex
+    +anchorCommit String
+    +stale boolean
+  }
+  class CurrentChangesResolver {
+    +resolveFromAnchor(project, changes, anchor) CurrentChanges
+  }
+  class SelectMojo
+
+  IndexStore <|.. FileIndexStore
+  IndexStore <|.. S3IndexStore
+  BaselineIndexResolver --> IndexStore
+  SelectMojo --> BaselineIndexResolver
+  SelectMojo --> CurrentChangesResolver
+  BaselineResolution --> DependencyIndex
+```
+
+## Sequence: select with a stale baseline
+
+```mermaid
+sequenceDiagram
+  participant Mojo as SelectMojo
+  participant Resolver as BaselineIndexResolver
+  participant Store as IndexStore
+  participant Git as CurrentChangesResolver
+  participant Engine as SelectionEngine
+
+  Mojo->>Resolver: resolve exact base and ancestor candidates
+  Resolver->>Store: get exact commit key
+  alt Exact baseline exists
+    Store-->>Resolver: exact index
+    Resolver-->>Mojo: exact baseline
+  else Exact baseline missing
+    Resolver->>Store: keys below index prefix
+    Resolver->>Resolver: keep valid ancestors of HEAD and choose nearest
+    Resolver-->>Mojo: stale baseline with anchor
+    Mojo->>Git: diff anchor to HEAD
+    Git-->>Mojo: widened changed files
+  end
+  Mojo->>Engine: select using baseline index and changed files
+  Engine-->>Mojo: conservative selected tests
+```
+
+## Design decision
+
+The exact base-commit index remains preferred. If it is unavailable, the plugin may use
+the nearest valid ancestor index only when the anchor is reachable from the tested HEAD.
+It then computes changes from that anchor through HEAD, which includes intervening main
+changes and the PR change. An unrelated or descendant index is never used; if no ancestor
+baseline is available, the build still runs the full suite.
+
+The index-store interface grows a prefix enumeration operation because both supported
+backends, filesystem and S3, need to expose the same candidate search. This is a concrete
+shared need, rather than a speculative abstraction.

--- a/docs/fluencyloop/features/use-a-reachable-stale-dependency-index-as-a-conservative-tes/sessions/specify-conservative-stale-baseline-selection.md
+++ b/docs/fluencyloop/features/use-a-reachable-stale-dependency-index-as-a-conservative-tes/sessions/specify-conservative-stale-baseline-selection.md
@@ -1,0 +1,34 @@
+# Session: Specify conservative stale baseline selection
+
+- **intent:** Specify conservative stale baseline selection
+- **started:** 2026-07-26
+
+<!--
+FluencyLoop Stage 3 — a session is a slice of the build. One block per meaningful decision,
+appended at the slice boundary as it's taught. No `commits:` field: the feature is a branch,
+so the PR view derives commits live from git.
+
+Each decision is a `## Decision:` heading followed by a bullet list — one bullet per field, so
+it renders one-per-line as real Markdown (plain `key: value` lines collapse into a single
+paragraph when rendered). Fields:
+
+  where        — file/area the decision lives in (NOT a line number — survives refactoring)
+  why          — the rationale, taught live before it was written
+  alternative  — the rejected option and why (this is what makes it rationale, not description)
+  design       — (optional) ../design.md#anchor — the diagram this decision shaped or used
+  constitution — (optional) §N — the principle this decision serves or trades off against
+  trust        — ✓ verified | ⚠ not independently verified  (about the DECISION, never the person)
+
+Delete this comment and the example below once real decisions land.
+-->
+
+---
+
+## Decision: Reuse only a reachable stale baseline with a widened diff
+
+- **where:** `IndexApplicabilityResolver`, `CurrentChangesResolver`, and `SelectMojo`
+- **why:** A cache race can leave the exact target-branch index unavailable even though a valid predecessor index is present; widening the comparison from a reachable predecessor preserves safe test selection.
+- **alternative:** Reuse an arbitrary prior index without widening the diff — rejected because it could omit changes introduced after that index's anchor. Keep exact-key-only lookup — rejected because the observed cache-publication race unnecessarily reruns every test.
+- **design:** `../design.md#design-decision`
+- **constitution:** §§I, II, III, V
+- **trust:** ✓ verified by focused resolver/storage tests and a subprocess end-to-end merge-result test


### PR DESCRIPTION
## Intent

Reuse a valid cached dependency index when the exact PR baseline is temporarily absent because the target-branch cache has not been published yet.

## Approach

- Prefer the exact commit-keyed index as before.
- If it is missing, search both supported stores (filesystem and S3) for commit-keyed candidates.
- Accept only current-format indexes whose anchor is reachable from the tested HEAD, and choose the nearest ancestor.
- Recompute the diff from that stale anchor through HEAD, covering both intervening `main` changes and PR changes.
- Surface the path as `SELECT — stale baseline index built from …`.

## Safety

This does not reuse unrelated, descendant, malformed, unreadable, or incompatible indexes. When no safe ancestor exists, the normal full-suite fallback remains.

## Verification

- `mvn -B --no-transfer-progress clean verify`
- Focused resolver, local-store, S3-store, and root-index-path tests
- End-to-end merge-result regression: a stale baseline runs both the PR test and the intervening-main test.

## FluencyLoop

- Design: `docs/fluencyloop/features/use-a-reachable-stale-dependency-index-as-a-conservative-tes/design.md`
- Decision: reachable stale baseline plus widened diff, verified by tests.
- Constitution check: supports TDD, simplicity (one concrete capability shared by file/S3), conservative safety, and explainability.
