### PR TITLE
Fix stale main dependency-index cache promotion

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "use-a-reachable-stale-dependency-index-as-a-conservative-tes",
-  "branch": "feature/use-a-reachable-stale-dependency-index-as-a-conservative-tes",
+  "feature": "refresh-the-main-ci-dependency-index-after-conservative-fall",
+  "branch": "feature/refresh-the-main-ci-dependency-index-after-conservative-fall",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/use-a-reachable-stale-dependency-index-as-a-conservative-tes/sessions/specify-conservative-stale-baseline-selection.md",
-  "base_ref": "origin/main",
+  "last_session": "docs/fluencyloop/features/refresh-the-main-ci-dependency-index-after-conservative-fall/sessions/refresh-main-baselines-after-non-exact-cache-restores.md",
+  "base_ref": "main",
   "updated": "2026-07-26"
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,17 @@ jobs:
             -Dversion="${SELF_HOST_VERSION}" \
             -Dpackaging=maven-plugin \
             -DgeneratePom=true
-      - run: mvn -B --no-transfer-progress -Pself-host-blastradius clean verify
+      - name: Verify with Blastradius
+        env:
+          # A restore-key hit contains an older baseline. It is safe for a PR to select
+          # from that baseline, but main must rebuild before saving this commit's cache key.
+          BLASTRADIUS_REFRESH_MAIN_INDEX: ${{ github.ref == 'refs/heads/main' && steps.blastradius-index.outputs.cache-hit != 'true' }}
+        run: |
+          blastradius_mode=()
+          if [[ "$BLASTRADIUS_REFRESH_MAIN_INDEX" == "true" ]]; then
+            blastradius_mode+=("-Dblastradius.mode=track")
+          fi
+          mvn -B --no-transfer-progress "${blastradius_mode[@]}" -Pself-host-blastradius clean verify
       - name: Generate JaCoCo badge
         if: matrix.java == '21'
         uses: cicirello/jacoco-badge-generator@v2

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojoModeRoutingTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojoModeRoutingTest.java
@@ -36,11 +36,11 @@ class SelectMojoModeRoutingTest {
     }
 
     @Test
-    void explicitTrackModeFlagRoutesToTrackEvenOnAPrBuild() {
-        IndexApplicability applicable = IndexApplicability.applicable(
+    void explicitTrackModeFlagRoutesToTrackEvenWithAReachableStaleBaseline() {
+        IndexApplicability staleBaseline = IndexApplicability.staleBaseline(
                 new DependencyIndex("abc123", "2026-07-09T10:00:00Z", List.of()));
 
-        BuildReport.Mode mode = SelectMojo.determineMode(PR_BUILD, applicable, "track");
+        BuildReport.Mode mode = SelectMojo.determineMode(PR_BUILD, staleBaseline, "track");
 
         assertEquals(BuildReport.Mode.TRACK, mode);
     }

--- a/docs/fluencyloop/features/refresh-the-main-ci-dependency-index-after-conservative-fall/design.md
+++ b/docs/fluencyloop/features/refresh-the-main-ci-dependency-index-after-conservative-fall/design.md
@@ -1,0 +1,72 @@
+# Design: Refresh the main CI dependency index after conservative fallback and prevent stale index promotion
+
+started: 2026-07-26
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class RestoreBlastradiusIndex {
+    cache-hit: exact key only
+  }
+  class VerifyBuild {
+    modeArgument()
+  }
+  class SelectMojo {
+    determineMode()
+  }
+  class TrackRunner {
+    track(currentCommit)
+  }
+  class FileIndexStore {
+    put(commitKey, index)
+  }
+  class SaveBlastradiusIndex {
+    cache key = current commit SHA
+  }
+
+  RestoreBlastradiusIndex --> VerifyBuild : exact miss selects TRACK
+  VerifyBuild --> SelectMojo : -Dblastradius.mode=track
+  SelectMojo --> TrackRunner : fresh dependency data
+  TrackRunner --> FileIndexStore : writes current commit index
+  FileIndexStore --> SaveBlastradiusIndex : archives fresh baseline
+```
+
+## Sequence: refresh a main baseline after an exact-cache miss
+
+```mermaid
+sequenceDiagram
+  participant Cache as GitHub Actions cache
+  participant Verify as Maven verify step
+  participant Plugin as SelectMojo
+  participant Tracker as TrackRunner
+  participant Store as FileIndexStore
+
+  Cache-->>Verify: restore exact key or older prefix match
+  alt main build with no exact cache hit
+    Verify->>Plugin: -Dblastradius.mode=track
+    Plugin->>Tracker: track checked out commit
+    Tracker-->>Plugin: complete dependency index
+    Plugin->>Store: write index under checked out SHA
+    Verify->>Cache: save archive under that same SHA
+  else exact cache hit
+    Verify->>Plugin: normal SELECT invocation
+    Note over Plugin: reuse the current-commit index
+  else pull request build
+    Verify->>Plugin: normal SELECT invocation
+    Note over Plugin: a reachable baseline may be used conservatively
+  end
+```
+
+## Design rationale
+
+An Actions cache is an archive, not proof of which commit produced its contents. A prefix
+restore is allowed to supply a usable older baseline for a pull request, but a main build that
+does not restore its exact commit key must refresh that baseline before it saves an archive under
+the current SHA. The workflow therefore explicitly requests the plugin's existing `TRACK` mode
+only for a main build with an exact-cache miss. `TRACK` records dependencies for the checked-out
+commit and writes an index keyed by that commit. A rerun with an exact cache hit keeps the normal
+selection path and avoids unnecessary tracking.
+
+This keeps the index payload and cache key aligned. It avoids a new engine abstraction and relies
+on the existing explicit mode switch, `TrackRunner`, and commit-keyed `FileIndexStore`.

--- a/docs/fluencyloop/features/refresh-the-main-ci-dependency-index-after-conservative-fall/sessions/refresh-main-baselines-after-non-exact-cache-restores.md
+++ b/docs/fluencyloop/features/refresh-the-main-ci-dependency-index-after-conservative-fall/sessions/refresh-main-baselines-after-non-exact-cache-restores.md
@@ -1,0 +1,27 @@
+# Session: Refresh main baselines after non-exact cache restores
+
+- **intent:** Refresh main baselines after non-exact cache restores
+- **started:** 2026-07-26
+
+## Knowledge transfer
+
+- **GitHub Actions cache restore:** An exact primary-key hit identifies an archive already
+  associated with the checked-out commit. A `restore-keys` match only supplies an older usable
+  archive, so its cache key cannot prove that its embedded dependency index was produced by the
+  current commit. **Status:** documented.
+- **Main baseline refresh:** The verify step owns the CI-specific exact-hit test. On a main exact
+  miss it passes `-Dblastradius.mode=track`, which reuses `SelectMojo` and `TrackRunner` to run
+  unfiltered tracking and write a dependency index under the checked-out commit key. **Status:**
+  documented.
+- **Cache persistence invariant:** The cache archive saved under a main SHA must contain an index
+  anchored to that SHA. Prefix-restored baseline data may coexist in the archive, but it must not
+  be the only index represented by the new key. **Status:** documented.
+
+## Decision: refresh non-exact main cache restores with TRACK
+
+- **where:** `.github/workflows/build.yml verify step`
+- **why:** GitHub Actions alone knows whether the restored archive matched the checked-out SHA, so an exact miss on main explicitly invokes the plugin's existing TRACK mode to persist a commit-keyed fresh index before that SHA is cached.
+- **alternative:** Teach SelectMojo about GitHub Actions cache provenance — rejected: it would couple the portable Maven plugin to one CI transport instead of passing its existing explicit mode.
+- **design:** ../design.md#sequence-refresh-a-main-baseline-after-an-exact-cache-miss
+- **constitution:** III
+- **trust:** ✓ verified


### PR DESCRIPTION
## Summary

- Refresh the dependency index on `main` whenever Actions restores a fallback cache rather than the exact commit cache.
- Reuse the existing `TRACK` mode so the saved cache is anchored to the same commit SHA as its key.
- Cover explicit tracking over a reachable stale baseline.

## Design and decision

See `docs/fluencyloop/features/refresh-the-main-ci-dependency-index-after-conservative-fall/design.md`.

The workflow owns cache-hit provenance while the Maven plugin remains CI-agnostic. A non-exact restore on `main` adds `-Dblastradius.mode=track`; PRs and exact cache hits keep normal selection.

## Verification

- `mvn -B --no-transfer-progress clean verify` (JDK 25)
- Workflow YAML parsed locally
- Mode-argument branches simulated locally

Constitution check: supports Principle III by preserving conservative selection while preventing stale index promotion.