### PR TITLE
fix: avoid tracking-agent callback recursion

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
   "feature": "narrow-ambient-dependency-fallback-to-statically-identified",
-  "branch": "feature/narrow-ambient-dependency-fallback-to-statically-identified",
+  "branch": "fix/avoid-tracking-agent-callback-recursion",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/narrow-ambient-dependency-fallback-to-statically-identified/sessions/attribute-discovery-loaded-project-classes-by-runtime-execut.md",
+  "last_session": "docs/fluencyloop/features/narrow-ambient-dependency-fallback-to-statically-identified/sessions/protect-agent-infrastructure-from-runtime-probes.md",
   "base_ref": "main",
   "updated": "2026-07-27"
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
@@ -30,6 +30,8 @@ import java.util.stream.Collectors;
 public final class DependencyTrackingAgent implements ClassFileTransformer {
 
     private static final String HIDDEN_CLASS_CHECKSUM = "hidden-class-bytecode-unavailable";
+    private static final String TRACKING_PACKAGE_PREFIX =
+            "io.github.baokhang83.blastradius.core.tracking.";
 
     /**
      * Computing a checksum can initialize JDK security-provider classes. Those class loads call
@@ -208,7 +210,8 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
             return;
         }
         for (Class<?> loadedClass : loadedClasses) {
-            if (!isProjectClassOutput(loadedClass) || !currentInstrumentation.isModifiableClass(loadedClass)) {
+            if (!isAmbientInstrumentationCandidate(loadedClass)
+                    || !currentInstrumentation.isModifiableClass(loadedClass)) {
                 continue;
             }
             String className = loadedClass.getName();
@@ -226,8 +229,11 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
         }
     }
 
-    private static boolean isProjectClassOutput(Class<?> loadedClass) {
-        if (loadedClass.isArray() || loadedClass.isPrimitive() || loadedClass.getProtectionDomain() == null
+    static boolean isAmbientInstrumentationCandidate(Class<?> loadedClass) {
+        if (loadedClass.getName().startsWith(TRACKING_PACKAGE_PREFIX)
+                || loadedClass.isArray()
+                || loadedClass.isPrimitive()
+                || loadedClass.getProtectionDomain() == null
                 || loadedClass.getProtectionDomain().getCodeSource() == null) {
             return false;
         }

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.github.baokhang83.blastradius.core.index.CommitIndexKey;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
@@ -158,6 +159,13 @@ class DependencyTrackingAgentTest {
     void ambientDependenciesReturnsAnImmutableCopy() {
         Set<String> snapshot = agent.ambientDependencies();
         assertThrows(UnsupportedOperationException.class, () -> snapshot.add("com.example.Injected"));
+    }
+
+    @Test
+    void trackingInfrastructureIsNeverAnAmbientInstrumentationCandidate() {
+        assertFalse(DependencyTrackingAgent.isAmbientInstrumentationCandidate(DependencyTrackingAgent.class));
+        assertFalse(DependencyTrackingAgent.isAmbientInstrumentationCandidate(TestBoundaryListener.class));
+        assertTrue(DependencyTrackingAgent.isAmbientInstrumentationCandidate(CommitIndexKey.class));
     }
 
     private static String sha256Hex(byte[] bytes) throws NoSuchAlgorithmException {

--- a/docs/fluencyloop/features/narrow-ambient-dependency-fallback-to-statically-identified/sessions/protect-agent-infrastructure-from-runtime-probes.md
+++ b/docs/fluencyloop/features/narrow-ambient-dependency-fallback-to-statically-identified/sessions/protect-agent-infrastructure-from-runtime-probes.md
@@ -1,0 +1,13 @@
+# Session: protect agent infrastructure from runtime probes
+
+- **intent:** protect agent infrastructure from runtime probes
+- **started:** 2026-07-27
+
+## Decision: decision
+
+- **where:** `DependencyTrackingAgent retransformation eligibility`
+- **why:** The runtime callback obtains the active test through TestBoundaryListener. Instrumenting that listener injects the callback into currentTest itself, creating unbounded self-recursion. Exclude the tracking package from ambient retransformation while continuing to attribute ordinary project classes.
+- **alternative:** Add only a thread-local reentrancy guard — rejected: it would mask instrumentation of the callback path instead of preventing the agent from transforming its own control infrastructure.
+- **design:** [`../design.md`](../design.md)
+- **constitution:** §IV, §V
+- **trust:** ⚠ not independently verified


### PR DESCRIPTION
## Summary

- Exclude Blastradius tracking infrastructure from discovery-time retransformation.
- Prevent the injected runtime callback from re-entering `TestBoundaryListener.currentTest()` and overflowing the stack.
- Keep ordinary project classes eligible for runtime attribution, covered by a focused regression.

## Verification

- `mvn -B --no-transfer-progress -pl blastradius-core -Dtest=DependencyTrackingAgentTest test`
- Exact CI bootstrap followed by `mvn -B --no-transfer-progress -Pself-host-blastradius clean verify`

## FluencyLoop

The follow-up decision is recorded in `docs/fluencyloop/features/narrow-ambient-dependency-fallback-to-statically-identified/sessions/protect-agent-infrastructure-from-runtime-probes.md`.