### PR TITLE
fix: stop the e2e harness deleting the reports it is being timed by

### DIFF
--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
@@ -33,18 +33,48 @@ final class EndToEndTestSupport {
     private EndToEndTestSupport() {
     }
 
+    private static final Path REACTOR_ROOT = Path.of("..").toAbsolutePath().normalize();
+
     static void installThisPluginOnce() throws IOException, InterruptedException {
-        // `clean` is required, not cosmetic: without it, when blastradius-maven-plugin's own
-        // sources haven't changed, maven-jar-plugin's up-to-date check skips regenerating its
-        // plain jar, leaving the *previous* run's shaded uber-jar sitting at that same path —
-        // and the next shade execution bootstraps its assembly from that stale self-referential
-        // jar, silently keeping OLD embedded blastradius-core classes as "duplicates" over the
-        // freshly-rebuilt ones. A stale core fix would otherwise never make it into a real
-        // TRACK-mode build's classpath even after rebuilding blastradius-core.
-        PLUGIN_INSTALLER.installOnce(() -> runToCompletion(new ProcessBuilder(
-                "mvn", "-q", "-pl", "blastradius-maven-plugin", "-am", "clean", "install", "-DskipTests",
-                "-Dinvoker.skip=true")
-                .directory(Path.of("..").toAbsolutePath().normalize().toFile())));
+        PLUGIN_INSTALLER.installOnce(() -> {
+            deleteBuiltJars(REACTOR_ROOT.resolve("blastradius-maven-plugin").resolve("target"));
+            runToCompletion(new ProcessBuilder(pluginInstallCommand()).directory(REACTOR_ROOT.toFile()));
+        });
+    }
+
+    static List<String> pluginInstallCommand() {
+        return List.of("mvn", "-q", "-pl", "blastradius-maven-plugin", "-am", "install", "-DskipTests",
+                "-Dinvoker.skip=true");
+    }
+
+    /**
+     * Removes this module's built jars, deliberately in place of a {@code clean} goal.
+     *
+     * <p>Removing them is required, not cosmetic: when blastradius-maven-plugin's own sources
+     * haven't changed, maven-jar-plugin's up-to-date check skips regenerating its plain jar,
+     * leaving the <em>previous</em> run's shaded uber-jar sitting at that same path — and the
+     * next shade execution bootstraps its assembly from that stale self-referential jar,
+     * silently keeping OLD embedded blastradius-core classes as "duplicates" over the
+     * freshly-rebuilt ones. A stale core fix would otherwise never make it into a real
+     * TRACK-mode build's classpath even after rebuilding blastradius-core.
+     *
+     * <p>{@code clean} achieved that too, but it deleted the whole {@code target/} of this very
+     * module while the Surefire run that called this method was still in progress — taking that
+     * run's own {@code surefire-reports/} with it. {@code TimingHistoryRecorder} reads that
+     * directory when Surefire finishes, so every test class that had already completed lost its
+     * timing sample, and those missing samples made {@code BuildReport} withhold the time-saved
+     * estimate for the entire build. Being run with {@code -am}, it wiped the upstream modules'
+     * {@code target/} directories as well, JaCoCo execution data included.
+     */
+    static void deleteBuiltJars(Path targetDir) throws IOException {
+        if (!Files.isDirectory(targetDir)) {
+            return;
+        }
+        try (var entries = Files.list(targetDir)) {
+            for (Path jar : entries.filter(path -> path.getFileName().toString().endsWith(".jar")).toList()) {
+                Files.deleteIfExists(jar);
+            }
+        }
     }
 
     /** A single-module fixture with an independent Foo/FooTest and Bar/BarTest pair. */

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupportTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupportTest.java
@@ -1,0 +1,43 @@
+package io.github.baokhang83.blastradius.plugin.mojo;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Guards the one property of the end-to-end harness that silently corrupted real reporting:
+ * it rebuilds this very module while this module's own Surefire run is in progress, so it must
+ * replace the stale shaded jar without destroying anything else in {@code target/}.
+ */
+class EndToEndTestSupportTest {
+
+    @Test
+    void replacingTheBuiltJarsLeavesTheRunningSurefireReportsIntact(@TempDir Path targetDir) throws Exception {
+        // Surefire writes a report per class as that class finishes, but TimingHistoryRecorder only
+        // reads the directory once the whole mojo completes. Deleting it midway (as `clean` did)
+        // discards every sample gathered so far, and a single missing sample makes BuildReport
+        // withhold the time-saved estimate for the entire build.
+        Path reports = Files.createDirectory(targetDir.resolve("surefire-reports"));
+        Path report = Files.writeString(reports.resolve("TEST-com.example.FooTest.xml"), "<testsuite/>");
+        Path classes = Files.createDirectory(targetDir.resolve("classes"));
+        Path shadedJar = Files.writeString(targetDir.resolve("blastradius-maven-plugin-0.3.0.jar"), "stale");
+
+        EndToEndTestSupport.deleteBuiltJars(targetDir);
+
+        assertFalse(Files.exists(shadedJar), "the stale shaded jar must go, or the next shade "
+                + "execution bootstraps its assembly from it and keeps old embedded core classes");
+        assertTrue(Files.exists(report), "an in-progress run's Surefire reports must survive");
+        assertTrue(Files.exists(classes), "unrelated build output must survive");
+    }
+
+    @Test
+    void theInstallCommandNeverCleansTheModuleItIsRunningInside() {
+        assertFalse(EndToEndTestSupport.pluginInstallCommand().contains("clean"),
+                "`clean` here deletes target/ of the module whose Surefire run invoked it — and with "
+                        + "-am, the upstream modules' target/ too, JaCoCo execution data included");
+    }
+}


### PR DESCRIPTION
Selection itself is working since #129 — PR #131 correctly ran 33/234. But every run
reported **"Timing history incomplete"** instead of a time-saved figure.

## Diagnosis

The per-module reports from #131's run localise it precisely:

| module | skipped | timed | estimate |
|---|---:|---:|---|
| blastradius-core | 71 | 71 | 13.3s |
| blastradius-validator | 52 | 52 | 39.4s |
| blastradius-s3-index-store | 6 | 6 | 0.8s |
| **blastradius-maven-plugin** | 72 | **70** | **null** |

`BuildReport.forSelect` withholds the estimate entirely rather than guess when any skipped
test lacks a sample, and the summary action nulls the combined figure if any module's is
null. So **2 missing samples out of 234 blanked the whole matrix**, both JDKs.

## Cause

`EndToEndTestSupport.installThisPluginOnce` ran, from inside a test:

```
mvn -q -pl blastradius-maven-plugin -am clean install -DskipTests
```

at the reactor root. That `clean` deletes `target/` of the very module whose Surefire run
invoked it — including the `surefire-reports/` written so far.

Surefire persists a report per class as that class finishes, but `TimingHistoryRecorder`
reads the directory only once the mojo completes. Everything that finished before the first
end-to-end test triggered the install was therefore already deleted by the time the recorder
looked.

Measured locally: the module runs **77/77 tests but persists only 40 testcase reports**. The
37 missing ones are whole classes — precisely every test outside `plugin.mojo.*`, which is
the set that finishes before the first e2e test runs. Run those classes in isolation and
their reports appear normally, which is what pins the cause on deletion rather than on
reporting.

Because of `-am` it also wiped **core, validator and s3-index-store**'s `target/` mid-reactor,
JaCoCo execution data included. Those three modules still showed complete timing coverage
only because their recorder had already fired before the plugin module's tests began.

## Fix

`clean` was there for a real reason, documented in the original comment: without it
maven-jar-plugin's up-to-date check skips regenerating the plain jar, and shade then
bootstraps its assembly from the previous run's stale uber-jar, silently keeping old embedded
core classes. Deleting just the module's **built jars** preserves that guarantee and leaves
the rest of `target/` untouched.

## Verification

| | before | after |
|---|---:|---:|
| blastradius-core | 89 | 89 |
| blastradius-s3-index-store | 6 | 6 |
| blastradius-validator | 61 | 61 |
| **blastradius-maven-plugin** | **40** | **79** |

(persisted testcase reports after a full `clean test`; 79 = 77 existing + the 2 added here)

Full reactor BUILD SUCCESS. `EndToEndTestSupportTest` covers both halves of the invariant:
the stale jar is removed, and an in-progress run's reports survive.

## What to expect

The estimate will not appear until main next rebuilds the timing cache — the cache is only
saved from main, so this needs one merge plus one main run before a PR shows a figure.
