### PR TITLE
fix: remove stray underline ticks between README badges, fix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,12 @@
 
 # Blastradius
 
-<a href="https://shenyu.apache.org/docs/">
-  <img src="https://img.shields.io/badge/document-English-blue.svg" alt="EN docs" />
-</a>
-<a target="_blank" href="https://central.sonatype.com/search?q=g:io.github.baokhang83.blastradius%20%20a:blastradius-maven-plugin">
-    <img src="https://img.shields.io/maven-central/v/io.github.baokhang83.blastradius/blastradius-maven-plugin.svg?label=maven%20central" />
-</a>
-<a target="_blank" href="https://www.oracle.com/technetwork/java/javase/downloads/index.html">
-   <img src="https://img.shields.io/badge/JDK-21+-green.svg" />
-</a>
-<a target="_blank" href="https://github.com/baokhang83/blastradius/actions/workflows/build.yml">
-   <img src="https://github.com/baokhang83/blastradius/actions/workflows/build.yml/badge.svg" />
-</a>
-<a target="_blank" href="https://github.com/baokhang83/blastradius">
-   <img src="https://img.shields.io/github/languages/top/baokhang83/blastradius?cacheSeconds=86400" />
-</a>
-<a target="_blank" href="https://github.com/baokhang83/blastradius">
-   <img src="https://raw.githubusercontent.com/baokhang83/blastradius/refs/heads/gh-pages/badges/jacoco.svg" />
-</a>
+<a href="https://baokhang83.github.io/blastradius/"><img src="https://img.shields.io/badge/document-English-blue.svg" alt="EN docs" /></a>
+<a target="_blank" href="https://central.sonatype.com/search?q=g:io.github.baokhang83.blastradius%20%20a:blastradius-maven-plugin"><img src="https://img.shields.io/maven-central/v/io.github.baokhang83.blastradius/blastradius-maven-plugin.svg?label=maven%20central" /></a>
+<a target="_blank" href="https://www.oracle.com/technetwork/java/javase/downloads/index.html"><img src="https://img.shields.io/badge/JDK-21+-green.svg" /></a>
+<a target="_blank" href="https://github.com/baokhang83/blastradius/actions/workflows/build.yml"><img src="https://github.com/baokhang83/blastradius/actions/workflows/build.yml/badge.svg" /></a>
+<a target="_blank" href="https://github.com/baokhang83/blastradius"><img src="https://img.shields.io/github/languages/top/baokhang83/blastradius?cacheSeconds=86400" /></a>
+<a target="_blank" href="https://github.com/baokhang83/blastradius"><img src="https://raw.githubusercontent.com/baokhang83/blastradius/refs/heads/gh-pages/badges/jacoco.svg" /></a>
 
 
 Most "test impact analysis" tools guess from a static, per-module dependency graph, or


### PR DESCRIPTION
## Summary
- Each badge was `<a href="..">\n  <img .../>\n</a>` split across lines. The whitespace/newline inside the anchor is a text node that still inherits the link's blue underline (unlike the `<img>` itself, a replaced element that suppresses it), rendering as a small blue tick at the edge of every badge in the row.
- Fix: collapse each anchor onto a single line with no interior whitespace.
- Also fixes the "document" badge's `href`, which pointed at `shenyu.apache.org/docs/` — a leftover from using shenyu's own badge markup as a copy-paste template — to blastradius's actual docs site.

## Test plan
- [x] Visual: rendered README on GitHub no longer shows the blue ticks between badges; "document" badge now links to blastradius's docs.