### PR TITLE
fix: exclude a pair instead of aborting the whole run when analysis fails

### DIFF
--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
@@ -41,8 +41,9 @@ import java.util.stream.Collectors;
  * out the base commit to obtain a dependency baseline, checks out the head commit to
  * obtain ground truth, classifies changes, runs selection, and compares against ground
  * truth for would-miss cases — then computes the overall verdict and writes the report.
- * A pair whose base or head commit fails to build is excluded (FR-009) rather than
- * aborting the whole run.
+ * A pair whose base or head commit fails to build — or whose analysis fails for any
+ * other reason (e.g. the tracking agent produced no output for a commit whose build
+ * otherwise succeeded) — is excluded (FR-009) rather than aborting the whole run.
  *
  * <p>Exit codes per the CLI contract: {@code 0} = PASS, {@code 1} = FAIL, {@code 2} =
  * the run itself could not complete.
@@ -86,7 +87,12 @@ public final class RunCommand {
             Path scratchParent = Files.createTempDirectory("blastradius-scratch-");
             try (CommitCheckout checkout = CommitCheckout.forTargetProject(config.projectPath(), scratchParent)) {
                 for (CommitPair pair : window) {
-                    PairAnalysis analysis = analyzePair(pair, config.projectPath(), checkout, agentJar);
+                    PairAnalysis analysis;
+                    try {
+                        analysis = analyzePair(pair, config.projectPath(), checkout, agentJar);
+                    } catch (Exception e) {
+                        analysis = excluded(pair, "analysis failed: " + e.getMessage());
+                    }
                     if (analysis.pair().status() == PairStatus.EXCLUDED) {
                         excludedPairs.add(analysis.pair());
                     } else {

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/cli/RunCommandErrorHandlingTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/cli/RunCommandErrorHandlingTest.java
@@ -67,6 +67,34 @@ class RunCommandErrorHandlingTest {
         assertTrue(report.get("analyzedCommitPairs").isEmpty());
     }
 
+    @Test
+    void baseCommitWithNoTrackedDependencyOutputExcludesThePairInsteadOfAbortingTheRun(
+            @TempDir Path projectDir, @TempDir Path outDir) throws Exception {
+        Path agentJar = findOwnAgentJar();
+        Path reportFile = outDir.resolve("report.json");
+
+        // A real, buildable Maven project with zero test classes: `mvn clean test`
+        // succeeds (exit 0) but Surefire runs nothing, so the tracking agent's shutdown
+        // hook sees an empty record and never writes an output file — the same shape of
+        // failure as a build whose only forked test JVM crashes before writing (e.g. a
+        // conflicting javaagent), found running against apache/shenyu.
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.commit("initial (no tests)");
+        fixture.writeResource("NOTES.txt", "second commit");
+        fixture.commit("second commit");
+
+        RunConfig config = new RunConfig(projectDir, 1, reportFile);
+        int exitCode = new RunCommand().run(config, agentJar);
+
+        // Not a crash (no exit-2): the pair is excluded with a clear reason, and the run
+        // still completes and writes a report, per the class's own documented FR-009
+        // contract ("excluded... rather than aborting the whole run").
+        assertEquals(0, exitCode);
+        JsonNode report = new ObjectMapper().readTree(reportFile.toFile());
+        assertEquals(1, report.get("excludedCommitPairs").size());
+        assertTrue(report.get("analyzedCommitPairs").isEmpty());
+    }
+
     private static Path findOwnAgentJar() throws IOException {
         Path targetDir = Path.of("target");
         try (var stream = Files.list(targetDir)) {


### PR DESCRIPTION
## Summary
- `RunCommand`'s per-pair loop had no exception handling: any failure inside `analyzePair()` propagated to the outer catch and aborted the entire run (exit 2), even though the class's own javadoc promises a pair whose base/head commit fails to build is excluded rather than aborting the whole run (FR-009). That promise only actually held for the two explicit `isBuildFailure()` checks.
- Found running blastradius-validator against a real-world project (apache/shenyu): a commit whose build genuinely succeeds can still leave the dependency-tracking agent with nothing to write (its shutdown-hook thread can crash independently of the build's own outcome — e.g. from a conflicting javaagent in the target project's own build, or a module with zero test classes). `DependencyRecordReader.readAll()` then throws because no per-JVM output file exists, which used to abort analysis of every remaining commit in the window instead of just excluding that one pair.
- Fix: wrap the per-pair `analyzePair()` call in `RunCommand.run()`'s loop and treat any exception as an excluded pair (reason = the exception message), matching the documented contract.

## Test plan
- [x] New regression test `RunCommandErrorHandlingTest#baseCommitWithNoTrackedDependencyOutputExcludesThePairInsteadOfAbortingTheRun` — a real Maven fixture project with zero test classes (build succeeds, agent writes nothing) — RED before the fix (exit code 2), GREEN after (exit 0, pair excluded with a clear reason).
- [x] Full `blastradius-validator` test suite passes clean.
- [x] Re-ran the validator against a local `apache/shenyu` clone (20-commit window) that previously crashed the whole run with `blastradius-validator: failed to read dependency record from ...`: now completes and writes a report with each problematic pair excluded, instead of aborting.