### PR TITLE
docs: backfill CI test-selection reliability decisions

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "self-host-blastradius-test-selection-in-ci",
-  "branch": "feature/self-host-blastradius-test-selection-in-ci",
+  "feature": "backfill-ci-test-selection-reliability-decisions-from-2026-0",
+  "branch": "feature/backfill-ci-test-selection-reliability-decisions-from-2026-0",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/self-host-blastradius-test-selection-in-ci/sessions/self-host-the-maven-reactor-in-ci.md",
-  "base_ref": "main",
+  "last_session": "docs/fluencyloop/features/backfill-ci-test-selection-reliability-decisions-from-2026-0/sessions/reconstruct-ci-test-selection-reliability-fixes-merged-on-20.md",
+  "base_ref": "origin/main",
   "updated": "2026-07-26"
 }

--- a/docs/fluencyloop/features/backfill-ci-test-selection-reliability-decisions-from-2026-0/design.md
+++ b/docs/fluencyloop/features/backfill-ci-test-selection-reliability-decisions-from-2026-0/design.md
@@ -53,7 +53,7 @@ sequenceDiagram
   Mojo->>Runner: TRACK needed
   Runner->>Fork: mvn test with agent in argLine
   Fork->>Agent: start test, then transform classes
-  Agent->>Agent: preserve empty baseline; guard checksum recursion
+  Agent->>Agent: preserve empty baseline, guard checksum recursion
   alt tracking succeeds
     Runner-->>Mojo: complete dependency index
     Mojo->>Cache: persist commit-keyed index

--- a/docs/fluencyloop/features/backfill-ci-test-selection-reliability-decisions-from-2026-0/design.md
+++ b/docs/fluencyloop/features/backfill-ci-test-selection-reliability-decisions-from-2026-0/design.md
@@ -1,0 +1,76 @@
+# Design: Backfill CI test-selection reliability decisions from 2026-07-26
+
+started: 2026-07-26
+
+> Backfill record for merged PRs #89, #91, #92, #94, #96, #98, #99, and #102.
+> Decision confirmations are recorded in the linked session.
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class TestBoundaryListener
+  class DependencyTrackingAgent {
+    +recordTestStarted(test)
+    +transform(...)
+    +recordedDependencies()
+  }
+  class TrackRunner {
+    +track(project, agentJar, anchor)
+  }
+  class SelectMojo
+  class DependencyIndex
+  class BuildReport
+  class TimingHistory
+  class GitHubCache
+  class MatrixFeedbackJob
+  class SelectionSummaryRenderer
+
+  TestBoundaryListener --> DependencyTrackingAgent : registers every test start
+  DependencyTrackingAgent --> DependencyIndex : records empty or loaded dependencies
+  SelectMojo --> TrackRunner : starts TRACK subprocess
+  TrackRunner --> DependencyTrackingAgent : Surefire argLine
+  TrackRunner --> DependencyIndex : emits only on success
+  SelectMojo --> DependencyIndex : persists or falls back
+  BuildReport --> TimingHistory : normalizes lookup identity
+  GitHubCache --> TimingHistory : restores module histories
+  MatrixFeedbackJob --> SelectionSummaryRenderer : one PR comment
+```
+
+## Sequence: safe tracking and matrix feedback
+
+```mermaid
+sequenceDiagram
+  participant CI as CI workflow
+  participant Mojo as SelectMojo
+  participant Runner as TrackRunner
+  participant Fork as Surefire fork
+  participant Agent as Tracking agent
+  participant Cache as Cache and artifacts
+  participant Feedback as Matrix feedback job
+
+  CI->>Cache: restore root and module .blastradius
+  Mojo->>Runner: TRACK needed
+  Runner->>Fork: mvn test with agent in argLine
+  Fork->>Agent: start test, then transform classes
+  Agent->>Agent: preserve empty baseline; guard checksum recursion
+  alt tracking succeeds
+    Runner-->>Mojo: complete dependency index
+    Mojo->>Cache: persist commit-keyed index
+  else tracking fails
+    Runner-->>Mojo: failure plus output tail
+    Mojo->>Mojo: discard partial data and run full suite
+  end
+  CI->>Cache: upload each JDK report artifact
+  Feedback->>Cache: download matrix reports
+  Feedback->>Feedback: normalize timing identities and render one comment
+```
+
+## Backfilled design decision
+
+The merged fixes preserve one invariant across the pipeline: selection data is either complete,
+attributable, and comparable, or it is discarded in favor of a conservative full run. The agent
+records a test even when it sees no dependency loads; the tracking process is isolated to
+Surefire and commits an index only after success; JDK-25 checksum work cannot recurse through
+class loading. CI retains timing data for every module, then aggregates both JDKs into one
+explainable PR summary whose savings estimate uses the same test identity as discovery.

--- a/docs/fluencyloop/features/backfill-ci-test-selection-reliability-decisions-from-2026-0/sessions/reconstruct-ci-test-selection-reliability-fixes-merged-on-20.md
+++ b/docs/fluencyloop/features/backfill-ci-test-selection-reliability-decisions-from-2026-0/sessions/reconstruct-ci-test-selection-reliability-fixes-merged-on-20.md
@@ -1,0 +1,78 @@
+# Session: Reconstruct CI test-selection reliability fixes merged on 2026-07-26
+
+- **intent:** Reconstruct CI test-selection reliability fixes merged on 2026-07-26
+- **started:** 2026-07-26
+- **sources:** PRs #89, #91, #92, #94, #96, #98, #99, and #102; merged on 2026-07-26
+
+## Decision: Persist an empty baseline for every started test
+
+- **where:** `DependencyTrackingAgent` and `TestBoundaryListener`
+- **why:** PR #89 records that tests with no class-load events need an explicit empty baseline so selection does not mistake them for newly added tests.
+- **alternative:** Infer absence from dependency records — rejected by the merged implementation because an existing test that loads no new classes is observably different from a new test.
+- **design:** `../design.md#class-diagram`
+- **constitution:** §§III, V
+- **trust:** ✓ confirmed 2026-07-26
+
+## Decision: Treat tracking as an isolated, all-or-nothing transaction
+
+- **where:** `TrackRunner`, `SelectMojo`, and `SurefireFilterApplier`
+- **why:** PRs #91 and #92 record that tracking must be restricted to test forks and that a failed tracker must never persist partial data; the ambient build falls back instead.
+- **alternative:** Attach through `JAVA_TOOL_OPTIONS` and retain records from a failed child — rejected because the agent leaked into nested Maven processes and a nonzero tracking run can leave an incomplete index.
+- **design:** `../design.md#sequence-safe-tracking-and-matrix-feedback`
+- **constitution:** §§III, V
+- **trust:** ✓ confirmed 2026-07-26
+
+## Decision: Prepare checksum machinery outside class transformation and block re-entrancy
+
+- **where:** `DependencyTrackingAgent` checksum path
+- **why:** PRs #94 and #96 record JDK 25 class-loading recursion while computing checksums, addressed with a re-entrancy guard and eager SHA-256 initialization.
+- **alternative:** Lazily create a digest during every transformation — rejected because security-provider initialization can load classes and re-enter the transformer, producing `ClassCircularityError`.
+- **design:** `../design.md#sequence-safe-tracking-and-matrix-feedback`
+- **constitution:** §§III, VI
+- **trust:** ✓ confirmed 2026-07-26
+
+## Decision: Cache timing history beside the dependency index for every module
+
+- **where:** `.github/workflows/build.yml` cache paths
+- **why:** PR #98 records that timing histories are module-local and must be restored and saved with the shared dependency index for estimates to become complete.
+- **alternative:** Cache only the root `.blastradius` directory — rejected because module reports and their timing histories live below each Maven module.
+- **design:** `../design.md#class-diagram`
+- **constitution:** §§II, V
+- **trust:** ✓ confirmed 2026-07-26
+
+## Decision: Aggregate JDK reports in one post-matrix feedback job
+
+- **where:** `.github/workflows/build.yml` selection-feedback job and summary renderer
+- **why:** PR #99 records that each JDK publishes its report as an artifact and one post-matrix job owns the single PR comment.
+- **alternative:** Let both matrix jobs upsert the same comment — rejected because concurrent writers produce competing or last-writer-wins feedback.
+- **design:** `../design.md#sequence-safe-tracking-and-matrix-feedback`
+- **constitution:** §§II, V
+- **trust:** ✓ confirmed 2026-07-26
+
+## Decision: Normalize Surefire timing identities before calculating savings
+
+- **where:** `BuildReport` timing lookup
+- **why:** PR #102 records that Surefire XML includes parameter signatures while discovery uses baseline identities, so durations must be normalized before completeness and savings are calculated.
+- **alternative:** Require exact raw method-name equality — rejected because valid parameterized or injected Surefire names would falsely make timing coverage incomplete.
+- **design:** `../design.md#class-diagram`
+- **constitution:** §§IV, V
+- **trust:** ✓ confirmed 2026-07-26
+
+## Knowledge transfer
+
+### Tracking data integrity
+
+- **`TestBoundaryListener` and `DependencyTrackingAgent`:** Each real test start creates a dependency-map entry before the test is published as current. A map with no entries means "existing test with no observed class loads," while no map means "no baseline"; selection needs that distinction to avoid rerunning established tests as if they were new. **Status:** documented.
+- **`TrackRunner` and `SelectMojo`:** TRACK is a child Maven build. The agent is placed in Surefire's `argLine`, so Maven infrastructure and nested Maven invocations are not instrumented. Only a zero-exit child produces an index; failure carries a diagnostic output tail and leaves the ambient build in conservative fallback. **Status:** documented.
+- **`SurefireFilterApplier`:** An empty chosen set is expressed with Maven's `skipTests`, not an empty `test` property, because Surefire treats the latter as no filter and would run everything. **Status:** documented.
+
+### JDK-25 agent safety
+
+- **`DependencyTrackingAgent.transform`:** The transformer observes class loads only while a test is active. It holds a thread-local re-entrancy guard around checksum computation, so classes loaded by the checksum path cannot recursively transform themselves. **Status:** documented.
+- **`DependencyTrackingAgent` SHA-256 state:** SHA-256 is initialized while the agent class loads, before the transformer is registered, and serialized while used because `MessageDigest` is mutable. This avoids security-provider initialization during a JDK class-load callback. **Status:** documented.
+
+### CI persistence and feedback
+
+- **GitHub Actions cache:** Main builds save, and PR builds restore, both the shared root index and each module's `.blastradius` timing history; `target`-local generated data is explicitly excluded. Timing estimates stay absent until all skipped tests have history. **Status:** documented.
+- **Matrix feedback:** Each JDK job retains its own job summary and uploads its reports. A post-matrix job downloads complete JDK artifacts and is the only writer of the PR comment, producing one labelled table rather than racing updates. **Status:** documented.
+- **`BuildReport`:** Surefire timing identities are folded to the discovery identity and duplicate parameterized invocations are summed. Completeness means every skipped discovered test has a duration under that stable key. **Status:** documented.


### PR DESCRIPTION
## Intent

Backfill today’s merged CI test-selection reliability work into a confirmed FluencyLoop design and decision record. No engine behavior changes are included.

## Confirmed decisions

- Persist empty baselines for tests with no observed class loads.
- Isolate tracking to Surefire and discard partial indexes on failure.
- Guard and eagerly initialize checksum machinery for JDK 25 safety.
- Cache per-module timing histories and normalize Surefire identities before estimating savings.
- Aggregate both JDK reports in one post-matrix PR-comment job.

## Review notes

- All six decisions were confirmed during backfill; no decision remains marked unverified.
- Constitution check: aligned with safety, determinism, explainability, and modern-runtime principles.
- FluencyLoop check: no unjournaled commits.
- Design and knowledge-transfer record: `docs/fluencyloop/features/backfill-ci-test-selection-reliability-decisions-from-2026-0/design.md`.