### PR TITLE
fix: attribute reactor classes loaded from a module's built jar

### DIFF
--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
@@ -1,9 +1,11 @@
 package io.github.baokhang83.blastradius.core.tracking;
 
+import java.io.IOException;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -32,6 +34,23 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
     private static final String HIDDEN_CLASS_CHECKSUM = "hidden-class-bytecode-unavailable";
     private static final String TRACKING_PACKAGE_PREFIX =
             "io.github.baokhang83.blastradius.core.tracking.";
+
+    /**
+     * Set by {@code TrackRunner} on the forked Surefire JVM's command line. It names the reactor
+     * root of the build being tracked, which is the only reliable way to tell a project class from
+     * a third-party one: a module that depends on another reactor module loads it from that
+     * module's built <em>jar</em>, not from its {@code target/classes} directory, so a
+     * code-source path shape alone cannot recognise it.
+     */
+    private static final String PROJECT_ROOT_PROPERTY = "blastradius.projectRoot";
+
+    /**
+     * The bytecode library the agent instruments with. It ships inside the agent jar, so it must be
+     * excluded by package: excluding the agent's own code source instead would be wrong, because a
+     * module that depends on this one loads the agent classes from the ordinary core jar — the very
+     * jar that carries the project classes we are trying to attribute.
+     */
+    private static final String INSTRUMENTATION_LIBRARY_PACKAGE_PREFIX = "org.objectweb.asm.";
 
     /**
      * Computing a checksum can initialize JDK security-provider classes. Those class loads call
@@ -209,8 +228,9 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
         if (currentInstrumentation == null || !currentInstrumentation.isRetransformClassesSupported()) {
             return;
         }
+        Path projectRoot = configuredProjectRoot();
         for (Class<?> loadedClass : loadedClasses) {
-            if (!isAmbientInstrumentationCandidate(loadedClass)
+            if (!isAmbientInstrumentationCandidate(loadedClass, projectRoot)
                     || !currentInstrumentation.isModifiableClass(loadedClass)) {
                 continue;
             }
@@ -230,25 +250,79 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
     }
 
     static boolean isAmbientInstrumentationCandidate(Class<?> loadedClass) {
+        return isAmbientInstrumentationCandidate(loadedClass, configuredProjectRoot());
+    }
+
+    static boolean isAmbientInstrumentationCandidate(Class<?> loadedClass, Path projectRoot) {
         if (loadedClass.getName().startsWith(TRACKING_PACKAGE_PREFIX)
+                || loadedClass.getName().startsWith(INSTRUMENTATION_LIBRARY_PACKAGE_PREFIX)
                 || loadedClass.isArray()
-                || loadedClass.isPrimitive()
-                || loadedClass.getProtectionDomain() == null
-                || loadedClass.getProtectionDomain().getCodeSource() == null) {
+                || loadedClass.isPrimitive()) {
             return false;
         }
+        Path codeSource = codeSourceOf(loadedClass);
+        return codeSource != null && isProjectCodeSource(codeSource, projectRoot);
+    }
+
+    /**
+     * A class belongs to the build under test when its code source lives under the reactor root —
+     * whether that is a module's {@code target/classes} directory or another module's built jar,
+     * which is how every downstream module sees its reactor dependencies. Without the reactor root
+     * the only safe answer is the class-output directory shape: a jar cannot then be told apart
+     * from a third-party one, so it stays ambient and selection keeps its conservative fallback.
+     */
+    static boolean isProjectCodeSource(Path codeSource, Path projectRoot) {
+        if (projectRoot != null && codeSource.startsWith(projectRoot)) {
+            return true;
+        }
+        String path = codeSource.toString().replace('\\', '/');
+        return path.endsWith("/target/classes")
+                || path.endsWith("/target/test-classes")
+                || path.endsWith("/build/classes/java/main")
+                || path.endsWith("/build/classes/java/test");
+    }
+
+    private static Path configuredProjectRoot() {
+        String configured = System.getProperty(PROJECT_ROOT_PROPERTY);
+        if (configured == null || configured.isBlank()) {
+            return null;
+        }
         try {
-            URI location = loadedClass.getProtectionDomain().getCodeSource().getLocation().toURI();
+            return canonicalize(Path.of(configured));
+        } catch (InvalidPathException ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Resolves symlinks so the reactor root and a code source under it stay comparable. They
+     * routinely disagree otherwise — a macOS temp directory is handed to the build as
+     * {@code /var/...} but reported by the class loader as {@code /private/var/...}, and a
+     * containment check between the two forms silently fails.
+     */
+    private static Path canonicalize(Path path) {
+        Path absolute = path.toAbsolutePath().normalize();
+        try {
+            return absolute.toRealPath();
+        } catch (IOException ignored) {
+            return absolute;
+        }
+    }
+
+    private static Path codeSourceOf(Class<?> loadedClass) {
+        ProtectionDomain protectionDomain = loadedClass.getProtectionDomain();
+        if (protectionDomain == null || protectionDomain.getCodeSource() == null
+                || protectionDomain.getCodeSource().getLocation() == null) {
+            return null;
+        }
+        try {
+            URI location = protectionDomain.getCodeSource().getLocation().toURI();
             if (!"file".equals(location.getScheme())) {
-                return false;
+                return null;
             }
-            String path = Path.of(location).normalize().toString().replace('\\', '/');
-            return path.endsWith("/target/classes")
-                    || path.endsWith("/target/test-classes")
-                    || path.endsWith("/build/classes/java/main")
-                    || path.endsWith("/build/classes/java/test");
+            return canonicalize(Path.of(location));
         } catch (URISyntaxException | IllegalArgumentException ignored) {
-            return false;
+            return null;
         }
     }
 

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
@@ -11,6 +11,7 @@ import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
@@ -166,6 +167,36 @@ class DependencyTrackingAgentTest {
         assertFalse(DependencyTrackingAgent.isAmbientInstrumentationCandidate(DependencyTrackingAgent.class));
         assertFalse(DependencyTrackingAgent.isAmbientInstrumentationCandidate(TestBoundaryListener.class));
         assertTrue(DependencyTrackingAgent.isAmbientInstrumentationCandidate(CommitIndexKey.class));
+    }
+
+    @Test
+    void reactorModuleJarIsAProjectCodeSourceEvenThoughItIsNotAClassOutputDirectory() {
+        // How every downstream module sees a reactor dependency: as a built jar, not as
+        // `target/classes`. Left unrecognised, such a class stays ambient in that module's fork and
+        // one ambient class forces every module's whole suite to run.
+        Path reactorRoot = Path.of("/build/repo");
+
+        assertTrue(DependencyTrackingAgent.isProjectCodeSource(
+                Path.of("/build/repo/core/target/core-1.0.0.jar"), reactorRoot));
+        assertTrue(DependencyTrackingAgent.isProjectCodeSource(
+                Path.of("/build/repo/core/target/classes"), reactorRoot));
+    }
+
+    @Test
+    void jarOutsideTheReactorRootIsNotAProjectCodeSource() {
+        // A dependency resolved from the local Maven repository rather than built by this reactor.
+        assertFalse(DependencyTrackingAgent.isProjectCodeSource(
+                Path.of("/elsewhere/junit-jupiter-api-5.14.0.jar"), Path.of("/build/repo")));
+    }
+
+    @Test
+    void aJarIsOnlyRecognisedWhenTheReactorRootIsKnown() {
+        // Without the reactor root a jar cannot be told apart from a third-party dependency, so it
+        // stays ambient and selection keeps its conservative fallback rather than guessing.
+        assertFalse(DependencyTrackingAgent.isProjectCodeSource(
+                Path.of("/build/repo/core/target/core-1.0.0.jar"), null));
+        assertTrue(DependencyTrackingAgent.isProjectCodeSource(
+                Path.of("/build/repo/core/target/classes"), null));
     }
 
     private static String sha256Hex(byte[] bytes) throws NoSuchAlgorithmException {

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/track/TrackRunner.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/track/TrackRunner.java
@@ -40,10 +40,21 @@ public final class TrackRunner {
         }
 
         String agentOption = "-javaagent:" + agentJar.toAbsolutePath() + "=" + outputFile.toAbsolutePath();
+        // The agent can only recognise a class as belonging to this build by its code source, and a
+        // module that depends on another reactor module loads it from that module's built jar
+        // rather than from a `target/classes` directory. Naming the reactor root here is what lets
+        // those classes be attributed to the tests that use them instead of staying ambient — one
+        // unattributed class is enough to force every module's whole suite to run.
+        String projectRootOption = "-Dblastradius.projectRoot=" + projectDir.toAbsolutePath();
+        String agentOptions = agentOption + " " + projectRootOption;
+        // Ours go last, not first: the surrounding build's argLine is inherited wholesale and may
+        // already name a `blastradius.projectRoot` of its own, and the last `-D` on a JVM command
+        // line is the one that takes effect. Appending ours keeps the tracked build's own reactor
+        // root authoritative rather than letting an outer build's root silently replace it.
         String existingArgLine = System.getProperty("argLine");
         String trackedArgLine = existingArgLine == null || existingArgLine.isBlank()
-                ? agentOption
-                : agentOption + " " + existingArgLine;
+                ? agentOptions
+                : existingArgLine + " " + agentOptions;
         // -Dblastradius.trackChild=true: this subprocess runs against the same pom that
         // binds this very goal, so without the flag its own SelectMojo execution would
         // resolve TRACK again (same commit, same baseRef) and recurse without bound — see

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
@@ -151,7 +151,10 @@ final class EndToEndTestSupport {
             throws IOException, InterruptedException {
         Path agentJar = findCoreAgentJar();
         Path outputFile = Files.createTempFile("blastradius-e2e-track-", ".json");
-        String agentOption = "-javaagent:" + agentJar.toAbsolutePath() + "=" + outputFile.toAbsolutePath();
+        // Mirrors TrackRunner: without the reactor root the agent cannot recognise a class loaded
+        // from another module's built jar as belonging to this build, and leaves it ambient.
+        String agentOption = "-javaagent:" + agentJar.toAbsolutePath() + "=" + outputFile.toAbsolutePath()
+                + " -Dblastradius.projectRoot=" + projectDir.toAbsolutePath();
         ProcessBuilder pb = new ProcessBuilder("mvn", "-B", "--no-transfer-progress", "clean", "test")
                 .directory(projectDir.toFile());
         pb.environment().merge("JAVA_TOOL_OPTIONS", agentOption, (a, b) -> a + " " + b);

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/track/TrackRunnerTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/track/TrackRunnerTest.java
@@ -1,6 +1,7 @@
 package io.github.baokhang83.blastradius.plugin.track;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -102,6 +103,61 @@ class TrackRunnerTest {
                 IllegalStateException.class, () -> trackRunner.track(projectDir, agentJar, anchorCommit));
         assertTrue(exception.getMessage().contains("intentional"),
                 "expected the tracking subprocess output in the failure diagnostic: " + exception.getMessage());
+    }
+
+    @Test
+    void classOfAnotherReactorModuleIsAttributedToTheTestUsingItRatherThanLeftAmbient(
+            @TempDir Path projectDir) throws Exception {
+        Path agentJar = findOwnAgentJar();
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.twoModuleReactor(projectDir);
+        fixture.addSystemDependency("moduleB", agentJar);
+        // moduleA packages before moduleB's tests run, so moduleB resolves it as a jar rather than
+        // as a target/classes directory — the shape every real multi-module build has, and the one
+        // that used to leave moduleA's classes permanently ambient.
+        fixture.addBuildPlugin("moduleA", """
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>package-early</id>
+                            <phase>process-test-classes</phase>
+                            <goals><goal>jar</goal></goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                """);
+        fixture.writeClassInModule("moduleA", "com.example.a.Shared",
+                "package com.example.a; public class Shared { public int value() { return 42; } }");
+        // Naming Shared in a method signature makes JUnit's discovery pass load it before any test
+        // starts, which is what puts it in the ambient snapshot in the first place.
+        fixture.writeTestInModule("moduleB", "com.example.b.SharedUserTest", """
+                package com.example.b;
+                import com.example.a.Shared;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class SharedUserTest {
+                    private Shared shared() {
+                        return new Shared();
+                    }
+
+                    @Test
+                    void usesShared() {
+                        assertEquals(42, shared().value());
+                    }
+                }
+                """);
+        String anchorCommit = fixture.commit("initial");
+
+        DependencyIndex index = trackRunner.track(projectDir, agentJar, anchorCommit);
+
+        assertFalse(index.ambientDependencies().contains("com.example.a.Shared"),
+                "a class built by this reactor must not stay ambient just because a downstream "
+                        + "module loads it from a jar");
+        assertTrue(index.testDependencies().stream()
+                        .filter(entry -> entry.test().className().equals("com.example.b.SharedUserTest"))
+                        .anyMatch(entry -> entry.dependsOnClasses().contains("com.example.a.Shared")),
+                "the test that uses it must own it as a dependency");
     }
 
     private static Path findOwnAgentJar() throws IOException {


### PR DESCRIPTION
## The bug

A downstream reactor module resolves its reactor dependencies as **built jars**, not as
`target/classes` directories. `blastradius-core/pom.xml`'s `build-base-jar-early` execution
(jar bound to `process-test-classes`) makes that true here too: by the time the validator
module's tests run, core is `blastradius-core-0.3.0.jar`.

The agent recognised a "project class" purely by class-output directory suffix
(`/target/classes`, `/build/classes/java/main`, …). A jar matches none of them — so those
classes were never retransformed, were never attributable to a test, and stayed in that
fork's **ambient** set forever.

`AmbientDependencySelector.shouldFallback` returns true if *any* changed class is ambient,
and the index merges every fork's ambient set. So one unattributed class in one fork forced
**every test in every module** to run. That is the `fallback-ambient: 87` in the CI logs.

## The chain

1. `build-base-jar-early` packages core before downstream tests run.
2. JUnit discovery loads `ChangedFile` in the validator fork (it appears in a test method signature).
3. `isAmbientInstrumentationCandidate` rejects it — code source is a jar.
4. Never retransformed → stays ambient → merged into the index.
5. `shouldFallback` fires for every module.

## The fix

`TrackRunner` names the reactor root on the forked JVM
(`-Dblastradius.projectRoot=…`), and the agent treats **any** code source under that root as
a project class — directory or jar. Without the root it falls back to the old
directory-shape test, so the conservative behaviour is preserved rather than guessed at.

Paths are canonicalised (`toRealPath()`) on both sides. A macOS temp dir handed to the build
as `/var/…` is reported by the class loader as `/private/var/…`, and `Path.startsWith`
silently fails between the two forms — this cost a full debugging cycle.

Two related corrections found while verifying:

- **Exclude the instrumentation library by package** (`org.objectweb.asm.`), not by code
  source. Excluding the agent's own jar is wrong: the plain core jar *also* contains
  `DependencyTrackingAgent.class`, so in a downstream fork that blacklisted every project
  class in the very jar we need to attribute.
- **`TrackRunner` appends its options after the inherited `argLine`**, not before. The last
  `-D` on a JVM command line wins, so an outer build carrying its own
  `blastradius.projectRoot` used to silently replace the tracked build's.

## Verification

Real subprocess regression test (`TrackRunnerTest.classOfAnotherReactorModuleIsAttributedTo…`)
reproduces the production shape — a two-module reactor where moduleA packages early so
moduleB sees it as a jar. It **fails before this change and passes after**.

On this reactor, with the agent attached to a full `clean test`:

| | before | after |
|---|---|---|
| `ChangedFile` in merged ambient set | yes | **no** |
| tests selected when `ChangedFile.java` changes | 238 (all) | **33** |

`blastradius-core` 89/89 green; `blastradius-maven-plugin` 77/77 green; full reactor
BUILD SUCCESS.

## Known remaining gap (not fixed here)

`io.github.baokhang83.blastradius.core.index.IndexStore` still stays ambient. It is a pure
interface — `AmbientClassInstrumenter.instrument()` returns `null` because there is no
executable body to inject a callback into, so no test can be attributed to it. Changing that
interface therefore still triggers the full-suite fallback.

That is defensible (safe fallback, and it is the *only* such class here — the other 24
project classes left ambient are the tracking package itself, which is excluded on purpose:
changing the agent *should* re-run everything). Closing it properly means attributing a
supertype through its implementors, which is a separate mechanism and deliberately not
bundled into this already-verified fix.
