### PR TITLE
Surface stale-baseline fallback reason and fix TrackRunner's self-poisoning test isolation

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "fix-dependency-tracking-agent-missing-classes-loaded-before",
-  "branch": "feature/fix-dependency-tracking-agent-missing-classes-loaded-before",
+  "feature": "surface-a-distinct-reason-when-the-stale-baseline-fallback-s",
+  "branch": "feature/surface-a-distinct-reason-when-the-stale-baseline-fallback-s",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/fix-dependency-tracking-agent-missing-classes-loaded-before/sessions/tests-full-verify-fixture-ordering-fix-for-ambient-snapshot.md",
+  "last_session": "docs/fluencyloop/features/surface-a-distinct-reason-when-the-stale-baseline-fallback-s/sessions/surface-format-version-mismatch-instead-of-bare-missing-and.md",
   "base_ref": "main",
-  "updated": "2026-07-26"
+  "updated": "2026-07-27"
 }

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -116,21 +117,41 @@ class DependencyTrackingAgentTest {
     }
 
     @Test
-    void ambientDependenciesIsEmptyWithNoInstrumentationAttached() {
-        // In a plain unit-test JVM (no -javaagent), the static Instrumentation seam is
-        // never set, so loadedClasses() returns Set.of() and the snapshot captures nothing —
-        // this documents that graceful degradation rather than throwing.
-        agent.snapshotAmbientDependencies();
+    void ambientDependenciesIsEmptyWithNoInstrumentationAttached() throws Exception {
+        // loadedClasses() reads the static Instrumentation seam shared by the whole JVM fork.
+        // It's genuinely null in a plain unit-test run, but TrackRunner re-forks this very
+        // module's own tests with a real -javaagent attached to collect dependency data —
+        // so this test must force the seam to its "no agent" state itself rather than assume
+        // the ambient JVM matches, or it fails deterministically under that fork. No lambda
+        // here: another test in this class self-loads this class's own compiled bytecode as
+        // a hidden class, which an invokedynamic call site (as a lambda would add) breaks.
+        Field instrumentationField = DependencyTrackingAgent.class.getDeclaredField("instrumentation");
+        instrumentationField.setAccessible(true);
+        Object previous = instrumentationField.get(null);
+        instrumentationField.set(null, null);
+        try {
+            agent.snapshotAmbientDependencies();
 
-        assertTrue(agent.ambientDependencies().isEmpty());
+            assertTrue(agent.ambientDependencies().isEmpty());
+        } finally {
+            instrumentationField.set(null, previous);
+        }
     }
 
     @Test
-    void snapshotAmbientDependenciesIsIdempotent() {
-        agent.snapshotAmbientDependencies();
-        agent.snapshotAmbientDependencies();
+    void snapshotAmbientDependenciesIsIdempotent() throws Exception {
+        Field instrumentationField = DependencyTrackingAgent.class.getDeclaredField("instrumentation");
+        instrumentationField.setAccessible(true);
+        Object previous = instrumentationField.get(null);
+        instrumentationField.set(null, null);
+        try {
+            agent.snapshotAmbientDependencies();
+            agent.snapshotAmbientDependencies();
 
-        assertTrue(agent.ambientDependencies().isEmpty());
+            assertTrue(agent.ambientDependencies().isEmpty());
+        } finally {
+            instrumentationField.set(null, previous);
+        }
     }
 
     @Test

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolver.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolver.java
@@ -5,6 +5,7 @@ import io.github.baokhang83.blastradius.core.index.CommitIndexKey;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Optional;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
@@ -61,26 +62,44 @@ public final class IndexApplicabilityResolver {
         }
 
         try {
-            return store.keys(parentPrefix(indexPathKey)).stream()
+            List<KeyEvaluation> evaluations = store.keys(parentPrefix(indexPathKey)).stream()
                     .map(key -> CommitIndexKey.commitFromKey(indexPathKey, key)
-                            .flatMap(commit -> readCandidate(store, key, commit, currentCommit, projectDir)))
+                            .map(commit -> evaluate(store, key, commit, currentCommit, projectDir)))
                     .flatMap(Optional::stream)
-                .min(Comparator.comparingInt(Candidate::distanceFromHead))
+                    .toList();
+
+            return evaluations.stream()
+                    .flatMap(evaluation -> evaluation.candidate().stream())
+                    .min(Comparator.comparingInt(Candidate::distanceFromHead))
                     .map(candidate -> IndexApplicability.staleBaseline(candidate.index()))
-                    .orElseGet(IndexApplicability::missing);
+                    .orElseGet(() -> evaluations.stream().anyMatch(KeyEvaluation::formatIncompatible)
+                            ? IndexApplicability.formatVersionMismatch()
+                            : IndexApplicability.missing());
         } catch (UncheckedIOException e) {
             return IndexApplicability.unreadable();
         }
     }
 
-    private static Optional<Candidate> readCandidate(IndexStore<DependencyIndex> store, String key, String keyCommit,
+    /**
+     * Evaluates one enumerated candidate key, distinguishing "this key just doesn't
+     * qualify" (empty candidate) from *why* — a format-incompatible index still means an
+     * index was found, which is more informative than the enumeration coming up
+     * completely empty (Constitution §V, Explainability): a stale baseline whose only
+     * candidate predates a format-version bump on {@code main} should say so, not report
+     * bare {@code MISSING} as if nothing had ever been cached.
+     */
+    private static KeyEvaluation evaluate(IndexStore<DependencyIndex> store, String key, String keyCommit,
             String currentCommit, Path projectDir) {
         DependencyIndex index = store.get(key).orElse(null);
-        if (index == null || !index.hasCurrentFormat() || !index.anchorCommit().equals(keyCommit)) {
-            return Optional.empty();
+        if (index == null || !index.anchorCommit().equals(keyCommit)) {
+            return new KeyEvaluation(Optional.empty(), false);
         }
-        return distanceFromHead(index.anchorCommit(), currentCommit, projectDir)
+        if (!index.hasCurrentFormat()) {
+            return new KeyEvaluation(Optional.empty(), true);
+        }
+        Optional<Candidate> candidate = distanceFromHead(index.anchorCommit(), currentCommit, projectDir)
                 .map(distance -> new Candidate(index, distance));
+        return new KeyEvaluation(candidate, false);
     }
 
     private static String parentPrefix(String indexPathKey) {
@@ -113,6 +132,9 @@ public final class IndexApplicabilityResolver {
     }
 
     private record Candidate(DependencyIndex index, int distanceFromHead) {}
+
+    /** A qualifying {@code candidate}, or a non-qualifying key flagged {@code formatIncompatible}. */
+    private record KeyEvaluation(Optional<Candidate> candidate, boolean formatIncompatible) {}
 
     private static boolean anchorIsReachable(String anchorCommit, Path projectDir) {
         try (org.eclipse.jgit.api.Git git = org.eclipse.jgit.api.Git.open(projectDir.toFile())) {

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolverTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolverTest.java
@@ -120,6 +120,33 @@ class IndexApplicabilityResolverTest {
     }
 
     @Test
+    void staleBaselineFallbackReportsFormatMismatchNotMissingWhenOnlyCandidateIsOutdated(
+            @TempDir Path projectDir) {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        String oldAnchor = fixture.commit("last baseline before a format bump");
+        fixture.writeClass("com.example.Feature", "package com.example; class Feature {}");
+        String expectedBase = fixture.commit("main advances past the format bump");
+        fixture.writeClass("com.example.Changed", "package com.example; class Changed {}");
+        String head = fixture.commit("feature change");
+
+        DependencyIndex outdatedIndex = new DependencyIndex(DependencyIndexFormat.CURRENT_VERSION - 1,
+                oldAnchor, "2026-07-09T10:00:00Z", List.of(), Set.of());
+        IndexStore<DependencyIndex> store = store(projectDir);
+        store.put(CommitIndexKey.forCommit(INDEX_KEY, oldAnchor), outdatedIndex);
+
+        IndexApplicability applicability = resolver.resolve(
+                store,
+                CommitIndexKey.forCommit(INDEX_KEY, expectedBase),
+                INDEX_KEY,
+                expectedBase,
+                head,
+                projectDir);
+
+        assertEquals(IndexApplicability.Status.FORMAT_VERSION_MISMATCH, applicability.status());
+        assertNull(applicability.index());
+    }
+
+    @Test
     void unsupportedIndexFormatIsReportedAsAMismatch(@TempDir Path projectDir) {
         String anchorCommit = FixtureProjectBuilder.singleModule(projectDir).commit("initial");
         store(projectDir).put(INDEX_KEY, new DependencyIndex(

--- a/docs/fluencyloop/features/surface-a-distinct-reason-when-the-stale-baseline-fallback-s/design.md
+++ b/docs/fluencyloop/features/surface-a-distinct-reason-when-the-stale-baseline-fallback-s/design.md
@@ -1,0 +1,119 @@
+# Design: surface a distinct reason when the stale-baseline fallback's only candidates are format-incompatible, instead of collapsing to bare MISSING
+
+<!--
+FluencyLoop Stage 2 — one design.md per feature, committed alongside it.
+Defaults: a class diagram and a sequence diagram (the two first-class Mermaid types that
+pay their way most often). Add an interaction/flow view only when it earns its place.
+Keep the Mermaid blocks TOP-LEVEL (not nested in another code fence) so GitHub renders them.
+Delete this comment once the diagrams are real.
+-->
+
+started: 2026-07-27
+
+Root cause (PR #121): the ambient-dependency feature bumped `DependencyIndexFormat.CURRENT_VERSION`
+1 -> 2. Right after that merge, every previously-cached commit-keyed index on disk is genuinely
+`formatVersion: 1` until main's own next TRACK run produces and saves a fresh v2 index. A PR built
+from that same main tip, before main's save completes, hits the ancestor-enumeration fallback in
+`IndexApplicabilityResolver` with exactly one candidate — the old v1 index — which gets silently
+dropped for failing `hasCurrentFormat()`. With zero survivors the resolver falls back to a bare
+`IndexApplicability.missing()`, so the console prints "no persisted index found (MISSING)" even
+though an index *was* found; it's just the wrong schema version. This is misleading under this
+repo's Explainability principle (a distinct fallback reason must be surfaced, not blurred) — and
+running the full suite in this case is otherwise the *correct*, safe call (an old-schema index
+can't be safely consumed by the current selection engine).
+
+The fix stays inside `IndexApplicabilityResolver`'s enumeration path only: track *why* each
+enumerated candidate was rejected, not just whether one qualified, and prefer reporting
+`FORMAT_VERSION_MISMATCH` (an existing `IndexApplicability.Status` with its own console message
+already) over generic `MISSING` when that's what actually happened. No new status, no behavior
+change to which mode runs (`FALLBACK` either way) — only the reported *reason* changes.
+
+## Root cause (PR #122): main can never recover on its own
+
+PR #122 was built from the exact same commit (`4fad559f`, the very merge commit that bumped the
+format version) and hit the same bare `MISSING`. Tracing it further: main's own push-triggered CI
+run for `4fad559f` forced `TRACK` mode (first build of that commit), but the forked tracking
+subprocess (`TrackRunner`, `mvn clean test -DargLine=-javaagent:...`) failed before writing a
+fresh index — so nothing new was ever persisted. The workflow still reported overall success (a
+warning, not a failure) and still saved a cache entry *labeled* with `4fad559f`'s commit sha, but
+its actual contents were whatever stale, pre-bump data had been restored earlier in that same job.
+Every PR built from `4fad559f` therefore restored a cache that *looked* like a hit for the right
+commit but wasn't — a genuinely different failure from the enumeration-fallback bug above, and a
+more serious one: main could not fix this by itself on a rerun, since the same subprocess would
+fail identically every time.
+
+The subprocess failed because it re-runs the *whole reactor's* tests with a real `-javaagent`
+attached to collect dependency data — including `blastradius-core`'s own
+`DependencyTrackingAgentTest`. Two of its tests assumed the static `Instrumentation` seam
+(`DependencyTrackingAgent.instrumentation`) was always `null`, true in a plain unit-test run but
+false inside `TrackRunner`'s own subprocess. The fix makes those two tests force that seam to
+`null` via reflection for their own duration and restore it afterward, so they're correct
+regardless of which JVM fork they run in.
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class IndexApplicabilityResolver {
+    +resolve(store, exactKey, expectedAnchor, projectDir) IndexApplicability
+    +resolve(store, exactKey, indexPathKey, expectedAnchor, currentCommit, projectDir) IndexApplicability
+    -evaluate(store, key, keyCommit, currentCommit, projectDir) KeyEvaluation
+    -distanceFromHead(anchor, current, projectDir) Optional~int~
+  }
+  class KeyEvaluation {
+    <<record, new>>
+    +candidate: Optional~Candidate~
+    +formatIncompatible: boolean
+  }
+  class Candidate {
+    <<record>>
+    +index: DependencyIndex
+    +distanceFromHead: int
+  }
+  class IndexApplicability {
+    +status: Status
+    +index: DependencyIndex
+  }
+  class Status {
+    <<enum>>
+    APPLICABLE
+    STALE_BASELINE
+    MISSING
+    FORMAT_VERSION_MISMATCH
+    ANCHOR_UNREACHABLE
+    ANCHOR_MISMATCH
+    MERGE_BASE_UNAVAILABLE
+    UNREADABLE
+    INTERNAL_ERROR
+  }
+
+  IndexApplicabilityResolver ..> KeyEvaluation : produces per candidate key
+  KeyEvaluation --> Candidate : wraps, when qualified
+  IndexApplicabilityResolver ..> IndexApplicability : returns
+  IndexApplicability --> Status
+```
+
+## Sequence: enumeration fallback picks a reason, not just a candidate
+
+```mermaid
+sequenceDiagram
+  participant Mojo as SelectMojo
+  participant Resolver as IndexApplicabilityResolver
+  participant Store as FileIndexStore
+
+  Mojo->>Resolver: resolve(exactKey=4fad559f, ...)
+  Resolver->>Store: get(4fad559f)
+  Store-->>Resolver: empty (not saved yet - main still tracking)
+  Resolver->>Store: keys(".blastradius")
+  Store-->>Resolver: [".blastradius/a34c0337.../index.json"]
+  Resolver->>Resolver: evaluate(key=a34c0337)
+  note right of Resolver: hasCurrentFormat() false (v1, pre-bump)<br/>KeyEvaluation(candidate=empty, formatIncompatible=true)
+  Resolver->>Resolver: no candidates qualified
+  alt any evaluation formatIncompatible
+    Resolver-->>Mojo: FORMAT_VERSION_MISMATCH
+  else
+    Resolver-->>Mojo: MISSING
+  end
+  Mojo->>Mojo: determineMode(...) -> FALLBACK (unchanged)
+  note over Mojo: console now reports the real reason instead of bare MISSING
+```

--- a/docs/fluencyloop/features/surface-a-distinct-reason-when-the-stale-baseline-fallback-s/sessions/surface-format-version-mismatch-instead-of-bare-missing-and.md
+++ b/docs/fluencyloop/features/surface-a-distinct-reason-when-the-stale-baseline-fallback-s/sessions/surface-format-version-mismatch-instead-of-bare-missing-and.md
@@ -1,0 +1,52 @@
+# Session: surface FORMAT_VERSION_MISMATCH instead of bare MISSING, and fix TrackRunner's self-poisoning test isolation bug
+
+- **intent:** surface FORMAT_VERSION_MISMATCH instead of bare MISSING, and fix TrackRunner's self-poisoning test isolation bug
+- **started:** 2026-07-27
+
+---
+
+## Knowledge transfer
+
+- **`IndexApplicabilityResolver`'s two-overload shape**: a 2-arg exact-match check and a 5-arg
+  enumeration fallback that runs only when the exact key misses. The fallback walks every
+  commit-keyed index on disk, filters to ancestor-reachable candidates, and previously reduced
+  "found candidates, none qualified" and "found nothing at all" to the same bare `MISSING` —
+  now it distinguishes them via `KeyEvaluation(candidate, formatIncompatible)`. Status:
+  documented.
+- **GitHub Actions `restore-keys` prefix matching is not aware of what's inside the tarball it
+  restores**: a `cache-hit` output of `false` combined with a restore-key hit that happens to
+  share the *current commit's own sha as a substring of the matched key name* does not mean the
+  cache's actual on-disk contents are anchored at that commit — it only means the key *string*
+  matched a prefix. If the job that later `save`s under the new key never actually refreshed
+  the on-disk files (e.g. a forked subprocess failed before writing), the save step silently
+  re-uploads stale data under the new commit's label. Status: documented.
+- **`TrackRunner` re-forks `mvn clean test` on the whole reactor with `-DargLine=-javaagent:...`**
+  to collect real dependency data — this means every module's own test suite, including
+  `blastradius-core`'s tests *for the tracking agent itself*, runs a second time inside a JVM
+  that genuinely has the agent attached. Any test that assumes "no agent is attached" as its
+  baseline is only safe in the primary (non-TRACK) build; it must actively force that state
+  rather than assume it. Status: documented.
+- **`MethodHandles.lookup().defineHiddenClass(bytes, false)` self-loading a test class's own
+  compiled bytecode is fragile to what's in that bytecode**: adding a lambda (and its
+  `invokedynamic` call site) to `DependencyTrackingAgentTest` broke
+  `newlyCreatedHiddenClassUsesItsStableSourceName` with a `VerifyError`, because the hidden-class
+  redefinition can't cleanly re-link an `invokedynamic` bootstrap bound to the original class's
+  identity. Any future edit to this test class must avoid introducing lambdas/method references.
+  Status: documented.
+
+## Decision: report FORMAT_VERSION_MISMATCH over bare MISSING when the enumeration fallback's only candidates are format-stale
+
+- **where:** `blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolver.java`
+- **why:** PR #121/#122 both printed 'no persisted index found (MISSING)' when an index genuinely existed on disk but predated the v1->v2 format bump; the enumeration path silently discarded format-incompatible candidates instead of reporting why, so operators couldn't tell 'nothing was ever cached' from 'a stale-schema index was found and correctly rejected'
+- **alternative:** leave enumeration collapsing all rejections to bare MISSING — rejected: hides the real reason from the console/report, violating this repo's Explainability principle, and looks identical to a cold cache to anyone debugging why the full suite ran
+- **design:** ../design.md#sequence-enumeration-fallback-picks-a-reason-not-just-a-candidate
+- **constitution:** §V
+- **trust:** ✓ verified
+
+## Decision: reset the static instrumentation seam via reflection in DependencyTrackingAgentTest instead of assuming the JVM has no agent attached
+
+- **where:** `blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java`
+- **why:** TrackRunner re-forks 'mvn clean test' on the whole reactor with a real -javaagent attached to collect dependency data, which re-runs blastradius-core's own test suite inside that instrumented JVM; two tests assumed the static Instrumentation field was always null (true in a plain unit-test run, false inside TrackRunner's subprocess), so they failed deterministically every time main tried to refresh its index — main could never successfully re-track, so every downstream PR fell back to the full suite with no way to recover on its own
+- **alternative:** leave the tests asserting on ambient JVM state — rejected: this is exactly the risk flagged (but deferred) in the ambient-dependency PR's own notes ('the unit-test gap is covered only for the safe no-agent path'); it materialized as a self-inflicted, deterministic TRACK failure, not flakiness. Also rejected: wrapping the reset in a Runnable lambda — a lambda adds an invokedynamic call site to this class's bytecode, which breaks a separate pre-existing test that self-loads this class's own compiled .class bytes as a hidden class; the reset is inlined per-test instead
+- **constitution:** §V
+- **trust:** ✓ verified


### PR DESCRIPTION
# PR view — surface a distinct reason when the stale-baseline fallback's only candidates are format-incompatible, instead of collapsing to bare MISSING

_1 commit(s) over `main..HEAD`; feature branch `feature/surface-a-distinct-reason-when-the-stale-baseline-fallback-s`._

---

# Session: surface FORMAT_VERSION_MISMATCH instead of bare MISSING, and fix TrackRunner's self-poisoning test isolation bug

- **intent:** surface FORMAT_VERSION_MISMATCH instead of bare MISSING, and fix TrackRunner's self-poisoning test isolation bug
- **started:** 2026-07-27

---

## Knowledge transfer

- **`IndexApplicabilityResolver`'s two-overload shape**: a 2-arg exact-match check and a 5-arg
  enumeration fallback that runs only when the exact key misses. The fallback walks every
  commit-keyed index on disk, filters to ancestor-reachable candidates, and previously reduced
  "found candidates, none qualified" and "found nothing at all" to the same bare `MISSING` —
  now it distinguishes them via `KeyEvaluation(candidate, formatIncompatible)`. Status:
  documented.
- **GitHub Actions `restore-keys` prefix matching is not aware of what's inside the tarball it
  restores**: a `cache-hit` output of `false` combined with a restore-key hit that happens to
  share the *current commit's own sha as a substring of the matched key name* does not mean the
  cache's actual on-disk contents are anchored at that commit — it only means the key *string*
  matched a prefix. If the job that later `save`s under the new key never actually refreshed
  the on-disk files (e.g. a forked subprocess failed before writing), the save step silently
  re-uploads stale data under the new commit's label. Status: documented.
- **`TrackRunner` re-forks `mvn clean test` on the whole reactor with `-DargLine=-javaagent:...`**
  to collect real dependency data — this means every module's own test suite, including
  `blastradius-core`'s tests *for the tracking agent itself*, runs a second time inside a JVM
  that genuinely has the agent attached. Any test that assumes "no agent is attached" as its
  baseline is only safe in the primary (non-TRACK) build; it must actively force that state
  rather than assume it. Status: documented.
- **`MethodHandles.lookup().defineHiddenClass(bytes, false)` self-loading a test class's own
  compiled bytecode is fragile to what's in that bytecode**: adding a lambda (and its
  `invokedynamic` call site) to `DependencyTrackingAgentTest` broke
  `newlyCreatedHiddenClassUsesItsStableSourceName` with a `VerifyError`, because the hidden-class
  redefinition can't cleanly re-link an `invokedynamic` bootstrap bound to the original class's
  identity. Any future edit to this test class must avoid introducing lambdas/method references.
  Status: documented.

## Decision: report FORMAT_VERSION_MISMATCH over bare MISSING when the enumeration fallback's only candidates are format-stale

- **where:** `blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/IndexApplicabilityResolver.java`
- **why:** PR #121/#122 both printed 'no persisted index found (MISSING)' when an index genuinely existed on disk but predated the v1->v2 format bump; the enumeration path silently discarded format-incompatible candidates instead of reporting why, so operators couldn't tell 'nothing was ever cached' from 'a stale-schema index was found and correctly rejected'
- **alternative:** leave enumeration collapsing all rejections to bare MISSING — rejected: hides the real reason from the console/report, violating this repo's Explainability principle, and looks identical to a cold cache to anyone debugging why the full suite ran
- **design:** ../design.md#sequence-enumeration-fallback-picks-a-reason-not-just-a-candidate
- **constitution:** §V
- **trust:** ✓ verified

## Decision: reset the static instrumentation seam via reflection in DependencyTrackingAgentTest instead of assuming the JVM has no agent attached

- **where:** `blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java`
- **why:** TrackRunner re-forks 'mvn clean test' on the whole reactor with a real -javaagent attached to collect dependency data, which re-runs blastradius-core's own test suite inside that instrumented JVM; two tests assumed the static Instrumentation field was always null (true in a plain unit-test run, false inside TrackRunner's subprocess), so they failed deterministically every time main tried to refresh its index — main could never successfully re-track, so every downstream PR fell back to the full suite with no way to recover on its own
- **alternative:** leave the tests asserting on ambient JVM state — rejected: this is exactly the risk flagged (but deferred) in the ambient-dependency PR's own notes ('the unit-test gap is covered only for the safe no-agent path'); it materialized as a self-inflicted, deterministic TRACK failure, not flakiness. Also rejected: wrapping the reset in a Runnable lambda — a lambda adds an invokedynamic call site to this class's bytecode, which breaks a separate pre-existing test that self-loads this class's own compiled .class bytes as a hidden class; the reset is inlined per-test instead
- **constitution:** §V
- **trust:** ✓ verified

