### PR TITLE
fix: stop ambient class-loading from spuriously matching every test

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "refresh-the-main-ci-dependency-index-after-conservative-fall",
-  "branch": "feature/refresh-the-main-ci-dependency-index-after-conservative-fall",
+  "feature": "fix-dependency-tracking-agent-missing-classes-loaded-before",
+  "branch": "feature/fix-dependency-tracking-agent-missing-classes-loaded-before",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/refresh-the-main-ci-dependency-index-after-conservative-fall/sessions/refresh-main-baselines-after-non-exact-cache-restores.md",
+  "last_session": "docs/fluencyloop/features/fix-dependency-tracking-agent-missing-classes-loaded-before/sessions/tests-full-verify-fixture-ordering-fix-for-ambient-snapshot.md",
   "base_ref": "main",
   "updated": "2026-07-26"
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/index/DependencyIndexFormat.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/index/DependencyIndexFormat.java
@@ -4,16 +4,26 @@ package io.github.baokhang83.blastradius.core.index;
 public final class DependencyIndexFormat {
 
     /** The version emitted for every newly tracked dependency index. */
-    public static final int CURRENT_VERSION = 1;
+    public static final int CURRENT_VERSION = 2;
 
     private static final int LEGACY_UNVERSIONED_VERSION = 0;
+
+    /**
+     * The version a {@link #LEGACY_UNVERSIONED_VERSION} index migrates to: the last schema
+     * before {@code ambientDependencies} existed. Fixed independently of {@link #CURRENT_VERSION}
+     * — a legacy index genuinely has no ambient data, so migrating it straight to whatever
+     * {@code CURRENT_VERSION} happens to be would falsely validate it against a schema it
+     * doesn't match (an empty ambient set would look indistinguishable from "no ambient
+     * classes exist", silently reintroducing the exact bug this format models).
+     */
+    public static final int PRE_AMBIENT_DEPENDENCIES_VERSION = 1;
 
     private DependencyIndexFormat() {
     }
 
-    /** Maps the one known unversioned schema to the current version without accepting future schemas. */
+    /** Maps the one known unversioned schema to its actual legacy version, never to {@link #CURRENT_VERSION}. */
     public static int migrateLegacyVersion(int version) {
-        return version == LEGACY_UNVERSIONED_VERSION ? CURRENT_VERSION : version;
+        return version == LEGACY_UNVERSIONED_VERSION ? PRE_AMBIENT_DEPENDENCIES_VERSION : version;
     }
 
     /** Returns whether an index version is safe for the current selection implementation to use. */

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/AmbientDependencySelector.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/AmbientDependencySelector.java
@@ -1,0 +1,23 @@
+package io.github.baokhang83.blastradius.core.selection;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * A distinct, deliberately conservative fallback rule alongside {@link FallbackSelector}: a
+ * changed class that was loaded before any test's tracking window opened in some fork (see
+ * {@code DependencyTrackingAgent#ambientDependencies()}) has no trustworthy per-test
+ * dependency data — no test can be soundly ruled out for it, so every test is selected
+ * instead of risking a silent {@link SelectionReason#NO_MATCH}.
+ */
+public final class AmbientDependencySelector {
+
+    public boolean shouldFallback(Set<String> changedClassNames, Set<String> ambientDependencies) {
+        return !Collections.disjoint(changedClassNames, ambientDependencies);
+    }
+
+    public SelectionDecision select(TestIdentity test) {
+        return SelectionDecision.fallbackAmbientDependency(test);
+    }
+}

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionDecision.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionDecision.java
@@ -36,6 +36,10 @@ public record SelectionDecision(
         return new SelectionDecision(test, true, SelectionReason.FALLBACK_NON_SOURCE_CHANGE, null);
     }
 
+    public static SelectionDecision fallbackAmbientDependency(TestIdentity test) {
+        return new SelectionDecision(test, true, SelectionReason.FALLBACK_AMBIENT_DEPENDENCY, null);
+    }
+
     public static SelectionDecision newOrModifiedTest(TestIdentity test) {
         return new SelectionDecision(test, true, SelectionReason.NEW_OR_MODIFIED_TEST, null);
     }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionEngine.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionEngine.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 public final class SelectionEngine {
 
     private final FallbackSelector fallbackSelector = new FallbackSelector();
+    private final AmbientDependencySelector ambientDependencySelector = new AmbientDependencySelector();
     private final NewOrModifiedTestSelector newOrModifiedTestSelector = new NewOrModifiedTestSelector();
     private final DependencyMatchSelector dependencyMatchSelector = new DependencyMatchSelector();
 
@@ -28,12 +29,15 @@ public final class SelectionEngine {
      * @param testDependencies   each test's previously-tracked dependency class names
      * @param newOrModifiedTests tests with no prior baseline or whose own file changed
      * @param changedFiles       this commit pair's changed files
+     * @param ambientDependencies classes loaded before any test's tracking window opened in
+     *                            some fork — never soundly attributable to a specific test
      */
     public List<SelectionDecision> selectAll(
             Set<TestIdentity> allTests,
             Map<TestIdentity, Set<String>> testDependencies,
             Set<TestIdentity> newOrModifiedTests,
-            List<ChangedFile> changedFiles) {
+            List<ChangedFile> changedFiles,
+            Set<String> ambientDependencies) {
 
         if (fallbackSelector.shouldFallback(changedFiles)) {
             return allTests.stream().map(fallbackSelector::select).toList();
@@ -42,6 +46,10 @@ public final class SelectionEngine {
         Set<String> changedClassNames = changedFiles.stream()
                 .flatMap(file -> file.candidateClassNames().stream())
                 .collect(Collectors.toUnmodifiableSet());
+
+        if (ambientDependencySelector.shouldFallback(changedClassNames, ambientDependencies)) {
+            return allTests.stream().map(ambientDependencySelector::select).toList();
+        }
 
         List<SelectionDecision> decisions = new ArrayList<>();
         for (TestIdentity test : allTests) {

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionReason.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionReason.java
@@ -6,6 +6,12 @@ public enum SelectionReason {
     DEPENDENCY_MATCH,
     /** A non-Java-source change forced selection of every test (FR-006). */
     FALLBACK_NON_SOURCE_CHANGE,
+    /**
+     * A changed class was loaded before any test's tracking window opened in some fork
+     * (an "ambient" dependency), so no per-test dependency data can be trusted for it —
+     * every test was conservatively selected instead of risking a silent {@code NO_MATCH}.
+     */
+    FALLBACK_AMBIENT_DEPENDENCY,
     /** The test is new or its own file was modified (FR-007). */
     NEW_OR_MODIFIED_TEST,
     /** Not selected — no changed class intersects its tracked dependencies. */

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordFile.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordFile.java
@@ -1,0 +1,13 @@
+package io.github.baokhang83.blastradius.core.tracking;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ * On-disk shape of a single {@code <prefix>.<pid>} file: one JVM fork's per-test dependency
+ * records plus the classes it loaded before any test's tracking window opened (see
+ * {@link DependencyTrackingAgent#ambientDependencies()}). Purely an ephemeral intra-build
+ * protocol between {@link DependencyRecordWriter} and {@link DependencyRecordReader} — never
+ * persisted across builds — so its shape is free to change without a version migration.
+ */
+record DependencyRecordFile(List<DependencyRecord> tests, Set<String> ambientDependencies) {}

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordReader.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordReader.java
@@ -1,6 +1,5 @@
 package io.github.baokhang83.blastradius.core.tracking;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -8,8 +7,9 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /** Reads back what {@link DependencyRecordWriter} persisted. */
@@ -18,11 +18,15 @@ public final class DependencyRecordReader {
     private final ObjectMapper mapper = new ObjectMapper();
 
     public Map<TestIdentity, Map<String, String>> read(Path inputFile) {
+        return readFile(inputFile).tests();
+    }
+
+    private DependencyRecordSet readFile(Path inputFile) {
         try {
-            List<DependencyRecord> records =
-                    mapper.readValue(inputFile.toFile(), new TypeReference<List<DependencyRecord>>() {});
-            return records.stream()
+            DependencyRecordFile file = mapper.readValue(inputFile.toFile(), DependencyRecordFile.class);
+            Map<TestIdentity, Map<String, String>> tests = file.tests().stream()
                     .collect(Collectors.toUnmodifiableMap(DependencyRecord::test, DependencyRecord::dependencies));
+            return new DependencyRecordSet(tests, file.ambientDependencies());
         } catch (IOException e) {
             throw new UncheckedIOException("failed to read dependency record from " + inputFile, e);
         }
@@ -33,22 +37,34 @@ public final class DependencyRecordReader {
      * {@link DependencyTrackingAgent} wrote — one per JVM that had the agent attached
      * (see {@code DependencyTrackingAgent#premain}). A build with multiple forked test
      * JVMs (e.g. a target project configured with {@code reuseForks=false}) produces one
-     * such file per fork; this merges them all into a single map, as if it had all been
-     * recorded by one JVM.
+     * such file per fork; this merges them all into a single {@link DependencyRecordSet},
+     * as if it had all been recorded by one JVM — including the {@code ambientDependencies},
+     * since each fork's discovery pass can force-load a different subset of classes.
+     *
+     * <p>A test class itself is excluded from the merged ambient set: JUnit Platform's
+     * discovery pass loads every discovered test class (to introspect for {@code @Test}
+     * methods) before any test's tracking window opens, in every fork, regardless of what
+     * that test actually depends on — so its own class name is unconditionally ambient and
+     * carries no dependency-graph signal, unlike a production class force-loaded before
+     * tracking could attribute it. Left unfiltered, changing any single test file would
+     * trigger the ambient fallback for the entire reactor, every time.
      */
-    public Map<TestIdentity, Map<String, String>> readAll(Path baseOutputFile) {
+    public DependencyRecordSet readAll(Path baseOutputFile) {
         Path parent = baseOutputFile.toAbsolutePath().getParent();
         String prefix = baseOutputFile.getFileName().toString() + ".";
-        Map<TestIdentity, Map<String, String>> merged = new HashMap<>();
+        Map<TestIdentity, Map<String, String>> mergedTests = new HashMap<>();
+        Set<String> mergedAmbient = new HashSet<>();
         boolean foundAny = false;
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(parent, prefix + "*")) {
             for (Path siblingFile : stream) {
                 foundAny = true;
-                read(siblingFile).forEach((test, classes) -> merged.merge(test, classes, (oldClasses, newClasses) -> {
+                DependencyRecordSet sibling = readFile(siblingFile);
+                sibling.tests().forEach((test, classes) -> mergedTests.merge(test, classes, (oldClasses, newClasses) -> {
                     Map<String, String> combined = new HashMap<>(oldClasses);
                     combined.putAll(newClasses);
                     return combined;
                 }));
+                mergedAmbient.addAll(sibling.ambientDependencies());
             }
         } catch (IOException e) {
             throw new UncheckedIOException("failed to list dependency record files matching " + prefix + "* in "
@@ -59,6 +75,9 @@ public final class DependencyRecordReader {
                     "failed to read dependency record from " + baseOutputFile,
                     new IOException("no files matching " + prefix + "* found in " + parent));
         }
-        return Map.copyOf(merged);
+        for (TestIdentity test : mergedTests.keySet()) {
+            mergedAmbient.remove(test.className());
+        }
+        return new DependencyRecordSet(Map.copyOf(mergedTests), Set.copyOf(mergedAmbient));
     }
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordSet.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordSet.java
@@ -1,0 +1,12 @@
+package io.github.baokhang83.blastradius.core.tracking;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Every {@code <baseOutputFile>.<pid>} sibling file merged into one: per-test dependencies
+ * unioned across forks, and the fork-wide {@code ambientDependencies} — classes loaded before
+ * the first test's tracking window opened in any fork — also unioned, since each fork's
+ * discovery pass can force-load a different subset.
+ */
+public record DependencyRecordSet(Map<TestIdentity, Map<String, String>> tests, Set<String> ambientDependencies) {}

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordWriter.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordWriter.java
@@ -6,21 +6,28 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
- * Persists {@link DependencyTrackingAgent#recordedDependencies()} to a file, so a parent
- * process can read it back after the agent's subprocess JVM exits (research.md #1).
+ * Persists {@link DependencyTrackingAgent#recordedDependencies()} (and
+ * {@link DependencyTrackingAgent#ambientDependencies()}) to a file, so a parent process can
+ * read it back after the agent's subprocess JVM exits (research.md #1).
  */
 public final class DependencyRecordWriter {
 
     private final ObjectMapper mapper = new ObjectMapper();
 
     public void write(Path outputFile, Map<TestIdentity, Map<String, String>> recordedDependencies) {
+        write(outputFile, recordedDependencies, Set.of());
+    }
+
+    public void write(Path outputFile, Map<TestIdentity, Map<String, String>> recordedDependencies,
+            Set<String> ambientDependencies) {
         List<DependencyRecord> records = recordedDependencies.entrySet().stream()
                 .map(entry -> new DependencyRecord(entry.getKey(), entry.getValue()))
                 .toList();
         try {
-            mapper.writeValue(outputFile.toFile(), records);
+            mapper.writeValue(outputFile.toFile(), new DependencyRecordFile(records, ambientDependencies));
         } catch (IOException e) {
             throw new UncheckedIOException("failed to write dependency record to " + outputFile, e);
         }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -46,6 +47,8 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
 
     private final Supplier<TestIdentity> currentTestSupplier;
     private final Map<TestIdentity, Map<String, String>> checksumsByTest = new ConcurrentHashMap<>();
+    private final Set<String> ambientDependencies = ConcurrentHashMap.newKeySet();
+    private final AtomicBoolean ambientSnapshotTaken = new AtomicBoolean(false);
 
     public DependencyTrackingAgent() {
         this(TestBoundaryListener::currentTest);
@@ -85,7 +88,7 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 Map<TestIdentity, Map<String, String>> recorded = agent.recordedDependencies();
                 if (!recorded.isEmpty()) {
-                    new DependencyRecordWriter().write(outputFile, recorded);
+                    new DependencyRecordWriter().write(outputFile, recorded, agent.ambientDependencies());
                 }
             }));
         }
@@ -133,11 +136,40 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
         checksumsByTest.computeIfAbsent(test, ignored -> new ConcurrentHashMap<>());
     }
 
+    /**
+     * Called once, before the very first test in a fork starts (see {@link TestBoundaryListener}).
+     * Everything already loaded at that point — JVM/Surefire bootstrap, JUnit Platform's
+     * discovery pass walking every test class's signatures — got exactly one, unattributed
+     * {@link #transform} call each and can never be re-observed, so no single test can be
+     * blamed for depending on them. Recording them as fork-wide {@code ambientDependencies}
+     * lets selection fall back rather than silently reporting {@code NO_MATCH} when one of
+     * them changes. Idempotent: only the first caller's snapshot is taken.
+     */
+    static void recordAmbientSnapshot() {
+        DependencyTrackingAgent currentAgent = installedAgent;
+        if (currentAgent != null) {
+            currentAgent.snapshotAmbientDependencies();
+        }
+    }
+
+    void snapshotAmbientDependencies() {
+        if (ambientSnapshotTaken.compareAndSet(false, true)) {
+            for (Class<?> loadedClass : loadedClasses()) {
+                ambientDependencies.add(loadedClass.getName());
+            }
+        }
+    }
+
     /** An immutable snapshot of {@code test -> {className -> tracking token}} recorded so far. */
     public Map<TestIdentity, Map<String, String>> recordedDependencies() {
         return checksumsByTest.entrySet().stream()
                 .collect(java.util.stream.Collectors.toUnmodifiableMap(
                         Map.Entry::getKey, e -> Map.copyOf(e.getValue())));
+    }
+
+    /** Class names loaded before the first test's tracking window opened in this fork. */
+    public Set<String> ambientDependencies() {
+        return Set.copyOf(ambientDependencies);
     }
 
     static Set<Class<?>> loadedClasses() {

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/TestBoundaryListener.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/TestBoundaryListener.java
@@ -28,6 +28,11 @@ public final class TestBoundaryListener implements TestExecutionListener {
     @Override
     public void executionStarted(TestIdentifier testIdentifier) {
         if (testIdentifier.isTest()) {
+            // First call in this fork snapshots everything already loaded — JVM/Surefire
+            // bootstrap plus JUnit Platform's discovery pass, which runs before any test's
+            // window opens and can force-load classes the tracker can never re-observe.
+            // No-op on every call after the first.
+            DependencyTrackingAgent.recordAmbientSnapshot();
             TestIdentity test = toTestIdentity(testIdentifier);
             // Register before publishing this identity to the agent. Computing the record's
             // generated hash code may load JVM support classes; while no test is current those

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/index/DependencyIndexFormatTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/index/DependencyIndexFormatTest.java
@@ -9,8 +9,15 @@ import org.junit.jupiter.api.Test;
 class DependencyIndexFormatTest {
 
     @Test
-    void migratesTheKnownUnversionedLegacySchemaToTheCurrentVersion() {
-        assertEquals(DependencyIndexFormat.CURRENT_VERSION, DependencyIndexFormat.migrateLegacyVersion(0));
+    void migratesTheKnownUnversionedLegacySchemaToItsPreAmbientDependenciesVersion() {
+        // Not CURRENT_VERSION: a legacy index genuinely has no ambient data, so it must land
+        // on the last pre-ambient-dependencies schema, not silently pass as fully current.
+        assertEquals(DependencyIndexFormat.PRE_AMBIENT_DEPENDENCIES_VERSION, DependencyIndexFormat.migrateLegacyVersion(0));
+    }
+
+    @Test
+    void preAmbientDependenciesVersionIsNotTheCurrentVersion() {
+        assertFalse(DependencyIndexFormat.isCurrentVersion(DependencyIndexFormat.PRE_AMBIENT_DEPENDENCIES_VERSION));
     }
 
     @Test

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/AmbientDependencySelectorTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/AmbientDependencySelectorTest.java
@@ -1,0 +1,42 @@
+package io.github.baokhang83.blastradius.core.selection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class AmbientDependencySelectorTest {
+
+    private final AmbientDependencySelector selector = new AmbientDependencySelector();
+
+    @Test
+    void triggersWhenAChangedClassIsAmbient() {
+        assertTrue(selector.shouldFallback(Set.of("com.example.Foo"), Set.of("com.example.Foo", "java.lang.String")));
+    }
+
+    @Test
+    void doesNotTriggerWhenNoChangedClassIsAmbient() {
+        assertFalse(selector.shouldFallback(Set.of("com.example.Foo"), Set.of("java.lang.String")));
+    }
+
+    @Test
+    void doesNotTriggerWhenAmbientSetIsEmpty() {
+        assertFalse(selector.shouldFallback(Set.of("com.example.Foo"), Set.of()));
+    }
+
+    @Test
+    void doesNotTriggerWhenNoClassesChanged() {
+        assertFalse(selector.shouldFallback(Set.of(), Set.of("com.example.Foo")));
+    }
+
+    @Test
+    void selectProducesFallbackAmbientDependencyReason() {
+        SelectionDecision decision = selector.select(new TestIdentity("com.example.FooTest", "checksAdd"));
+
+        assertTrue(decision.selected());
+        assertEquals(SelectionReason.FALLBACK_AMBIENT_DEPENDENCY, decision.reason());
+    }
+}

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/SelectionEngineTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/SelectionEngineTest.java
@@ -27,7 +27,8 @@ class SelectionEngineTest {
                 Set.of(MATCHED_TEST, UNRELATED_TEST),
                 Map.of(MATCHED_TEST, Set.of("com.example.Foo")),
                 Set.of(),
-                changed);
+                changed,
+                Set.of());
 
         assertTrue(decisions.stream().allMatch(SelectionDecision::selected));
         assertTrue(decisions.stream()
@@ -43,7 +44,8 @@ class SelectionEngineTest {
                 Set.of(NEW_TEST),
                 Map.of(),
                 Set.of(NEW_TEST),
-                changed);
+                changed,
+                Set.of());
 
         assertEquals(1, decisions.size());
         assertEquals(SelectionReason.NEW_OR_MODIFIED_TEST, decisions.get(0).reason());
@@ -58,7 +60,8 @@ class SelectionEngineTest {
                 Set.of(MATCHED_TEST, UNRELATED_TEST),
                 Map.of(MATCHED_TEST, Set.of("com.example.Foo"), UNRELATED_TEST, Set.of("com.example.Other")),
                 Set.of(),
-                changed);
+                changed,
+                Set.of());
 
         SelectionDecision matched = decisions.stream().filter(d -> d.test().equals(MATCHED_TEST)).findFirst().orElseThrow();
         SelectionDecision unrelated = decisions.stream().filter(d -> d.test().equals(UNRELATED_TEST)).findFirst().orElseThrow();
@@ -74,7 +77,8 @@ class SelectionEngineTest {
                 "src/main/kotlin/com/example/Greeting.kt", FileKind.JAVA_SOURCE, "com.example.Greeting"));
 
         List<SelectionDecision> decisions = engine.selectAll(
-                Set.of(MATCHED_TEST), Map.of(MATCHED_TEST, Set.of("com.example.GreetingKt")), Set.of(), changed);
+                Set.of(MATCHED_TEST), Map.of(MATCHED_TEST, Set.of("com.example.GreetingKt")), Set.of(), changed,
+                Set.of());
 
         assertTrue(decisions.getFirst().selected());
         assertEquals("com.example.GreetingKt", decisions.getFirst().matchedChangedClass());
@@ -83,9 +87,26 @@ class SelectionEngineTest {
     @Test
     void producesExactlyOneDecisionPerTest() {
         List<SelectionDecision> decisions = engine.selectAll(
-                Set.of(MATCHED_TEST, UNRELATED_TEST, NEW_TEST), Map.of(), Set.of(), List.of());
+                Set.of(MATCHED_TEST, UNRELATED_TEST, NEW_TEST), Map.of(), Set.of(), List.of(), Set.of());
 
         assertEquals(3, decisions.size());
+    }
+
+    @Test
+    void ambientFallbackTriggersWhenAChangedClassIsAmbient() {
+        List<ChangedFile> changed = List.of(
+                new ChangedFile("src/main/java/com/example/Foo.java", FileKind.JAVA_SOURCE, "com.example.Foo"));
+
+        List<SelectionDecision> decisions = engine.selectAll(
+                Set.of(MATCHED_TEST, UNRELATED_TEST),
+                Map.of(MATCHED_TEST, Set.of("com.example.Foo")),
+                Set.of(),
+                changed,
+                Set.of("com.example.Foo"));
+
+        assertTrue(decisions.stream().allMatch(SelectionDecision::selected));
+        assertTrue(decisions.stream()
+                .allMatch(d -> d.reason() == SelectionReason.FALLBACK_AMBIENT_DEPENDENCY));
     }
 
     @Test
@@ -98,7 +119,8 @@ class SelectionEngineTest {
                 Set.of(MATCHED_TEST, UNRELATED_TEST),
                 Map.of(MATCHED_TEST, Set.of("com.example.Foo")),
                 Set.of(),
-                changed);
+                changed,
+                Set.of());
 
         assertTrue(decisions.stream().noneMatch(SelectionDecision::selected));
         assertTrue(decisions.stream()

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/testsupport/FixtureProjectBuilder.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/testsupport/FixtureProjectBuilder.java
@@ -310,6 +310,13 @@ public final class FixtureProjectBuilder {
                                 <groupId>org.apache.maven.plugins</groupId>
                                 <artifactId>maven-surefire-plugin</artifactId>
                                 <version>3.2.5</version>
+                                <configuration>
+                                    <!-- Deterministic cross-class execution order, so fixtures that rely on
+                                         one test class running before another (e.g. an ambient-dependency
+                                         warm-up class preceding a @BeforeAll-loaded-class gap scenario)
+                                         are reproducible instead of depending on filesystem enumeration. -->
+                                    <runOrder>alphabetical</runOrder>
+                                </configuration>
                             </plugin>
                         </plugins>
                     </build>

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordIoTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordIoTest.java
@@ -1,11 +1,13 @@
 package io.github.baokhang83.blastradius.core.tracking;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -52,5 +54,46 @@ class DependencyRecordIoTest {
         Map<TestIdentity, Map<String, String>> roundTripped = reader.read(file);
 
         assertEquals(original, roundTripped);
+    }
+
+    @Test
+    void readAllStripsATestsOwnClassNameFromTheMergedAmbientSet(@TempDir Path tempDir) throws Exception {
+        // JUnit's discovery pass loads every discovered test class before any test's
+        // tracking window opens, in every fork — so a test class is unconditionally
+        // ambient, regardless of module or fork boundaries, and that membership must
+        // never be mistaken for a real production dependency.
+        Path base = tempDir.resolve("dependencies.json");
+        TestIdentity fooTest = new TestIdentity("com.example.FooTest", "checksFoo");
+        writer.write(base.resolveSibling(base.getFileName() + ".111"),
+                Map.of(fooTest, Map.of("com.example.Foo", "abc123")),
+                Set.of("com.example.FooTest", "com.example.Foo", "java.lang.String"));
+
+        DependencyRecordSet merged = reader.readAll(base);
+
+        assertFalse(merged.ambientDependencies().contains("com.example.FooTest"),
+                "a test's own class name must never remain in the ambient set");
+        assertTrue(merged.ambientDependencies().contains("com.example.Foo"));
+        assertTrue(merged.ambientDependencies().contains("java.lang.String"));
+    }
+
+    @Test
+    void readAllStripsEveryTestsClassNameAcrossMultipleForks(@TempDir Path tempDir) throws Exception {
+        // Simulates a multi-module reactor: each module's tests run in a separate fork
+        // (sibling file), but the merged ambient set must exclude every known test class
+        // across ALL forks, not just the ones tracked in the same fork.
+        Path base = tempDir.resolve("dependencies.json");
+        TestIdentity fooTest = new TestIdentity("com.example.a.FooTest", "checksFoo");
+        TestIdentity usesFooTest = new TestIdentity("com.example.b.UsesFooTest", "checksFoo");
+        writer.write(base.resolveSibling(base.getFileName() + ".111"),
+                Map.of(fooTest, Map.of("com.example.a.Foo", "abc")),
+                Set.of("com.example.a.FooTest", "com.example.b.UsesFooTest"));
+        writer.write(base.resolveSibling(base.getFileName() + ".222"),
+                Map.of(usesFooTest, Map.of("com.example.a.Foo", "abc")),
+                Set.of());
+
+        DependencyRecordSet merged = reader.readAll(base);
+
+        assertFalse(merged.ambientDependencies().contains("com.example.a.FooTest"));
+        assertFalse(merged.ambientDependencies().contains("com.example.b.UsesFooTest"));
     }
 }

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
@@ -3,6 +3,7 @@ package io.github.baokhang83.blastradius.core.tracking;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
@@ -112,6 +113,30 @@ class DependencyTrackingAgentTest {
         assertTrue(all.get(FOO_TEST).containsKey("com.example.Foo"));
         assertFalse(all.get(FOO_TEST).containsKey("com.example.Bar"));
         assertTrue(all.get(barTest).containsKey("com.example.Bar"));
+    }
+
+    @Test
+    void ambientDependenciesIsEmptyWithNoInstrumentationAttached() {
+        // In a plain unit-test JVM (no -javaagent), the static Instrumentation seam is
+        // never set, so loadedClasses() returns Set.of() and the snapshot captures nothing —
+        // this documents that graceful degradation rather than throwing.
+        agent.snapshotAmbientDependencies();
+
+        assertTrue(agent.ambientDependencies().isEmpty());
+    }
+
+    @Test
+    void snapshotAmbientDependenciesIsIdempotent() {
+        agent.snapshotAmbientDependencies();
+        agent.snapshotAmbientDependencies();
+
+        assertTrue(agent.ambientDependencies().isEmpty());
+    }
+
+    @Test
+    void ambientDependenciesReturnsAnImmutableCopy() {
+        Set<String> snapshot = agent.ambientDependencies();
+        assertThrows(UnsupportedOperationException.class, () -> snapshot.add("com.example.Injected"));
     }
 
     private static String sha256Hex(byte[] bytes) throws NoSuchAlgorithmException {

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingIntegrationTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingIntegrationTest.java
@@ -45,7 +45,7 @@ class DependencyTrackingIntegrationTest {
 
         runMvnTest(projectDir, agentJar, recordFile);
 
-        Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(recordFile);
+        Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(recordFile).tests();
         TestIdentity fooTest = new TestIdentity("com.example.FooTest", "checksValue");
 
         assertTrue(recorded.containsKey(fooTest), "expected an entry for " + fooTest + " in " + recorded.keySet());
@@ -86,7 +86,7 @@ class DependencyTrackingIntegrationTest {
         // the reactor session itself, with no separate `mvn install` needed.
         runMvnTest(projectDir, agentJar, recordFile);
 
-        Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(recordFile);
+        Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(recordFile).tests();
         TestIdentity consumerTest = new TestIdentity("com.example.b.ConsumerTest", "checksConsume");
 
         assertTrue(recorded.containsKey(consumerTest),
@@ -115,7 +115,7 @@ class DependencyTrackingIntegrationTest {
 
         runMvnTest(projectDir, agentJar, recordFile);
 
-        Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(recordFile);
+        Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(recordFile).tests();
         TestIdentity emptyTest = new TestIdentity("com.example.EmptyTest", "doesNothing");
 
         assertTrue(recorded.containsKey(emptyTest),
@@ -186,7 +186,7 @@ class DependencyTrackingIntegrationTest {
 
         runMvnTest(projectDir, agentJar, recordFile);
 
-        Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(recordFile);
+        Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(recordFile).tests();
         TestIdentity jdk25Test = new TestIdentity(
                 "com.example.Jdk25TrackingTest", "tracksVirtualThreadSealedAndHiddenClassLoads");
 

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ApplySelectionAction.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ApplySelectionAction.java
@@ -93,7 +93,8 @@ final class ApplySelectionAction implements Action<Task> {
                 .filter(test -> new NewOrModifiedTestSelector().appliesTo(
                         test, !dependenciesByTest.containsKey(test.baselineKey()), changedClassNames))
                 .collect(Collectors.toSet());
-        return new SelectionEngine().selectAll(allTests, dependenciesByTest, newOrModifiedTests, changedFiles);
+        return new SelectionEngine().selectAll(
+                allTests, dependenciesByTest, newOrModifiedTests, changedFiles, Set.of());
     }
 
     private static void applyFilter(Test test, List<SelectionDecision> decisions) {

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/WriteTrackingIndexAction.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/WriteTrackingIndexAction.java
@@ -3,12 +3,11 @@ package io.github.baokhang83.blastradius.gradle;
 import io.github.baokhang83.blastradius.core.index.CommitIndexKey;
 import io.github.baokhang83.blastradius.core.index.IndexStore;
 import io.github.baokhang83.blastradius.core.tracking.DependencyRecordReader;
-import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import io.github.baokhang83.blastradius.core.tracking.DependencyRecordSet;
 import java.io.File;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Task;
@@ -33,8 +32,8 @@ final class WriteTrackingIndexAction implements Action<Task> {
     @Override
     public void execute(Task task) {
         try {
-            Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(recordPrefix.toPath());
-            List<DependencyIndex.TestDependencyEntry> entries = recorded.entrySet().stream()
+            DependencyRecordSet recorded = new DependencyRecordReader().readAll(recordPrefix.toPath());
+            List<DependencyIndex.TestDependencyEntry> entries = recorded.tests().entrySet().stream()
                     .map(entry -> new DependencyIndex.TestDependencyEntry(entry.getKey(), entry.getValue().keySet()))
                     .toList();
             Path repositoryRoot = repositoryDirectory.toPath().toAbsolutePath().normalize();

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/DependencyIndex.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/DependencyIndex.java
@@ -18,14 +18,22 @@ import java.util.stream.Collectors;
  * checksums (data-model.md) — the proven {@code SelectionEngine}/{@code
  * DependencyMatchSelector} logic only ever consumes class names.
  */
-public record DependencyIndex(int formatVersion, String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies) {
+public record DependencyIndex(int formatVersion, String anchorCommit, String builtAt,
+        List<TestDependencyEntry> testDependencies, Set<String> ambientDependencies) {
 
     public DependencyIndex {
         formatVersion = DependencyIndexFormat.migrateLegacyVersion(formatVersion);
+        ambientDependencies = ambientDependencies == null ? Set.of() : Set.copyOf(ambientDependencies);
     }
 
+    public DependencyIndex(String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies,
+            Set<String> ambientDependencies) {
+        this(DependencyIndexFormat.CURRENT_VERSION, anchorCommit, builtAt, testDependencies, ambientDependencies);
+    }
+
+    /** Convenience for callers that don't populate {@code ambientDependencies} (mostly tests). */
     public DependencyIndex(String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies) {
-        this(DependencyIndexFormat.CURRENT_VERSION, anchorCommit, builtAt, testDependencies);
+        this(anchorCommit, builtAt, testDependencies, Set.of());
     }
 
     public record TestDependencyEntry(TestIdentity test, Set<String> dependsOnClasses) {}

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
@@ -399,6 +399,7 @@ public final class SelectMojo extends AbstractMojo {
                         test, !testDependencies.containsKey(test.baselineKey()), changedClassNames))
                 .collect(Collectors.toSet());
 
-        return SELECTION_ENGINE.selectAll(allTests, testDependencies, newOrModifiedTests, changedFiles);
+        return SELECTION_ENGINE.selectAll(
+                allTests, testDependencies, newOrModifiedTests, changedFiles, index.ambientDependencies());
     }
 }

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/ConsoleSummaryRenderer.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/ConsoleSummaryRenderer.java
@@ -31,8 +31,10 @@ public final class ConsoleSummaryRenderer {
             long dependencyMatched = countReason(report, SelectionReason.DEPENDENCY_MATCH);
             long newOrModified = countReason(report, SelectionReason.NEW_OR_MODIFIED_TEST);
             long fallback = countReason(report, SelectionReason.FALLBACK_NON_SOURCE_CHANGE);
-            lines.add(String.format("[blastradius]   dependency-matched: %d, new-or-modified: %d, fallback: %d",
-                    dependencyMatched, newOrModified, fallback));
+            long fallbackAmbient = countReason(report, SelectionReason.FALLBACK_AMBIENT_DEPENDENCY);
+            lines.add(String.format(
+                    "[blastradius]   dependency-matched: %d, new-or-modified: %d, fallback: %d, fallback-ambient: %d",
+                    dependencyMatched, newOrModified, fallback, fallbackAmbient));
             lines.add("[blastradius] Skipped test detail: run with -Dblastradius.explain=true for the full per-test reasoning");
         }
         return lines;

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/track/TrackRunner.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/track/TrackRunner.java
@@ -1,6 +1,7 @@
 package io.github.baokhang83.blastradius.plugin.track;
 
 import io.github.baokhang83.blastradius.core.tracking.DependencyRecordReader;
+import io.github.baokhang83.blastradius.core.tracking.DependencyRecordSet;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex.TestDependencyEntry;
@@ -55,11 +56,11 @@ public final class TrackRunner {
 
         runToCompletion(processBuilder, projectDir);
 
-        Map<TestIdentity, Map<String, String>> recorded = recordReader.readAll(outputFile);
-        List<TestDependencyEntry> entries = recorded.entrySet().stream()
+        DependencyRecordSet recorded = recordReader.readAll(outputFile);
+        List<TestDependencyEntry> entries = recorded.tests().entrySet().stream()
                 .map(entry -> new TestDependencyEntry(entry.getKey(), entry.getValue().keySet()))
                 .toList();
-        return new DependencyIndex(anchorCommit, Instant.now().toString(), entries);
+        return new DependencyIndex(anchorCommit, Instant.now().toString(), entries, recorded.ambientDependencies());
     }
 
     /**

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/DependencyIndexIoTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/DependencyIndexIoTest.java
@@ -81,6 +81,8 @@ class DependencyIndexIoTest {
 
         DependencyIndex migrated = store.get("legacy.json").orElseThrow();
 
-        assertEquals(DependencyIndexFormat.CURRENT_VERSION, migrated.formatVersion());
+        // Not CURRENT_VERSION: a legacy index genuinely has no ambient data, so it must
+        // land on the last pre-ambient-dependencies schema, not silently pass as current.
+        assertEquals(DependencyIndexFormat.PRE_AMBIENT_DEPENDENCIES_VERSION, migrated.formatVersion());
     }
 }

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolverTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolverTest.java
@@ -123,7 +123,7 @@ class IndexApplicabilityResolverTest {
     void unsupportedIndexFormatIsReportedAsAMismatch(@TempDir Path projectDir) {
         String anchorCommit = FixtureProjectBuilder.singleModule(projectDir).commit("initial");
         store(projectDir).put(INDEX_KEY, new DependencyIndex(
-                DependencyIndexFormat.CURRENT_VERSION + 1, anchorCommit, "2026-07-09T10:00:00Z", List.of()));
+                DependencyIndexFormat.CURRENT_VERSION + 1, anchorCommit, "2026-07-09T10:00:00Z", List.of(), Set.of()));
 
         IndexApplicability applicability = resolver.resolve(store(projectDir), INDEX_KEY, anchorCommit, projectDir);
 

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
@@ -6,7 +6,7 @@ import io.github.baokhang83.blastradius.core.index.FileIndexStore;
 import io.github.baokhang83.blastradius.core.index.CommitIndexKey;
 import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
 import io.github.baokhang83.blastradius.core.tracking.DependencyRecordReader;
-import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import io.github.baokhang83.blastradius.core.tracking.DependencyRecordSet;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex.TestDependencyEntry;
 import java.io.IOException;
@@ -34,8 +34,16 @@ final class EndToEndTestSupport {
     }
 
     static void installThisPluginOnce() throws IOException, InterruptedException {
+        // `clean` is required, not cosmetic: without it, when blastradius-maven-plugin's own
+        // sources haven't changed, maven-jar-plugin's up-to-date check skips regenerating its
+        // plain jar, leaving the *previous* run's shaded uber-jar sitting at that same path —
+        // and the next shade execution bootstraps its assembly from that stale self-referential
+        // jar, silently keeping OLD embedded blastradius-core classes as "duplicates" over the
+        // freshly-rebuilt ones. A stale core fix would otherwise never make it into a real
+        // TRACK-mode build's classpath even after rebuilding blastradius-core.
         PLUGIN_INSTALLER.installOnce(() -> runToCompletion(new ProcessBuilder(
-                "mvn", "-q", "-pl", "blastradius-maven-plugin", "-am", "install", "-DskipTests", "-Dinvoker.skip=true")
+                "mvn", "-q", "-pl", "blastradius-maven-plugin", "-am", "clean", "install", "-DskipTests",
+                "-Dinvoker.skip=true")
                 .directory(Path.of("..").toAbsolutePath().normalize().toFile())));
     }
 
@@ -149,11 +157,11 @@ final class EndToEndTestSupport {
         pb.environment().merge("JAVA_TOOL_OPTIONS", agentOption, (a, b) -> a + " " + b);
         runToCompletion(pb);
 
-        Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(outputFile);
-        List<TestDependencyEntry> entries = recorded.entrySet().stream()
+        DependencyRecordSet recorded = new DependencyRecordReader().readAll(outputFile);
+        List<TestDependencyEntry> entries = recorded.tests().entrySet().stream()
                 .map(e -> new TestDependencyEntry(e.getKey(), e.getValue().keySet()))
                 .toList();
-        return new DependencyIndex(anchorCommit, Instant.now().toString(), entries);
+        return new DependencyIndex(anchorCommit, Instant.now().toString(), entries, recorded.ambientDependencies());
     }
 
     static void writeIndex(Path projectDir, DependencyIndex index) {

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/ConsoleSummaryRendererTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/ConsoleSummaryRendererTest.java
@@ -33,7 +33,7 @@ class ConsoleSummaryRendererTest {
         assertEquals(List.of(
                 "[blastradius] SELECT — index built from a1b2c3d (2026-07-09T10:03:00Z)",
                 "[blastradius] 41 / 96 tests selected (57.3% skipped)",
-                "[blastradius]   dependency-matched: 33, new-or-modified: 8, fallback: 0",
+                "[blastradius]   dependency-matched: 33, new-or-modified: 8, fallback: 0, fallback-ambient: 0",
                 "[blastradius] Skipped test detail: run with -Dblastradius.explain=true for the full per-test reasoning"),
                 lines);
     }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
@@ -20,6 +20,7 @@ import io.github.baokhang83.blastradius.core.selection.NewOrModifiedTestSelector
 import io.github.baokhang83.blastradius.core.selection.SelectionDecision;
 import io.github.baokhang83.blastradius.core.selection.SelectionEngine;
 import io.github.baokhang83.blastradius.core.tracking.DependencyRecordReader;
+import io.github.baokhang83.blastradius.core.tracking.DependencyRecordSet;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import io.github.baokhang83.blastradius.validator.verdict.FlakyFailure;
 import io.github.baokhang83.blastradius.validator.verdict.Verdict;
@@ -126,7 +127,8 @@ public final class RunCommand {
         if (buildFailureDetector.isBuildFailure(baseResult, baseWorkDir)) {
             return excluded(pair, "base commit " + pair.baseCommit() + " failed to build");
         }
-        Map<TestIdentity, Map<String, String>> baseRecord = new DependencyRecordReader().readAll(baseDepsFile);
+        DependencyRecordSet baseRecordSet = new DependencyRecordReader().readAll(baseDepsFile);
+        Map<TestIdentity, Map<String, String>> baseRecord = baseRecordSet.tests();
         // Keyed by baselineKey(), not the raw tracked identity, so a ground-truth lookup
         // (which may carry a parameterized-test's Surefire-style invocation suffix) can
         // still find the baseline the tracking agent recorded under the plain method
@@ -164,8 +166,8 @@ public final class RunCommand {
                         test, !testDependencies.containsKey(test.baselineKey()), changedClassNames))
                 .collect(Collectors.toSet());
 
-        List<SelectionDecision> decisions =
-                selectionEngine.selectAll(allTests, testDependencies, newOrModifiedTests, changedFiles);
+        List<SelectionDecision> decisions = selectionEngine.selectAll(
+                allTests, testDependencies, newOrModifiedTests, changedFiles, baseRecordSet.ambientDependencies());
 
         CommitPair enrichedPair = CommitPair.analyzed(pair.baseCommit(), pair.headCommit(), changedFiles);
         List<WouldMissCase> misses = wouldMissComparator.compare(enrichedPair, decisions, groundTruth);

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/EndToEndVerdictIntegrationTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/EndToEndVerdictIntegrationTest.java
@@ -81,6 +81,18 @@ class EndToEndVerdictIntegrationTest {
         fixture.addSystemDependency(null, agentJar);
         fixture.writeClass("com.example.Shared",
                 "package com.example; public class Shared { public static int value() { return 1; } }");
+        // Runs first (alphabetical runOrder, see FixtureProjectBuilder's pom), so the
+        // agent's once-per-fork ambient snapshot is already taken by the time GapTest's
+        // own @BeforeAll loads Shared — otherwise that first-in-fork timing would itself
+        // put Shared in the ambient set and mask the very gap this test documents.
+        fixture.writeTest("com.example.AaaWarmupTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                class AaaWarmupTest {
+                    @Test
+                    void warmsUpTheFork() {}
+                }
+                """);
         fixture.writeTest("com.example.GapTest", """
                 package com.example;
                 import org.junit.jupiter.api.BeforeAll;

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/MultiWouldMissIntegrationTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/MultiWouldMissIntegrationTest.java
@@ -44,6 +44,18 @@ class MultiWouldMissIntegrationTest {
         // before any test starts.
         fixture.writeClass("com.example.MarkerA", "package com.example; public class MarkerA {}");
         fixture.writeClass("com.example.MarkerB", "package com.example; public class MarkerB {}");
+        // Runs first (alphabetical runOrder, see FixtureProjectBuilder's pom), so the
+        // agent's once-per-fork ambient snapshot is already taken before GapATest's own
+        // @BeforeAll loads Shared — otherwise that first-in-fork timing would itself put
+        // Shared in the ambient set and mask the gap both Gap tests below rely on.
+        fixture.writeTest("com.example.AaaWarmupTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                class AaaWarmupTest {
+                    @Test
+                    void warmsUpTheFork() {}
+                }
+                """);
         fixture.writeTest("com.example.GapATest", """
                 package com.example;
                 import org.junit.jupiter.api.BeforeAll;

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunnerTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunnerTest.java
@@ -86,7 +86,7 @@ class MavenBuildRunnerTest {
         BuildResult result = runner.run(projectDir, agentJar, recordFile);
 
         assertEquals(0, result.exitCode());
-        assertTrue(!new DependencyRecordReader().readAll(recordFile).isEmpty(),
+        assertTrue(!new DependencyRecordReader().readAll(recordFile).tests().isEmpty(),
                 "agent should have written its dependency record");
     }
 

--- a/docs/fluencyloop/features/fix-dependency-tracking-agent-missing-classes-loaded-before/design.md
+++ b/docs/fluencyloop/features/fix-dependency-tracking-agent-missing-classes-loaded-before/design.md
@@ -1,0 +1,101 @@
+# Design: fix dependency-tracking agent missing classes loaded before a test's tracking window opens
+
+started: 2026-07-26
+
+## Bug (confirmed by local repro)
+
+`DependencyTrackingAgent.transform()` is a plain `ClassFileTransformer`, registered without
+`canRetransform`, so the JVM invokes it exactly once per class — on that class's first load in
+the fork. JUnit Platform's discovery pass (building the `TestPlan` from every test class's
+methods/annotations) happens before `TestBoundaryListener.executionStarted` ever fires for the
+first test, and can force-load a class like `ChangedFile` during that pass. Once loaded, it is
+never re-transformed, so it is permanently invisible to the tracker for the rest of the fork —
+even for tests that construct/use it directly and run later. Verified locally: 0 of 217 recorded
+test executions in blastradius-core's freshly-tracked index list `ChangedFile` as a dependency,
+despite three tests (`ChangedFileClassifierTest`, `SelectionEngineTest`, `FallbackSelectorTest`)
+constructing it directly.
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class DependencyTrackingAgent {
+    -checksumsByTest: Map~TestIdentity, Map~
+    -ambientDependencies: Set~String~
+    +transform(loader, className, ...) byte[]
+    +recordedDependencies() Map
+    +ambientDependencies() Set~String~
+  }
+  class TestBoundaryListener {
+    +executionStarted(TestIdentifier)
+    +executionFinished(TestIdentifier, Result)
+    -firstTestSeen: boolean
+  }
+  class DependencyIndex {
+    +anchorCommit: String
+    +testDependencies: List~TestDependencyEntry~
+    +ambientDependencies: Set~String~
+  }
+  class FallbackSelector {
+    +shouldFallback(changedFiles) boolean
+  }
+  class AmbientDependencySelector {
+    +selectAll(changedClassNames, ambientDependencies) boolean
+  }
+  class SelectionEngine {
+    +selectAll(...) List~SelectionDecision~
+  }
+  TestBoundaryListener --> DependencyTrackingAgent : snapshots pre-first-test\nloaded classes once
+  DependencyTrackingAgent --> DependencyIndex : ambientDependencies
+  SelectionEngine --> FallbackSelector : non-source change?
+  SelectionEngine --> AmbientDependencySelector : changed class is ambient?
+  AmbientDependencySelector --> DependencyIndex : reads ambientDependencies
+```
+
+## Sequence: before (bug) vs after (fix)
+
+```mermaid
+sequenceDiagram
+  participant JVM as JVM/Surefire fork
+  participant Disc as JUnit discovery
+  participant Agent as DependencyTrackingAgent
+  participant T1 as ChangedFileClassifierTest
+  Note over JVM,T1: BEFORE — the bug
+  JVM->>Disc: build TestPlan (scans all test classes)
+  Disc->>Agent: loads ChangedFile (transform() fires once)
+  Agent-->>Agent: currentTest() == null -> discarded
+  Disc->>T1: executionStarted
+  T1->>T1: new ChangedFile(...) (already loaded, no transform() call)
+  T1->>Agent: executionFinished
+  Note over Agent: ChangedFile never recorded for ANY test
+```
+
+```mermaid
+sequenceDiagram
+  participant JVM as JVM/Surefire fork
+  participant Disc as JUnit discovery
+  participant Agent as DependencyTrackingAgent
+  participant TBL as TestBoundaryListener
+  participant T1 as ChangedFileClassifierTest
+  Note over JVM,T1: AFTER — the fix
+  JVM->>Disc: build TestPlan (scans all test classes)
+  Disc->>Agent: loads ChangedFile (transform() fires once, discarded)
+  Disc->>TBL: executionStarted (first test in this fork)
+  TBL->>Agent: snapshot loadedClasses() once -> ambientDependencies
+  Agent-->>Agent: ambientDependencies += ChangedFile
+  TBL->>T1: proceed
+  T1->>T1: new ChangedFile(...)
+  Note over Agent: index now carries ambientDependencies alongside per-test data
+  Note over Agent: SELECT: ChangedFile changed and in ambientDependencies -> fallback (safe)
+```
+
+## Rejected alternative
+
+Retransform every already-loaded class at each `executionStarted` (`canRetransform=true` +
+`Instrumentation.retransformClasses`) so `transform()` fires again, attributed to whichever test
+is current. Rejected: it only reassigns the "first loader wins" problem to whichever test happens
+to run first after the retransform, and re-running it per test is expensive across a large
+classpath. The ambient-set approach captures the pre-discovery loaded-classes snapshot exactly
+once per fork and treats it as fork-wide (a changed ambient class conservatively triggers
+fallback), which is cheap and matches the system's existing philosophy of falling back rather
+than guessing (FR-007) instead of trying to attribute what is structurally unattributable per-test.

--- a/docs/fluencyloop/features/fix-dependency-tracking-agent-missing-classes-loaded-before/sessions/core-agent-boundary-listener-ambient-snapshot.md
+++ b/docs/fluencyloop/features/fix-dependency-tracking-agent-missing-classes-loaded-before/sessions/core-agent-boundary-listener-ambient-snapshot.md
@@ -1,0 +1,41 @@
+# Session: core: agent + boundary listener ambient snapshot
+
+- **intent:** core: agent + boundary listener ambient snapshot
+- **started:** 2026-07-26
+
+<!--
+FluencyLoop Stage 3 — a session is a slice of the build. One block per meaningful decision,
+appended at the slice boundary as it's taught. No `commits:` field: the feature is a branch,
+so the PR view derives commits live from git.
+
+Each decision is a `## Decision:` heading followed by a bullet list — one bullet per field, so
+it renders one-per-line as real Markdown (plain `key: value` lines collapse into a single
+paragraph when rendered). Fields:
+
+  where        — file/area the decision lives in (NOT a line number — survives refactoring)
+  why          — the rationale, taught live before it was written
+  alternative  — the rejected option and why (this is what makes it rationale, not description)
+  design       — (optional) ../design.md#anchor — the diagram this decision shaped or used
+  constitution — (optional) §N — the principle this decision serves or trades off against
+  trust        — ✓ verified | ⚠ not independently verified  (about the DECISION, never the person)
+
+Delete this comment and the example below once real decisions land.
+-->
+
+---
+
+## Knowledge transfer
+
+- `DependencyTrackingAgent.ambientDependencies`/`ambientSnapshotTaken`: a `ConcurrentHashMap.newKeySet()` and an `AtomicBoolean`, both instance-scoped (per fork, since `installedAgent` is one per JVM). `snapshotAmbientDependencies()` is guarded by `compareAndSet(false, true)` so only the very first caller across all threads actually iterates `loadedClasses()`; every later call in the same fork is a no-op. Status: documented.
+- `recordAmbientSnapshot()` (static) mirrors the existing `recordTestStarted(TestIdentity)` entry-point pattern: null-check `installedAgent`, delegate to an instance method. Kept consistent with the rest of the class rather than inventing a new shape. Status: documented.
+- `TestBoundaryListener.executionStarted` now calls `recordAmbientSnapshot()` as its very first statement, before `recordTestStarted(test)` — ordering matters: the ambient snapshot must be taken before the first test's own tracking window opens, otherwise classes the first test itself loads would be wrongly folded into the "ambient" (pre-test) set. Status: documented.
+- `ambientDependencies()` public accessor returns `Set.copyOf(...)` (immutable snapshot), same convention as `recordedDependencies()`'s `Map.copyOf` per-entry — callers (the not-yet-built `TrackRunner`/`DependencyIndex` wiring) can't mutate agent-internal state. Status: documented.
+- Follow-up (not yet built): this set is currently only readable in-process; it still needs a path to disk (Task #2 — record writer/reader) before `TrackRunner` can pull it into the persisted `DependencyIndex`. Status: follow-up.
+
+## Decision: snapshot ambient classes at first executionStarted, not agent install
+
+- **where:** `blastradius-core/.../tracking/DependencyTrackingAgent.java, TestBoundaryListener.java`
+- **why:** premain() runs before JUnit Platform's discovery pass builds the TestPlan, so a snapshot taken at install time would miss exactly the classes discovery force-loads — the first test boundary is the earliest point after discovery has already run, guarded idempotent via an AtomicBoolean so later tests are no-ops
+- **alternative:** canRetransform=true + retransformClasses() at every executionStarted — rejected: only reassigns 'first loader wins' to whichever test runs right after the retransform, and re-running it per test is expensive across a large classpath
+- **design:** ../design.md#sequence-before-bug-vs-after-fix
+- **trust:** ⚠ not independently verified

--- a/docs/fluencyloop/features/fix-dependency-tracking-agent-missing-classes-loaded-before/sessions/core-persist-ambient-set-through-record-writer-reader.md
+++ b/docs/fluencyloop/features/fix-dependency-tracking-agent-missing-classes-loaded-before/sessions/core-persist-ambient-set-through-record-writer-reader.md
@@ -1,0 +1,46 @@
+# Session: core: persist ambient set through record writer/reader
+
+- **intent:** core: persist ambient set through record writer/reader
+- **started:** 2026-07-26
+
+<!--
+FluencyLoop Stage 3 — a session is a slice of the build. One block per meaningful decision,
+appended at the slice boundary as it's taught. No `commits:` field: the feature is a branch,
+so the PR view derives commits live from git.
+
+Each decision is a `## Decision:` heading followed by a bullet list — one bullet per field, so
+it renders one-per-line as real Markdown (plain `key: value` lines collapse into a single
+paragraph when rendered). Fields:
+
+  where        — file/area the decision lives in (NOT a line number — survives refactoring)
+  why          — the rationale, taught live before it was written
+  alternative  — the rejected option and why (this is what makes it rationale, not description)
+  design       — (optional) ../design.md#anchor — the diagram this decision shaped or used
+  constitution — (optional) §N — the principle this decision serves or trades off against
+  trust        — ✓ verified | ⚠ not independently verified  (about the DECISION, never the person)
+
+Delete this comment and the example below once real decisions land.
+-->
+
+---
+
+## Knowledge transfer
+
+- `DependencyRecordFile`/`DependencyRecordSet`: two distinct types with a similar shape but different jobs — `DependencyRecordFile` is the private on-disk JSON shape for one `<prefix>.<pid>` file; `DependencyRecordSet` is the public in-memory result of merging every sibling file's tests and ambient sets in `readAll`. Kept separate rather than reusing one type across both roles, since the merged/queryable shape and the raw per-file JSON shape are allowed to diverge independently. Status: documented.
+- `DependencyRecordReader.readAll` changed its return type from a bare `Map<TestIdentity, Map<String,String>>` to `DependencyRecordSet` — every existing caller (`TrackRunner`, `RunCommand` in blastradius-validator, `WriteTrackingIndexAction` in blastradius-gradle-plugin, `EndToEndTestSupport`, `DependencyTrackingIntegrationTest`, `MavenBuildRunnerTest`) needed a one-line `.tests()` unwrap; the gradle plugin's own `DependencyIndex` class (same simple name, different package) was untouched since it isn't the type this feature is changing. Status: documented.
+- `DependencyIndexFormat.CURRENT_VERSION` bumped 1 → 2 for the new `ambientDependencies` field; `IndexApplicabilityResolver`'s existing `hasCurrentFormat()` check (unchanged) now naturally rejects any index still at version 1 or migrated-legacy version 1, forcing the safe TRACK/fallback path rather than trusting a possibly-absent ambient set. Status: documented.
+
+## Decision: changed DependencyRecord on-disk shape from bare JSON array to an object wrapper
+
+- **where:** `blastradius-core/.../tracking/DependencyRecordFile.java, DependencyRecordWriter.java, DependencyRecordReader.java`
+- **why:** the per-JVM record file is an ephemeral intra-build protocol between the writer and reader, never persisted across builds, so its shape can change freely without a version-migration story — unlike DependencyIndex
+- **alternative:** keep the flat array and smuggle the ambient set into a sentinel DependencyRecord entry — rejected: overloads a type that already means 'one test's dependencies' with an unrelated fork-wide concept
+- **trust:** ⚠ not independently verified
+
+## Decision: decoupled legacy index migration target from CURRENT_VERSION; kept a 3-arg DependencyIndex convenience overload
+
+- **where:** `blastradius-core/.../index/DependencyIndexFormat.java (PRE_AMBIENT_DEPENDENCIES_VERSION), blastradius-maven-plugin/.../index/DependencyIndex.java`
+- **why:** migrateLegacyVersion mapping straight to CURRENT_VERSION would let a legacy index masquerade as having the new ambientDependencies field (silently empty) instead of correctly failing hasCurrentFormat() and falling back; the 3-arg overload avoids touching ~20 existing tests that don't exercise ambient behavior, mirroring the record's existing formatVersion-defaulting convenience constructor
+- **alternative:** bump every old test call site to pass Set.of() explicitly — rejected: pure churn across files unrelated to this feature, no behavioral coverage gained
+- **constitution:** Principle III (Safety Over Speed)
+- **trust:** ⚠ not independently verified

--- a/docs/fluencyloop/features/fix-dependency-tracking-agent-missing-classes-loaded-before/sessions/core-plugin-ambientdependencyselector-wiring-into-selectione.md
+++ b/docs/fluencyloop/features/fix-dependency-tracking-agent-missing-classes-loaded-before/sessions/core-plugin-ambientdependencyselector-wiring-into-selectione.md
@@ -1,0 +1,47 @@
+# Session: core+plugin: AmbientDependencySelector wiring into SelectionEngine, SelectMojo, ConsoleSummaryRenderer
+
+- **intent:** core+plugin: AmbientDependencySelector wiring into SelectionEngine, SelectMojo, ConsoleSummaryRenderer
+- **started:** 2026-07-26
+
+<!--
+FluencyLoop Stage 3 — a session is a slice of the build. One block per meaningful decision,
+appended at the slice boundary as it's taught. No `commits:` field: the feature is a branch,
+so the PR view derives commits live from git.
+
+Each decision is a `## Decision:` heading followed by a bullet list — one bullet per field, so
+it renders one-per-line as real Markdown (plain `key: value` lines collapse into a single
+paragraph when rendered). Fields:
+
+  where        — file/area the decision lives in (NOT a line number — survives refactoring)
+  why          — the rationale, taught live before it was written
+  alternative  — the rejected option and why (this is what makes it rationale, not description)
+  design       — (optional) ../design.md#anchor — the diagram this decision shaped or used
+  constitution — (optional) §N — the principle this decision serves or trades off against
+  trust        — ✓ verified | ⚠ not independently verified  (about the DECISION, never the person)
+
+Delete this comment and the example below once real decisions land.
+-->
+
+---
+
+## Decision: distinct FALLBACK_AMBIENT_DEPENDENCY reason instead of reusing FALLBACK_NON_SOURCE_CHANGE
+
+- **where:** `blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionReason.java`
+- **why:** a changed class showing up in the ambient set is a fundamentally different signal from a non-source file change — collapsing them into one reason would hide from the console/report exactly why every test ran, which is the whole point of Principle V (Explainability)
+- **alternative:** reuse FALLBACK_NON_SOURCE_CHANGE for both cases — rejected: it would silently blur two distinct root causes in the build report, making the ambient-dependency bug invisible to anyone reading the summary
+- **constitution:** Principle V (Explainability)
+- **trust:** ⚠ not independently verified
+
+## Decision: wire real ambient data into SelectMojo/RunCommand, stub Set.of() in ApplySelectionAction
+
+- **where:** `blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ApplySelectionAction.java`
+- **why:** the gradle-plugin's tracking pipeline doesn't capture ambient dependencies yet — passing Set.of() is an honest default for what it actually has, rather than pretending it participates in this fix
+- **alternative:** wire the gradle-plugin's tracking side up to capture ambient data too, in this same slice — rejected: out of scope for this bugfix, and would silently widen the blast radius of a targeted fix into an unrelated module
+- **trust:** ⚠ not independently verified
+
+## Knowledge transfer
+
+- **`AmbientDependencySelector`** (new, `core/selection`) — wraps `Collections.disjoint(changedClassNames, ambientDependencies)` to decide whether *any* changed class was present in the fork's ambient snapshot; if so, every test gets `fallbackAmbientDependency()`. status: documented
+- **`SelectionEngine.selectAll`** — gained a 5th `Set<String> ambientDependencies` parameter; the ambient short-circuit check runs after `changedClassNames` is computed but before the per-test decision loop, so it can skip per-test dependency matching entirely once it fires (same short-circuit shape as the existing non-source-change fallback). status: documented
+- **`ConsoleSummaryRenderer`/contract doc drift** — the `[blastradius]   dependency-matched: ..., fallback: ...` line is a documented, test-verified contract (`specs/002-ci-gating-plugin/contracts/mojo-and-index-contract.md`); adding a reason bucket to the renderer without updating both the contract doc and `ConsoleSummaryRendererTest`'s expected string would have let the doc, the code, and the test silently diverge. status: documented
+- **Stale test caught post-hoc**: `DependencyIndexFormatTest.migratesTheKnownUnversionedLegacySchemaToTheCurrentVersion` was written before Task #2's migration-target decoupling and still asserted `migrateLegacyVersion(0) == CURRENT_VERSION` — now wrong on purpose, since the whole point of `PRE_AMBIENT_DEPENDENCIES_VERSION` is that a legacy index must *not* pass as current. Fixed by asserting against `PRE_AMBIENT_DEPENDENCIES_VERSION` instead (widened from `private` to package-private so the test can reference it symbolically). Caught by a full-reactor `mvn test` run, not by `test-compile`. status: documented

--- a/docs/fluencyloop/features/fix-dependency-tracking-agent-missing-classes-loaded-before/sessions/tests-full-verify-fixture-ordering-fix-for-ambient-snapshot.md
+++ b/docs/fluencyloop/features/fix-dependency-tracking-agent-missing-classes-loaded-before/sessions/tests-full-verify-fixture-ordering-fix-for-ambient-snapshot.md
@@ -1,0 +1,59 @@
+# Session: tests + full verify: fixture ordering fix for ambient-snapshot timing regression
+
+- **intent:** tests + full verify: fixture ordering fix for ambient-snapshot timing regression
+- **started:** 2026-07-26
+
+<!--
+FluencyLoop Stage 3 — a session is a slice of the build. One block per meaningful decision,
+appended at the slice boundary as it's taught. No `commits:` field: the feature is a branch,
+so the PR view derives commits live from git.
+
+Each decision is a `## Decision:` heading followed by a bullet list — one bullet per field, so
+it renders one-per-line as real Markdown (plain `key: value` lines collapse into a single
+paragraph when rendered). Fields:
+
+  where        — file/area the decision lives in (NOT a line number — survives refactoring)
+  why          — the rationale, taught live before it was written
+  alternative  — the rejected option and why (this is what makes it rationale, not description)
+  design       — (optional) ../design.md#anchor — the diagram this decision shaped or used
+  constitution — (optional) §N — the principle this decision serves or trades off against
+  trust        — ✓ verified | ⚠ not independently verified  (about the DECISION, never the person)
+
+Delete this comment and the example below once real decisions land.
+-->
+
+---
+
+## Decision: fixed 2 integration tests by adding a deterministic warm-up test class, not by weakening the ambient fallback
+
+- **where:** `blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/EndToEndVerdictIntegrationTest.java`
+- **why:** the full reactor test run surfaced that the ambient snapshot (taken on the first executionStarted in the fork) incidentally captured Shared when GapTest/GapATest happened to be the very first test class run, since their own @BeforeAll runs before that first test's window opens — this coincidentally 'fixed' the exact narrow gap these tests exist to document, flipping verdict from FAIL to PASS. The fixtures needed a preceding warm-up test class (plus explicit alphabetical runOrder in FixtureProjectBuilder's pom, so cross-class order is deterministic rather than filesystem-dependent) so the ambient snapshot fires before the Gap classes' own @BeforeAll, preserving the real remaining limitation: a class loaded only during a later class's @BeforeAll is still invisible to tracking
+- **alternative:** narrow AmbientDependencySelector or special-case @BeforeAll-loaded classes so this fixture keeps failing — rejected: that would reintroduce exactly the bug this whole feature fixes for any project where the first-loaded test class happens to load its dependency in @BeforeAll; the fixture was wrong to assume that shape, not the fix
+- **trust:** ⚠ not independently verified
+
+## Knowledge transfer
+
+- **`FixtureProjectBuilder`'s base pom** now sets `<runOrder>alphabetical</runOrder>` on surefire — every fixture-based test that depends on cross-class execution order (not just these two) is now deterministic instead of relying on filesystem enumeration order. status: documented
+- **`DependencyIndexFormatTest`** had a second stale assertion from Task #2's work (`isCurrentVersion` should be false for the pre-ambient version) — added alongside the corrected migration-target test, both now passing. status: documented
+- **Remaining real gap, now precisely scoped**: a class loaded only inside a test class's `@BeforeAll`, where that class is *not* the first test executed in the fork, is still invisible to both per-test tracking and the ambient snapshot — this is the one case the ambient-dependency fix does not close, and it's what `EndToEndVerdictIntegrationTest`/`MultiWouldMissIntegrationTest` now correctly continue to document. status: documented
+
+## Decision: added clean to the plugin's E2E install command, not a target-dir workaround
+
+- **where:** `blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java`
+- **why:** mvn install (no clean) can leave a stale shaded uber-jar in place when the plugin's own sources haven't changed, since maven-jar-plugin's up-to-date check skips regenerating the plain jar; shade then bootstraps its assembly from that self-referential stale jar and discards the freshly-rebuilt blastradius-core classes as duplicates (first-seen-wins) - so a correct, unit-tested source fix could still silently not take effect through the actually-installed plugin. Confirmed via javap -c decompilation of the embedded class before/after: 0 to 1 occurrences of the fix's Set.remove call
+- **alternative:** manually delete blastradius-maven-plugin/target before each E2E run, or touch sources to defeat jar-plugin's up-to-date check - rejected: both are fragile hand-rolled workarounds for exactly what clean does correctly as maven's own designed mechanism
+- **trust:** ✓ verified
+
+## Decision: covered the ambient-snapshot mechanism's unit gap with the safe no-agent path only, not real capture
+
+- **where:** `blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java`
+- **why:** loadedClasses() reads a private static instrumentation field only ever set by premain, and that field plus installedAgent are shared JVM-wide across every test class in a surefire fork (default reuseForks=true) - faking a real Instrumentation via reflection to exercise actual capture would leak global state into every other test in the module, for behavior the E2E suite (IndexReuseAcrossBuildsTest, via a real -javaagent attach) already verifies authentically end to end
+- **alternative:** reflectively inject a fake Instrumentation and call premain from the unit test to exercise real class-capture - rejected: pollutes shared static state across the whole test JVM fork for coverage the E2E path already provides
+- **trust:** ⚠ not independently verified
+
+## Knowledge transfer
+
+- **`AmbientDependencySelectorTest`** (new file) covers `AmbientDependencySelector.shouldFallback`'s `Collections.disjoint` logic directly (trigger/no-trigger across an ambient hit, a miss, an empty ambient set, and no changed classes) plus `select()`'s `FALLBACK_AMBIENT_DEPENDENCY` reason — this class had zero prior test coverage. status: documented
+- **`DependencyTrackingAgentTest`** gained three tests for the ambient-snapshot surface (`ambientDependencies()` defaults empty with no agent attached, `snapshotAmbientDependencies()` is a safe idempotent no-op without a real `Instrumentation`, and `ambientDependencies()` returns an immutable `Set.copyOf`) — the actual class-capturing behavior (`loadedClasses()` reading a real `Instrumentation`) is only exercised for real by the E2E suite, since no unit-test seam exists to inject one without touching shared static state (see decision above). status: documented
+- **`DependencyIndexFormatTest`** already had full coverage of the version-2 (`ambientDependencies`) migration path (`migrateLegacyVersion`, `isCurrentVersion` for both the pre-ambient and current versions) from earlier in this feature — checked, nothing further needed. status: documented
+- **`TestBoundaryListenerTest`** was left as-is: it already exercises `executionStarted`'s no-installed-agent path (via `DependencyTrackingAgent.recordAmbientSnapshot()`'s null-safe no-op) implicitly, since the existing test would fail if that call misbehaved; asserting the snapshot-before-recordTestStarted ordering more directly would need the same static-state injection ruled out above. status: follow-up

--- a/specs/002-ci-gating-plugin/contracts/mojo-and-index-contract.md
+++ b/specs/002-ci-gating-plugin/contracts/mojo-and-index-contract.md
@@ -120,7 +120,7 @@ planned execution set, not their final pass/fail result.
 ```
 [blastradius] SELECT — index built from a1b2c3d (2026-07-09T10:03:00Z)
 [blastradius] 41 / 96 tests selected (57.3% skipped)
-[blastradius]   dependency-matched: 33, new-or-modified: 8, fallback: 0
+[blastradius]   dependency-matched: 33, new-or-modified: 8, fallback: 0, fallback-ambient: 0
 [blastradius] Skipped test detail: run with -Dblastradius.explain=true for the full per-test reasoning
 ```
 


### PR DESCRIPTION
## Fix dependency-tracking agent missing classes loaded before a test's tracking window opens

JUnit Platform's discovery pass force-loads every test class before any test's tracking
window opens, in every JVM fork — so a test class's own name was always present in the
ambient snapshot, with zero relation to real dependency data. Left unfixed, changing *any*
test file trivially matched the ambient set and spuriously ran the full suite.

### Decisions worth reviewer attention (all ⚠ not independently verified unless noted)

**Session: tests + full verify**
- **Added `clean` to the E2E harness's plugin install command** (`EndToEndTestSupport.java`) — `mvn install` (no clean) can leave a stale shaded uber-jar in place when the plugin's own sources are unchanged, since maven-jar-plugin's up-to-date check skips regenerating the plain jar; shade then bootstraps from that self-referential stale jar and silently discards freshly-rebuilt `blastradius-core` classes as duplicates. **Trust: ✓ verified** (confirmed via `javap -c` bytecode decompilation before/after).
- **Left the ambient-snapshot unit-test gap covered only for the safe no-agent path**, not real class-capture (`DependencyTrackingAgentTest.java`) — `loadedClasses()` reads a private static `instrumentation` field shared JVM-wide across the whole surefire fork; faking it via reflection would leak global state into every other test in the module for behavior the E2E suite (`IndexReuseAcrossBuildsTest`) already verifies authentically via a real `-javaagent` attach.

**Session: core agent + boundary listener**
- Snapshot ambient classes at the first `executionStarted`, not at agent install — install-time is before JUnit's discovery pass runs, so it would miss exactly the classes discovery force-loads. Idempotent via `AtomicBoolean`.

**Session: persist ambient set through record writer/reader**
- Changed the per-JVM `DependencyRecord` on-disk shape from a bare array to an object wrapper — it's an ephemeral intra-build protocol, never persisted across builds, so it can change freely unlike `DependencyIndex`.
- Decoupled legacy index migration target from `CURRENT_VERSION` (new `PRE_AMBIENT_DEPENDENCIES_VERSION`) — mapping straight to current would let a legacy index masquerade as having ambient data instead of correctly falling back.

**Session: SelectionReason + AmbientDependencySelector + SelectionEngine wiring**
- Distinct `FALLBACK_AMBIENT_DEPENDENCY` reason instead of reusing `FALLBACK_NON_SOURCE_CHANGE` — collapsing them would hide from the console/report exactly why every test ran (Constitution §V, Explainability).
- Wired real ambient data into `SelectMojo`/`RunCommand`; stubbed `Set.of()` in the gradle-plugin's `ApplySelectionAction`, since its tracking pipeline doesn't capture ambient data yet — honest default, not silently widening this bugfix's scope into another module.

### Constitution check

Reviewed against `.specify/memory/constitution.md` (this repo's real source of truth; `docs/fluencyloop/constitution.md` is a pointer to it). The distinct `FALLBACK_AMBIENT_DEPENDENCY` reason directly serves **§V (Explainability)** — a build report that already distinguished ambient-fallback from non-source-change fallback for anyone auditing why tests ran. No conflicts surfaced.

### Verification

- `mvn -q -pl blastradius-core test` — pass.
- Full reactor `mvn -q clean test -Dinvoker.skip=true` (core, S3 index store, validator, maven-plugin, gradle-plugin, coverage) — pass, no failures.
