### PR TITLE
fix: classify .fluencyloop/ paths as inert, not NON_SOURCE

### DIFF
--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/ChangedFileClassifier.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/git/ChangedFileClassifier.java
@@ -120,7 +120,7 @@ public final class ChangedFileClassifier {
             return false;
         }
         if (path.startsWith(".github/") || path.startsWith(".idea/") || path.startsWith(".vscode/")
-                || path.startsWith("docs/") || path.contains("/docs/")) {
+                || path.startsWith(".fluencyloop/") || path.startsWith("docs/") || path.contains("/docs/")) {
             return true;
         }
         String fileName = path.substring(path.lastIndexOf('/') + 1);

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/git/ChangedFileClassifierTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/git/ChangedFileClassifierTest.java
@@ -162,6 +162,22 @@ class ChangedFileClassifierTest {
     }
 
     @Test
+    void fluencyloopStateFileChangeIsClassifiedAsInert(@TempDir Path tempDir) {
+        // FluencyLoop's own branch/stage bookkeeping (.fluencyloop/state.json) can't affect
+        // any test outcome, but it lives outside docs/ and has no recognized doc extension —
+        // before this it fell through to NON_SOURCE and forced a full-suite fallback on every
+        // module in the build (found running blastradius against its own PR #140).
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(tempDir);
+        String base = fixture.commit("initial");
+        fixture.writeResource(".fluencyloop/state.json", "{\"feature\":\"x\"}");
+        String head = fixture.commit("update fluencyloop state");
+
+        List<ChangedFile> changed = classifier.classify(tempDir, base, head);
+
+        assertEquals(FileKind.INERT, single(changed, ".fluencyloop/state.json").kind());
+    }
+
+    @Test
     void markdownUnderResourcesIsNonSourceNotInert(@TempDir Path tempDir) {
         // Soundness (§III): a Markdown file under resources/ can be test data a test loads,
         // and class-load tracking can't see it — so it MUST fall back, never select nothing.


### PR DESCRIPTION
## Summary

PR #140's own CI run fell back to running every test in every module — 90/90, 6/6, 62/62, 79/79, all with `dependency-matched: 0` — even though the only real code change was in `blastradius-validator`. Root cause: `.fluencyloop/state.json` (FluencyLoop's own branch/stage bookkeeping file, updated by every FluencyLoop feature) lives outside `docs/` and has no recognized doc extension, so `ChangedFileClassifier.isInert()` fell through its allowlist to `NON_SOURCE`, which forces `FALLBACK_NON_SOURCE_CHANGE` (FR-006) — a full-suite fallback across the whole build, not just the file's own module.

`.fluencyloop/state.json` provably cannot affect any test outcome (Constitution Principle III's inert carve-out), so it belongs on the allowlist alongside `.github/`, `.idea/`, `.vscode/`, and `docs/`.

## What changed

- `ChangedFileClassifier.isInert()`: added a `.fluencyloop/` path prefix check.
- `ChangedFileClassifierTest`: new regression test `fluencyloopStateFileChangeIsClassifiedAsInert`, verified RED before the fix (asserted `NON_SOURCE`, fix asserts `INERT`).

## Test plan

- [x] New test confirmed RED without the fix, GREEN with it.
- [x] Full `blastradius-core` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)