### PR TITLE
fix: clear stale target/ in every submodule when reusing scratch clone

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "narrow-ambient-dependency-fallback-to-statically-identified",
-  "branch": "fix/avoid-tracking-agent-callback-recursion",
+  "feature": "fix-commitcheckout-to-clear-stale-target-dirs-in-every-submo",
+  "branch": "feature/fix-commitcheckout-to-clear-stale-target-dirs-in-every-submo",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/narrow-ambient-dependency-fallback-to-statically-identified/sessions/protect-agent-infrastructure-from-runtime-probes.md",
+  "last_session": "docs/fluencyloop/features/fix-commitcheckout-to-clear-stale-target-dirs-in-every-submo/sessions/walk-the-whole-scratch-tree-pruning-git-and-target-subtrees.md",
   "base_ref": "main",
   "updated": "2026-07-27"
 }

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,25 @@
 <!--
 Sync Impact Report
 ==================
+Version change: 2.1.0 → 2.2.0 (MINOR — new Principle VII added)
+Added principles:
+  - VII. Exhaustive Harness Cleanup — our own tooling that reuses a scratch/build
+    directory across repeated builds (CommitCheckout, the Maven plugin's E2E harness)
+    MUST clean every location a prior build could have left state in, not just the
+    top-level one, and MUST NOT rely on the target build's own `clean` goal to have
+    done it.
+    Rationale: found concretely when CommitCheckout cleaned only the reactor root and
+    a submodule's stale TEST-*.xml report survived into the next commit's failed
+    build against a real multi-module project (apache/shenyu), fooling
+    BuildFailureDetector's report-existence heuristic.
+Removed principles: none
+Added/removed sections: none
+Templates requiring updates:
+  - ✅ .specify/templates/plan-template.md — Constitution Check derived dynamically
+    from this file, no changes needed
+Follow-up TODOs: none
+
+Previous entry (2.0.0 → 2.1.0):
 Version change: 2.0.0 → 2.1.0 (MINOR — Principle III materially refined)
 Modified principles:
   - III. Safety Over Speed — added the inert-change carve-out: a change that provably
@@ -132,6 +151,24 @@ now-removed JDK mechanisms became unusable as the ecosystem moved on. Building o
 current, actively maintained foundations from the start is a precondition for the
 project outliving its predecessors.
 
+### VII. Exhaustive Harness Cleanup
+
+Any of our own tooling that reuses a scratch or build directory across repeated builds
+(the validator's `CommitCheckout` re-checking out commits into one clone, the Maven
+plugin's E2E harness rebuilding itself mid-Surefire-run, and any future equivalent)
+MUST clean every location a prior build could have left state in, not just the
+top-level or most visible one — and MUST NOT rely on the target build's own `clean`
+goal to have done it, since a genuinely broken build is exactly the case where that
+goal may not have reached every module.
+
+**Rationale**: A build harness's own detectors (e.g. "does a `TEST-*.xml` report
+exist") can only see what's on disk, not whether it's fresh. A partial cleanup turns a
+real build failure in the target project into a false "tests ran" signal one checkout
+later, corrupting the harness's own judgment rather than the target project's — found
+concretely when `CommitCheckout` cleaned only the reactor root and a submodule's stale
+report survived into the next commit's (failed) build against a real multi-module
+project (apache/shenyu).
+
 ## Technology & Architecture Constraints
 
 - **Test execution model**: JUnit 5 Platform (Jupiter) is the primary, native
@@ -185,4 +222,4 @@ gate defined in `.specify/templates/plan-template.md`. Any violation MUST be
 explicitly justified in that plan's Complexity Tracking section or the design MUST
 be simplified until it complies.
 
-**Version**: 2.1.0 | **Ratified**: 2026-07-08 | **Last Amended**: 2026-07-11
+**Version**: 2.2.0 | **Ratified**: 2026-07-08 | **Last Amended**: 2026-07-28

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/CommitCheckout.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/CommitCheckout.java
@@ -1,8 +1,11 @@
 package io.github.baokhang83.blastradius.validator.git;
 
 import java.io.IOException;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Comparator;
 import org.eclipse.jgit.api.Git;
 
@@ -47,25 +50,49 @@ public final class CommitCheckout implements AutoCloseable {
      * Checks out {@code commitSha} within the scratch clone (detached HEAD) and returns
      * the working directory now reflecting that commit's tree.
      *
-     * <p>Also deletes any {@code target/} directory left over from a previous
-     * checkout's build, rather than relying on the next {@code mvn clean test}
-     * invocation to do it. A commit whose {@code pom.xml} fails to resolve (e.g. an
-     * unpublished SNAPSHOT parent — a real case found running against jackson-databind)
-     * fails during Maven's project-model-building phase, before the {@code clean} goal
-     * ever runs, letting a stale {@code target/surefire-reports/TEST-*.xml} from the
-     * prior commit survive. {@code BuildFailureDetector} can only see whether *any*
-     * {@code TEST-*.xml} exists, not whether it's fresh, so a stale one fools it into
-     * treating a genuine build failure as if it had run tests — this cleanup (not
-     * relying on the target project's own `clean` goal succeeding) closes that gap
-     * directly at the source.
+     * <p>Also deletes every {@code target/} directory left over from a previous
+     * checkout's build — not just the reactor root's — rather than relying on the next
+     * {@code mvn clean test} invocation to do it. A commit whose {@code pom.xml} fails to
+     * resolve (e.g. an unpublished SNAPSHOT parent — a real case found running against
+     * jackson-databind) fails during Maven's project-model-building phase, before the
+     * {@code clean} goal ever runs, letting a stale {@code target/surefire-reports/TEST-*.xml}
+     * from the prior commit survive. In a multi-module reactor, a build can also fail
+     * partway through — after `clean` ran for some modules but before it reached others —
+     * leaving a stale report in a downstream module's own {@code target/} even though the
+     * root's was cleaned. {@code BuildFailureDetector} can only see whether *any*
+     * {@code TEST-*.xml} exists anywhere under the project, not whether it's fresh, so a
+     * stale one fools it into treating a genuine build failure as if it had run tests —
+     * this cleanup (not relying on the target project's own `clean` goal succeeding) closes
+     * that gap directly at the source, for every module.
      */
     public Path checkoutCommit(String commitSha) {
         try {
             scratchGit.checkout().setName(commitSha).call();
-            deleteRecursively(scratchDir.resolve("target"));
+            deleteAllTargetDirectories(scratchDir);
             return scratchDir;
         } catch (Exception e) {
             throw new IllegalStateException("failed to checkout commit " + commitSha, e);
+        }
+    }
+
+    private static void deleteAllTargetDirectories(Path scratchDir) {
+        try {
+            Files.walkFileTree(scratchDir, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    String name = dir.getFileName().toString();
+                    if (".git".equals(name)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    if ("target".equals(name)) {
+                        deleteRecursively(dir);
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            throw new IllegalStateException("failed to scan for stale target directories under " + scratchDir, e);
         }
     }
 

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/git/CommitCheckoutTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/git/CommitCheckoutTest.java
@@ -96,6 +96,40 @@ class CommitCheckoutTest {
         }
     }
 
+    /**
+     * The gap {@link #checkoutClearsStaleTargetDirectoryFromThePreviousCommit} didn't cover:
+     * in a multi-module reactor, a build can fail in one module before ever reaching another
+     * that a prior commit successfully tested — leaving that other module's own
+     * {@code target/} stale even though the reactor root's was cleared. Found running the
+     * validator against apache/shenyu, a real multi-module project.
+     */
+    @Test
+    void checkoutClearsStaleTargetDirectoriesInEverySubmoduleNotJustTheReactorRoot(
+            @TempDir Path targetDir, @TempDir Path scratchParent) throws Exception {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.twoModuleReactor(targetDir);
+        String c1 = fixture.commit("initial");
+        fixture.writeClass("com.example.Bar", "package com.example; class Bar {}");
+        String c2 = fixture.commit("add Bar");
+
+        try (CommitCheckout checkout = CommitCheckout.forTargetProject(targetDir, scratchParent)) {
+            Path atC1 = checkout.checkoutCommit(c1);
+            Path staleReport =
+                    atC1.resolve("moduleB/target/surefire-reports/TEST-com.example.OldTest.xml");
+            Files.createDirectories(staleReport.getParent());
+            Files.writeString(staleReport, "<testsuite/>", StandardCharsets.UTF_8);
+            assertTrue(Files.exists(staleReport), "sanity check: stale report was actually created");
+
+            Path atC2 = checkout.checkoutCommit(c2);
+
+            assertTrue(
+                    Files.notExists(
+                            atC2.resolve("moduleB/target/surefire-reports/TEST-com.example.OldTest.xml")),
+                    "a stale test report from the previous commit's build must not survive a checkout "
+                            + "of a different commit, even when it lives in a submodule rather than "
+                            + "the reactor root");
+        }
+    }
+
     @Test
     void checkingOutMultipleCommitsSequentiallyReusesTheSameScratchClone(
             @TempDir Path targetDir, @TempDir Path scratchParent) throws Exception {

--- a/docs/fluencyloop/features/fix-commitcheckout-to-clear-stale-target-dirs-in-every-submo/design.md
+++ b/docs/fluencyloop/features/fix-commitcheckout-to-clear-stale-target-dirs-in-every-submo/design.md
@@ -1,0 +1,86 @@
+# Design: fix CommitCheckout to clear stale target/ dirs in every submodule, not just the reactor root, when reusing a scratch clone across commits
+
+started: 2026-07-27
+
+## Context
+
+`RunCommand` reuses one scratch clone (`CommitCheckout`) across every commit pair in the
+validator's window. `checkoutCommit()` used to delete only the reactor-root `target/` between
+checkouts. On a multi-module target project, a module's own `target/` survives a checkout if the
+next commit's build never reaches that module (e.g. it fails to compile earlier in the reactor).
+`BuildFailureDetector` only asks "does any `TEST-*.xml` exist anywhere under the project?" — a
+stale one from the *previous* commit answers yes, so it wrongly treats a real build failure as a
+completed test run, and `RunCommand` crashes trying to read dependency-tracking output the agent
+never produced for that commit. Found running the validator against `apache/shenyu` (dozens of
+modules).
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class CommitCheckout {
+    -Path scratchDir
+    -Git scratchGit
+    +forTargetProject(targetRepo, scratchParent) CommitCheckout
+    +checkoutCommit(commitSha) Path
+    +close()
+    -deleteAllTargetDirectories(scratchDir)
+    -deleteRecursively(path)
+  }
+  class RunCommand {
+    -analyzePair(pair, targetRepo, checkout, agentJar)
+  }
+  class BuildFailureDetector {
+    +isBuildFailure(result, projectDir) bool
+    -anyTestReportsExist(projectDir) bool
+  }
+  class DependencyRecordReader {
+    +readAll(baseOutputFile) DependencyRecordSet
+  }
+  class ScratchTree {
+    <<shared filesystem state>>
+    every module's target/
+  }
+
+  RunCommand --> CommitCheckout : checkoutCommit() per pair
+  RunCommand --> BuildFailureDetector : isBuildFailure()
+  RunCommand --> DependencyRecordReader : readAll() when not excluded
+  CommitCheckout ..> ScratchTree : cleans (was: root only, now: every module)
+  BuildFailureDetector ..> ScratchTree : reads (any TEST-*.xml, fresh or stale)
+```
+
+The bug is coupling through `ScratchTree`, not through a method call: `CommitCheckout` and
+`BuildFailureDetector` never call each other, but they silently agree on the filesystem being
+clean between commits. Only cleaning the root broke that agreement for every submodule.
+
+## Sequence: two checkouts in the same scratch clone, one submodule behind a build failure
+
+```mermaid
+sequenceDiagram
+  participant RunCommand
+  participant CommitCheckout
+  participant FS as Scratch tree
+  participant Detector as BuildFailureDetector
+  participant Reader as DependencyRecordReader
+
+  RunCommand->>CommitCheckout: checkoutCommit(commitN)
+  CommitCheckout->>FS: git checkout commitN
+  CommitCheckout->>FS: walk tree, delete every target/ (skip .git)
+  RunCommand->>FS: mvn clean test (agent attached)
+  FS-->>RunCommand: success — moduleB/target/surefire-reports/TEST-*.xml written
+
+  RunCommand->>CommitCheckout: checkoutCommit(commitN+1)
+  CommitCheckout->>FS: git checkout commitN+1
+  Note over CommitCheckout,FS: fixed here — walks every module,<br/>not just the reactor root
+  CommitCheckout->>FS: walk tree, delete every target/ (skip .git)
+  RunCommand->>FS: mvn clean test (agent attached)
+  FS-->>RunCommand: exit != 0 — moduleA fails to compile, moduleB never reached
+
+  RunCommand->>Detector: isBuildFailure(result, scratchDir)
+  Detector->>FS: any TEST-*.xml anywhere?
+  FS-->>Detector: none (moduleB's was cleared above)
+  Detector-->>RunCommand: true
+  RunCommand->>RunCommand: pair EXCLUDED — loop continues
+
+  Note over RunCommand,Reader: before the fix: moduleB's stale report survived,<br/>Detector said "false", RunCommand called<br/>Reader.readAll() and crashed — no agent file<br/>was ever written for commitN+1
+```

--- a/docs/fluencyloop/features/fix-commitcheckout-to-clear-stale-target-dirs-in-every-submo/sessions/walk-the-whole-scratch-tree-pruning-git-and-target-subtrees.md
+++ b/docs/fluencyloop/features/fix-commitcheckout-to-clear-stale-target-dirs-in-every-submo/sessions/walk-the-whole-scratch-tree-pruning-git-and-target-subtrees.md
@@ -1,0 +1,53 @@
+# Session: walk the whole scratch tree pruning .git and target/ subtrees, add submodule-level regression test
+
+- **intent:** walk the whole scratch tree pruning .git and target/ subtrees, add submodule-level regression test
+- **started:** 2026-07-27
+
+<!--
+FluencyLoop Stage 3 — a session is a slice of the build. One block per meaningful decision,
+appended at the slice boundary as it's taught. No `commits:` field: the feature is a branch,
+so the PR view derives commits live from git.
+
+Each decision is a `## Decision:` heading followed by a bullet list — one bullet per field, so
+it renders one-per-line as real Markdown (plain `key: value` lines collapse into a single
+paragraph when rendered). Fields:
+
+  where        — file/area the decision lives in (NOT a line number — survives refactoring)
+  why          — the rationale, taught live before it was written
+  alternative  — the rejected option and why (this is what makes it rationale, not description)
+  design       — (optional) ../design.md#anchor — the diagram this decision shaped or used
+  constitution — (optional) §N — the principle this decision serves or trades off against
+  trust        — ✓ verified | ⚠ not independently verified  (about the DECISION, never the person)
+
+Delete this comment and the example below once real decisions land.
+-->
+
+---
+
+## Knowledge transfer
+
+- **CommitCheckout's reuse invariant** — `RunCommand` reuses one scratch clone across every
+  commit pair in the validator's window; `checkoutCommit()` is the only place responsible for
+  leaving the tree exactly as if it had never been built in before the next `mvn clean test`
+  runs. Any build artifact it misses becomes a false signal for the *next* commit, not the
+  current one — so bugs here show up one checkout later than the code that caused them.
+  status: documented
+- **BuildFailureDetector's heuristic and its blind spot** — it can only ask "does any
+  `TEST-*.xml` exist anywhere under the project," not whether one is fresh. That's why
+  `CommitCheckout` (not the target project's own `clean` goal) owns cleanup: the target
+  project's build failing is exactly the case where its `clean` goal may never have run for
+  every module. status: documented
+- **Root cause found empirically, not by inspection** — running the validator against a real
+  large multi-module project (apache/shenyu, dozens of modules) surfaced this; the existing
+  single-module fixture and test coverage couldn't have caught it because `twoModuleReactor`
+  existed as a fixture but had no test exercising `CommitCheckout`'s cleanup against it.
+  status: documented
+
+## Decision: walk the whole scratch tree with SKIP_SUBTREE, not Files.walk + filter
+
+- **where:** `blastradius-validator/.../git/CommitCheckout.java`
+- **why:** a multi-module reactor build can fail before reaching a module a prior commit tested, leaving that module's own target/ stale; only cleaning the root left BuildFailureDetector's any-TEST-*.xml heuristic fooled per-submodule. walkFileTree lets .git and each found target/ be pruned from the walk itself (SKIP_SUBTREE) instead of walking everything and filtering after — cheaper on a large reactor's object store, and target/ is deleted whole rather than visited file by file.
+- **alternative:** Files.walk(scratchDir) + stream filter for dirs named target — rejected: still descends into .git and into target/ internals before the filter throws them away, wasteful on a large real-world repo like apache/shenyu
+- **design:** ../design.md#sequence-two-checkouts-in-the-same-scratch-clone-one-submodule-behind-a-build-failure
+- **constitution:** VII (Exhaustive Harness Cleanup)
+- **trust:** ✓ verified


### PR DESCRIPTION
## Summary

`CommitCheckout` reuses one scratch clone across every commit pair the validator walks. It only cleared the reactor-root `target/` between checkouts, so in a multi-module reactor a stale `target/` (and any `TEST-*.xml` in it) from a module a prior commit successfully tested could survive into a checkout whose build fails before reaching that module. `BuildFailureDetector`'s "does any `TEST-*.xml` exist anywhere" heuristic can't tell fresh from stale, so it wrongly concluded the build had run tests — and `RunCommand` crashed reading dependency-tracking output the agent never produced. Found running the validator against `apache/shenyu` (a real, dozens-of-modules project):

```
blastradius-validator: failed to read dependency record from /var/folders/.../blastradius-base-deps-<random>.json
```

## Decision that matters

**Walk the whole scratch tree with `Files.walkFileTree` + `SKIP_SUBTREE`, not `Files.walk()` + filter** — `blastradius-validator/.../git/CommitCheckout.java`

- **Why**: `walkFileTree` lets `.git` and each found `target/` be pruned from the walk itself (`SKIP_SUBTREE`) instead of walking everything and filtering after — cheaper on a large reactor's object store, and `target/` is deleted whole rather than visited file by file.
- **Rejected alternative**: `Files.walk(scratchDir)` + stream filter for dirs named `target` — still descends into `.git` and into `target/` internals before the filter throws them away, wasteful on a repo the size of `apache/shenyu`.
- **Trust**: ✓ verified — confirmed RED without the fix (new test fails), GREEN with it, full validator suite green after.
- **Constitution**: cites new Principle VII (Exhaustive Harness Cleanup), promoted from this decision's rationale — see below.

Design: [`docs/fluencyloop/features/fix-commitcheckout-to-clear-stale-target-dirs-in-every-submo/design.md`](../blob/feature/fix-commitcheckout-to-clear-stale-target-dirs-in-every-submo/docs/fluencyloop/features/fix-commitcheckout-to-clear-stale-target-dirs-in-every-submo/design.md) (class + sequence diagrams of the `CommitCheckout` / `BuildFailureDetector` / `DependencyRecordReader` coupling through the shared scratch tree).

## Constitution amendment

Promoted the decision's rationale to a new principle, `### VII. Exhaustive Harness Cleanup` in `.specify/memory/constitution.md` (2.1.0 → 2.2.0, MINOR): any of our own tooling reusing a scratch/build directory across repeated builds must clean every location a prior build could have left state in, not just the top-level one, and must not rely on the target build's own `clean` goal.

## What changed

- `CommitCheckout.checkoutCommit()`: replaced root-only `target/` deletion with a full tree walk pruning `.git` and every `target/` found.
- `CommitCheckoutTest`: new regression test `checkoutClearsStaleTargetDirectoriesInEverySubmoduleNotJustTheReactorRoot`, using the existing `twoModuleReactor` fixture (previously unused for this purpose).
- `.specify/memory/constitution.md`: new Principle VII + Sync Impact Report entry, version bump.

## Test plan

- [x] New regression test verified RED without the fix, GREEN with it (via temporary `git stash`).
- [x] Full `blastradius-validator` suite: 62 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
