### PR TITLE
fix: derive the E2E harness's plugin version from the build, not a hardcoded string

### DIFF
--- a/blastradius-maven-plugin/pom.xml
+++ b/blastradius-maven-plugin/pom.xml
@@ -105,6 +105,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefire.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <blastradius.version>${project.version}</blastradius.version>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <!-- Generates the plugin.xml goal descriptor from @Mojo/@Parameter

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
@@ -30,6 +30,14 @@ final class EndToEndTestSupport {
 
     private static final PluginInstaller PLUGIN_INSTALLER = new PluginInstaller();
 
+    /**
+     * The plugin version under test, read from the build rather than hardcoded: a hardcoded
+     * string here resolves against whatever was last published to Central under that version
+     * once it no longer matches the reactor's actual version, silently testing that stale
+     * published jar instead of the one {@link #installThisPluginOnce()} just built.
+     */
+    private static final String PLUGIN_VERSION = System.getProperty("blastradius.version");
+
     private EndToEndTestSupport() {
     }
 
@@ -111,7 +119,7 @@ final class EndToEndTestSupport {
                         <plugin>
                             <groupId>io.github.baokhang83.blastradius</groupId>
                             <artifactId>blastradius-maven-plugin</artifactId>
-                            <version>0.3.0</version>
+                            <version>%s</version>
                             <executions>
                                 <execution>
                                     <phase>process-test-classes</phase>
@@ -122,7 +130,7 @@ final class EndToEndTestSupport {
                                 <baseRef>%s</baseRef>
                             </configuration>
                         </plugin>
-                """.formatted(anchorCommit);
+                """.formatted(PLUGIN_VERSION, anchorCommit);
     }
 
     /** Plugin binding deliberately missing the required {@code baseRef} configuration (T049). */
@@ -131,7 +139,7 @@ final class EndToEndTestSupport {
                         <plugin>
                             <groupId>io.github.baokhang83.blastradius</groupId>
                             <artifactId>blastradius-maven-plugin</artifactId>
-                            <version>0.3.0</version>
+                            <version>%s</version>
                             <executions>
                                 <execution>
                                     <phase>process-test-classes</phase>
@@ -139,7 +147,7 @@ final class EndToEndTestSupport {
                                 </execution>
                             </executions>
                         </plugin>
-                """;
+                """.formatted(PLUGIN_VERSION);
     }
 
     /** Plugin binding with an explicit, possibly-invalid {@code indexPath} (T049). */
@@ -148,7 +156,7 @@ final class EndToEndTestSupport {
                         <plugin>
                             <groupId>io.github.baokhang83.blastradius</groupId>
                             <artifactId>blastradius-maven-plugin</artifactId>
-                            <version>0.3.0</version>
+                            <version>%s</version>
                             <executions>
                                 <execution>
                                     <phase>process-test-classes</phase>
@@ -160,7 +168,7 @@ final class EndToEndTestSupport {
                                 <indexPath>%s</indexPath>
                             </configuration>
                         </plugin>
-                """.formatted(anchorCommit, indexPath);
+                """.formatted(PLUGIN_VERSION, anchorCommit, indexPath);
     }
 
     /** Recursively deletes {@code projectDir}'s {@code .git} directory (T049: non-git target). */


### PR DESCRIPTION
## Summary
- Fixture POMs generated by `EndToEndTestSupport` for the plugin's end-to-end tests hardcoded `blastradius-maven-plugin` at version `0.3.0`.
- Once the reactor's real version diverges from that string (e.g. any release bump), Maven resolves the fixture's plugin binding against the stale, already-published `0.3.0` jar on Central instead of the one just built and installed — silently testing old behavior instead of the current build.
- This was caught while attempting to cut the 0.3.1 release: `SelectModeEndToEndTest` and 6 other E2E suites failed on both JDK 21 and JDK 25 once the version was bumped, even though main (still at 0.3.0) was green.

## Fix
Wire the real `${project.version}` through Surefire's `systemPropertyVariables` (mirroring the existing `blastradius.self.host.version` pattern in the parent POM) and read it via `System.getProperty("blastradius.version")` instead of hardcoding the string in three places.

## Test plan
- [x] Installed the reactor locally at version 0.3.1 (simulating the release) and re-ran the previously-failing suites (`SelectModeEndToEndTest`, `NewTestAlwaysSelectedTest`, `SelectedTestFailurePropagatesTest`, `UnreachableAnchorFallbackTest`, `SelectMojoInternalErrorFallbackTest`, `TrackModeFailureFallbackTest`, `SelectModeMultiModuleEndToEndTest`) — all pass.
- [x] Re-ran the same suites at the real current version 0.3.0 — still pass, confirming no regression.
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)