### PR TITLE
fix: attribute discovery-loaded classes at runtime

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "surface-a-distinct-reason-when-the-stale-baseline-fallback-s",
-  "branch": "feature/surface-a-distinct-reason-when-the-stale-baseline-fallback-s",
+  "feature": "narrow-ambient-dependency-fallback-to-statically-identified",
+  "branch": "feature/narrow-ambient-dependency-fallback-to-statically-identified",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/surface-a-distinct-reason-when-the-stale-baseline-fallback-s/sessions/surface-format-version-mismatch-instead-of-bare-missing-and.md",
+  "last_session": "docs/fluencyloop/features/narrow-ambient-dependency-fallback-to-statically-identified/sessions/attribute-discovery-loaded-project-classes-by-runtime-execut.md",
   "base_ref": "main",
   "updated": "2026-07-27"
 }

--- a/blastradius-core/pom.xml
+++ b/blastradius-core/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>${asm.version}</version>
+        </dependency>
         <!-- Compile scope: TestBoundaryListener instruments the TARGET project's own
              JUnit 5 run, not just ours, so it ships as part of the shaded agent jar. -->
         <dependency>

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenter.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenter.java
@@ -1,0 +1,82 @@
+package io.github.baokhang83.blastradius.core.tracking;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+
+/**
+ * Adds lightweight runtime-use callbacks to an already-loaded project class: method entry plus
+ * field, type, and class-literal references. The callbacks are filtered by the agent to retain
+ * only successfully retransformed project classes.
+ */
+final class AmbientClassInstrumenter {
+
+    private static final String AGENT_INTERNAL_NAME =
+            "io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent";
+
+    byte[] instrument(String className, byte[] bytecode) {
+        ClassReader reader = new ClassReader(bytecode);
+        ClassWriter writer = new ClassWriter(reader, ClassWriter.COMPUTE_MAXS);
+        AtomicBoolean changed = new AtomicBoolean();
+        reader.accept(new ClassVisitor(Opcodes.ASM9, writer) {
+            @Override
+            public MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
+                    String[] exceptions) {
+                MethodVisitor delegate = super.visitMethod(access, name, descriptor, signature, exceptions);
+                if ((access & (Opcodes.ACC_ABSTRACT | Opcodes.ACC_NATIVE)) != 0) {
+                    return delegate;
+                }
+                changed.set(true);
+                return new MethodVisitor(Opcodes.ASM9, delegate) {
+                    @Override
+                    public void visitCode() {
+                        super.visitCode();
+                        record(className);
+                    }
+
+                    @Override
+                    public void visitFieldInsn(int opcode, String owner, String name, String descriptor) {
+                        record(owner.replace('/', '.'));
+                        super.visitFieldInsn(opcode, owner, name, descriptor);
+                    }
+
+                    @Override
+                    public void visitTypeInsn(int opcode, String type) {
+                        record(type.replace('/', '.'));
+                        super.visitTypeInsn(opcode, type);
+                    }
+
+                    @Override
+                    public void visitLdcInsn(Object value) {
+                        if (value instanceof Type type
+                                && (type.getSort() == Type.OBJECT || type.getSort() == Type.ARRAY)) {
+                            record(type.getClassName());
+                        }
+                        super.visitLdcInsn(value);
+                    }
+
+                    @Override
+                    public void visitMultiANewArrayInsn(String descriptor, int numDimensions) {
+                        record(Type.getType(descriptor).getClassName());
+                        super.visitMultiANewArrayInsn(descriptor, numDimensions);
+                    }
+
+                    private void record(String dependencyClassName) {
+                        super.visitLdcInsn(dependencyClassName);
+                        super.visitMethodInsn(
+                                Opcodes.INVOKESTATIC,
+                                AGENT_INTERNAL_NAME,
+                                "recordAmbientExecution",
+                                "(Ljava/lang/String;)V",
+                                false);
+                    }
+                };
+            }
+        }, 0);
+        return changed.get() ? writer.toByteArray() : null;
+    }
+}

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
@@ -2,6 +2,8 @@ package io.github.baokhang83.blastradius.core.tracking;
 
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -18,11 +20,12 @@ import java.util.stream.Collectors;
  * A {@code -javaagent} that observes every class loaded in the JVM it's attached to,
  * attributes each load to the currently-executing test (via the injected supplier — in
  * production, {@link TestBoundaryListener#currentTest()}), and records the class name with a
- * SHA-256 checksum of the loaded bytecode. Bytecode is never modified — {@link #transform}
- * always returns {@code null}. Classes loaded while no test is running (JVM/Surefire bootstrap,
- * etc.) are not attributable to anything and are not recorded. Hidden classes are not class-loader
- * definitions, so the listener uses the agent's loaded-class list at test boundaries to record
- * their stable source name. The persisted selection index consumes class names only.
+ * SHA-256 checksum of the loaded bytecode. A project class that discovery loaded before the first
+ * test can be retransformed with runtime-use callbacks, so its later execution is attributed to
+ * the test that actually uses it. Classes loaded while no test is running (JVM/Surefire bootstrap,
+ * etc.) are retained as ambient when they cannot be safely instrumented. Hidden classes are not
+ * class-loader definitions, so the listener uses the agent's loaded-class list at test boundaries
+ * to record their stable source name. The persisted selection index consumes class names only.
  */
 public final class DependencyTrackingAgent implements ClassFileTransformer {
 
@@ -48,6 +51,10 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
     private final Supplier<TestIdentity> currentTestSupplier;
     private final Map<TestIdentity, Map<String, String>> checksumsByTest = new ConcurrentHashMap<>();
     private final Set<String> ambientDependencies = ConcurrentHashMap.newKeySet();
+    private final Set<String> pendingAmbientRetransformations = ConcurrentHashMap.newKeySet();
+    private final Set<String> transformedAmbientClasses = ConcurrentHashMap.newKeySet();
+    private final Map<String, String> ambientChecksums = new ConcurrentHashMap<>();
+    private final AmbientClassInstrumenter ambientClassInstrumenter = new AmbientClassInstrumenter();
     private final AtomicBoolean ambientSnapshotTaken = new AtomicBoolean(false);
 
     public DependencyTrackingAgent() {
@@ -82,7 +89,7 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
         DependencyTrackingAgent agent = new DependencyTrackingAgent();
         installedAgent = agent;
         instrumentation = inst;
-        inst.addTransformer(agent);
+        inst.addTransformer(agent, true);
         if (agentArgs != null && !agentArgs.isBlank()) {
             Path outputFile = Path.of(agentArgs + "." + ProcessHandle.current().pid());
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -101,6 +108,21 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
             return null;
         }
 
+        String dottedClassName = className.replace('/', '.');
+        if (classBeingRedefined != null && pendingAmbientRetransformations.contains(dottedClassName)) {
+            try {
+                byte[] instrumented = ambientClassInstrumenter.instrument(dottedClassName, classfileBuffer);
+                if (instrumented != null) {
+                    ambientChecksums.put(dottedClassName, sha256Hex(classfileBuffer));
+                    transformedAmbientClasses.add(dottedClassName);
+                }
+                return instrumented;
+            } catch (RuntimeException ignored) {
+                // An uninstrumentable discovery-loaded class stays ambient and therefore safe.
+                return null;
+            }
+        }
+
         TestIdentity currentTest = currentTestSupplier.get();
         if (currentTest == null) {
             return null;
@@ -110,7 +132,7 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
         try {
             checksumsByTest
                     .computeIfAbsent(currentTest, ignored -> new ConcurrentHashMap<>())
-                    .put(className.replace('/', '.'), sha256Hex(classfileBuffer));
+                    .put(dottedClassName, sha256Hex(classfileBuffer));
         } finally {
             RECORDING_CLASS_LOAD.remove();
         }
@@ -154,9 +176,73 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
 
     void snapshotAmbientDependencies() {
         if (ambientSnapshotTaken.compareAndSet(false, true)) {
-            for (Class<?> loadedClass : loadedClasses()) {
+            Set<Class<?>> loadedClasses = loadedClasses();
+            for (Class<?> loadedClass : loadedClasses) {
                 ambientDependencies.add(loadedClass.getName());
             }
+            retransformProjectAmbientClasses(loadedClasses);
+        }
+    }
+
+    /** Called from bytecode injected into an already-loaded project class. */
+    public static void recordAmbientExecution(String className) {
+        DependencyTrackingAgent currentAgent = installedAgent;
+        if (currentAgent != null) {
+            currentAgent.recordAmbientExecutionForCurrentTest(className);
+        }
+    }
+
+    private void recordAmbientExecutionForCurrentTest(String className) {
+        TestIdentity currentTest = currentTestSupplier.get();
+        String checksum = ambientChecksums.get(className);
+        if (currentTest != null && checksum != null) {
+            checksumsByTest
+                    .computeIfAbsent(currentTest, ignored -> new ConcurrentHashMap<>())
+                    .putIfAbsent(className, checksum);
+        }
+    }
+
+    private void retransformProjectAmbientClasses(Set<Class<?>> loadedClasses) {
+        Instrumentation currentInstrumentation = instrumentation;
+        if (currentInstrumentation == null || !currentInstrumentation.isRetransformClassesSupported()) {
+            return;
+        }
+        for (Class<?> loadedClass : loadedClasses) {
+            if (!isProjectClassOutput(loadedClass) || !currentInstrumentation.isModifiableClass(loadedClass)) {
+                continue;
+            }
+            String className = loadedClass.getName();
+            pendingAmbientRetransformations.add(className);
+            try {
+                currentInstrumentation.retransformClasses(loadedClass);
+                if (transformedAmbientClasses.remove(className)) {
+                    ambientDependencies.remove(className);
+                }
+            } catch (Exception | LinkageError ignored) {
+                // Retain the ambient class so selection continues to use its safe fallback.
+            } finally {
+                pendingAmbientRetransformations.remove(className);
+            }
+        }
+    }
+
+    private static boolean isProjectClassOutput(Class<?> loadedClass) {
+        if (loadedClass.isArray() || loadedClass.isPrimitive() || loadedClass.getProtectionDomain() == null
+                || loadedClass.getProtectionDomain().getCodeSource() == null) {
+            return false;
+        }
+        try {
+            URI location = loadedClass.getProtectionDomain().getCodeSource().getLocation().toURI();
+            if (!"file".equals(location.getScheme())) {
+                return false;
+            }
+            String path = Path.of(location).normalize().toString().replace('\\', '/');
+            return path.endsWith("/target/classes")
+                    || path.endsWith("/target/test-classes")
+                    || path.endsWith("/build/classes/java/main")
+                    || path.endsWith("/build/classes/java/test");
+        } catch (URISyntaxException | IllegalArgumentException ignored) {
+            return false;
         }
     }
 

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingIntegrationTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.github.baokhang83.blastradius.core.tracking;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -120,6 +121,48 @@ class DependencyTrackingIntegrationTest {
 
         assertTrue(recorded.containsKey(emptyTest),
                 "an executed test must have a baseline even without application class loads: " + recorded.keySet());
+    }
+
+    @Test
+    void executionOfAClassLoadedBeforeTheFirstTestIsAttributedToThatTest(
+            @TempDir Path projectDir, @TempDir Path outDir) throws Exception {
+        Path agentJar = findOwnAgentJar();
+        Path recordFile = outDir.resolve("deps.json");
+
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.addSystemDependency(null, agentJar);
+        fixture.writeClass("com.example.DiscoveryLoadedDependency", """
+                package com.example;
+                public final class DiscoveryLoadedDependency {
+                    public static final String VALUE = new String("tracked");
+                }
+                """);
+        fixture.writeTest("com.example.DiscoveryLoadedDependencyTest", """
+                package com.example;
+                import org.junit.jupiter.api.BeforeAll;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class DiscoveryLoadedDependencyTest {
+                    @BeforeAll static void preloadBeforeAnyTestBoundary() {
+                        assertEquals("tracked", DiscoveryLoadedDependency.VALUE);
+                    }
+                    @Test void readsThePreloadedDependency() {
+                        assertEquals("tracked", DiscoveryLoadedDependency.VALUE);
+                    }
+                }
+                """);
+        fixture.commit("initial");
+
+        runMvnTest(projectDir, agentJar, recordFile);
+
+        DependencyRecordSet recorded = new DependencyRecordReader().readAll(recordFile);
+        TestIdentity test = new TestIdentity(
+                "com.example.DiscoveryLoadedDependencyTest", "readsThePreloadedDependency");
+
+        assertTrue(recorded.tests().get(test).containsKey("com.example.DiscoveryLoadedDependency"),
+                "runtime field use after discovery must be attributed: " + recorded.tests().get(test));
+        assertFalse(recorded.ambientDependencies().contains("com.example.DiscoveryLoadedDependency"),
+                "a successfully instrumented project class must not keep the global ambient fallback");
     }
 
     @Test

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeEndToEndTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeEndToEndTest.java
@@ -64,6 +64,75 @@ class SelectModeEndToEndTest {
     }
 
     @Test
+    void narrowsSelectionForAClassThatJUnitLoadedBeforeTheFirstTest(@TempDir Path projectDir) throws Exception {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.writeClass("com.example.DiscoveryLoadedDependency", """
+                package com.example;
+                public final class DiscoveryLoadedDependency {
+                    public static final String VALUE = new String("tracked");
+                }
+                """);
+        fixture.writeTest("com.example.DiscoveryLoadedDependencyTest", """
+                package com.example;
+                import org.junit.jupiter.api.BeforeAll;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class DiscoveryLoadedDependencyTest {
+                    @BeforeAll static void preloadBeforeAnyTestBoundary() {
+                        assertEquals("tracked", DiscoveryLoadedDependency.VALUE);
+                    }
+                    @Test void readsThePreloadedDependency() {
+                        assertEquals("tracked", DiscoveryLoadedDependency.VALUE);
+                    }
+                }
+                """);
+        fixture.writeClass("com.example.Unrelated", """
+                package com.example;
+                public final class Unrelated { public static int value() { return 7; } }
+                """);
+        fixture.writeTest("com.example.UnrelatedTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class UnrelatedTest {
+                    @Test void remainsIndependent() { assertEquals(7, Unrelated.value()); }
+                }
+                """);
+        String initialCommit = fixture.commit("initial");
+
+        DependencyIndex trackedIndex = EndToEndTestSupport.trackDependencies(projectDir, initialCommit);
+        fixture.addBuildPlugin(null, EndToEndTestSupport.pluginXml("baseline"));
+        String anchorCommit = fixture.commit("bind selection plugin");
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.branchCreate().setName("baseline").setStartPoint(anchorCommit).call();
+            git.checkout().setCreateBranch(true).setName("feature").call();
+        }
+        fixture.writeClass("com.example.DiscoveryLoadedDependency", """
+                package com.example;
+                public final class DiscoveryLoadedDependency {
+                    public static final String VALUE = String.join("", "tr", "acked");
+                }
+                """);
+        fixture.commit("change discovery-loaded dependency");
+        // The persisted index is a CI workspace artifact, not a source change. Write it after
+        // committing the feature change so the fixture's broad git-add cannot classify it as
+        // a non-source change and deliberately trigger the safety fallback.
+        EndToEndTestSupport.writeIndex(projectDir, new DependencyIndex(
+                anchorCommit,
+                trackedIndex.builtAt(),
+                trackedIndex.testDependencies(),
+                trackedIndex.ambientDependencies()));
+
+        String output = EndToEndTestSupport.runMvnTest(projectDir);
+
+        assertTrue(output.contains("BUILD SUCCESS"), "expected the build to succeed:\n" + output);
+        assertTrue(output.contains("Running com.example.DiscoveryLoadedDependencyTest"),
+                "expected the runtime consumer to run:\n" + output);
+        assertFalse(output.contains("Running com.example.UnrelatedTest"),
+                "expected the independent test to be skipped:\n" + output);
+    }
+
+    @Test
     void kotlinFileFacadeChangeSelectsOnlyItsTrackedKotlinTest(@TempDir Path projectDir) throws Exception {
         FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
         fixture.enableKotlin();

--- a/docs/fluencyloop/features/narrow-ambient-dependency-fallback-to-statically-identified/design.md
+++ b/docs/fluencyloop/features/narrow-ambient-dependency-fallback-to-statically-identified/design.md
@@ -1,0 +1,77 @@
+# Design: attribute discovery-loaded classes by runtime execution
+
+started: 2026-07-27
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class TestBoundaryListener {
+    +executionStarted()
+  }
+  class DependencyTrackingAgent {
+    +snapshotAmbientDependencies()
+    +recordAmbientExecution()
+  }
+  class AmbientClassInstrumenter {
+    +instrument runtime use probes
+  }
+  class Instrumentation {
+    +retransformClasses()
+  }
+  class DependencyRecordWriter {
+    +write()
+  }
+  class DependencyIndex {
+    +testDependencies
+    +ambientDependencies
+  }
+  TestBoundaryListener --> DependencyTrackingAgent : opens test boundary
+  DependencyTrackingAgent --> Instrumentation : retransforms project classes
+  DependencyTrackingAgent --> AmbientClassInstrumenter : adds method-entry probe
+  AmbientClassInstrumenter --> DependencyTrackingAgent : runtime execution callback
+  DependencyTrackingAgent --> DependencyRecordWriter : persists attributed dependencies
+  DependencyRecordWriter --> DependencyIndex : builds selection baseline
+```
+
+## Sequence: discovery-loaded application class
+
+```mermaid
+sequenceDiagram
+  participant JUnit as JUnit discovery
+  participant Agent as tracking agent
+  participant Listener as test boundary listener
+  participant Class as already-loaded application class
+  participant Index as dependency index
+
+  JUnit->>Agent: load application class before any test
+  Listener->>Agent: first test starts
+  Agent->>Agent: snapshot ambient classes
+  Agent->>Class: retransform with runtime use probes
+  Note over Listener,Agent: test identity becomes current after retransformation
+  Class->>Agent: method, field, type, or class-literal use during test
+  Agent->>Agent: record class under current test
+  Agent->>Index: persist per-test dependency
+  alt class cannot be retransformed or instrumented
+    Agent->>Index: retain class as ambient
+  end
+```
+
+## Decision
+
+Replace the static test-class scan with runtime attribution. At the first test boundary, the
+agent retransforms discovery-loaded project classes and adds probes for method execution plus
+field, type, and class-literal use. If a test later uses one of those classes, the probe records
+the class under that test's normal dependency entry. Selection can then use the existing
+dependency matcher, including indirect calls, reflection, dependency-injection paths, and direct
+non-constant static-field reads that a static scan cannot see.
+
+The ambient set remains the conservative escape hatch only for classes that cannot be safely
+retransformed or instrumented. Those classes still trigger the existing full-scope fallback when
+they change. The agent must instrument only project class-output directories, never JDK or third
+party library classes, to avoid changing platform behavior and to keep the retransformation scope
+bounded.
+
+The rejected alternative is a compiled-test-class reference scan. It can identify direct type
+references but cannot prove an indirect or dynamic runtime path, so it could miss the very tests
+the ambient guard was introduced to protect.

--- a/docs/fluencyloop/features/narrow-ambient-dependency-fallback-to-statically-identified/sessions/attribute-discovery-loaded-project-classes-by-runtime-execut.md
+++ b/docs/fluencyloop/features/narrow-ambient-dependency-fallback-to-statically-identified/sessions/attribute-discovery-loaded-project-classes-by-runtime-execut.md
@@ -1,0 +1,13 @@
+# Session: attribute discovery-loaded project classes by runtime execution probes
+
+- **intent:** attribute discovery-loaded project classes by runtime execution probes
+- **started:** 2026-07-27
+
+## Decision: decision
+
+- **where:** `DependencyTrackingAgent and AmbientClassInstrumenter`
+- **why:** Classes loaded during JUnit discovery are not attributable by load time. Retransform only project output classes at the first test boundary and record later method, field, type, and class-literal use under the active test. Any class that cannot be transformed stays ambient so SELECT retains the conservative fallback.
+- **alternative:** A compiled-test-class reference scan — rejected: it cannot observe indirect calls or dynamic runtime paths and would weaken the tracking model.
+- **design:** [`../design.md`](../design.md)
+- **constitution:** §III, §IV, §V
+- **trust:** ⚠ not independently verified

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
 
         <jgit.version>7.7.0.202606012155-r</jgit.version>
         <jackson.version>2.17.1</jackson.version>
+        <asm.version>9.7.1</asm.version>
         <junit.version>5.10.2</junit.version>
         <surefire.version>3.2.5</surefire.version>
         <compiler.plugin.version>3.13.0</compiler.plugin.version>


### PR DESCRIPTION
## Summary

- Retransform discovery-loaded project classes at the first test boundary and attribute their later runtime use to the active test.
- Preserve the conservative ambient fallback for classes that cannot be safely retransformed.
- Cover direct field use with core and Maven end-to-end regressions: the dependent test is selected and an unrelated test is skipped.

## FluencyLoop decision

Chose runtime probes over a compiled-test-class reference scan because runtime paths can be indirect or dynamic. The decision is documented in `docs/fluencyloop/features/narrow-ambient-dependency-fallback-to-statically-identified/` (design and session). The runtime behavior remains marked ⚠ not independently verified in CI.

## Verification

- `mvn -B --no-transfer-progress -pl blastradius-core test`
- `mvn -B --no-transfer-progress -pl blastradius-maven-plugin -am -Dtest=SelectModeEndToEndTest#narrowsSelectionForAClassThatJUnitLoadedBeforeTheFirstTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -B --no-transfer-progress clean verify`