### PR TITLE
chore: bump version to 0.3.1 for release

### DIFF
--- a/blastradius-core/pom.xml
+++ b/blastradius-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
     </parent>
 
     <artifactId>blastradius-core</artifactId>

--- a/blastradius-maven-plugin/pom.xml
+++ b/blastradius-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
     </parent>
 
     <artifactId>blastradius-maven-plugin</artifactId>

--- a/blastradius-s3-index-store/pom.xml
+++ b/blastradius-s3-index-store/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
     </parent>
     <artifactId>blastradius-s3-index-store</artifactId>
     <name>blastradius S3 index store</name>

--- a/blastradius-validator/pom.xml
+++ b/blastradius-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
     </parent>
 
     <artifactId>blastradius-validator</artifactId>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.0</version>
+        <version>0.3.1</version>
     </parent>
 
     <artifactId>coverage</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.baokhang83.blastradius</groupId>
     <artifactId>blastradius-parent</artifactId>
-    <version>0.3.0</version>
+    <version>0.3.1</version>
     <packaging>pom</packaging>
 
     <name>Blastradius parent</name>
@@ -38,7 +38,7 @@
         <connection>scm:git:https://github.com/baokhang83/blastradius.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/baokhang83/blastradius.git</developerConnection>
         <url>https://github.com/baokhang83/blastradius</url>
-        <tag>v0.3.0</tag>
+        <tag>v0.3.1</tag>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
Version bump for 0.3.1 release to Maven Central. Includes #138's fix so the E2E harness tests correctly.