### PR TITLE
fix: skip java.lang.invoke.* classes in the tracking agent

### DIFF
--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
@@ -62,6 +62,20 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
             "io.github.baokhang83.blastradius.shaded.asm.";
 
     /**
+     * Found running against a real apache/shenyu build: computing a checksum here (touching
+     * {@code MessageDigest} and {@code ConcurrentHashMap}) is reentrant class-loading work
+     * happening in the middle of the JVM's own {@code MethodHandle}/{@code invokedynamic}
+     * bootstrap sequence for a class shaped like this, which threw
+     * {@link ClassCircularityError} once a second, dynamically self-attached javaagent
+     * (Mockito's inline mock maker attaching its own byte-buddy agent at runtime) was also
+     * active in the same fork and racing to instrument the same machinery. These classes are
+     * pure JDK platform plumbing, identical for any two commits built with the same JDK, so
+     * tracking their checksums has no test-selection value — skipping them removes a real
+     * crash risk for free.
+     */
+    private static final String JDK_INVOKE_BOOTSTRAP_PACKAGE_PREFIX = "java.lang.invoke.";
+
+    /**
      * Computing a checksum can initialize JDK security-provider classes. Those class loads call
      * this transformer again, so they must not recursively trigger another checksum computation.
      */
@@ -162,6 +176,9 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
         }
 
         String dottedClassName = className.replace('/', '.');
+        if (dottedClassName.startsWith(JDK_INVOKE_BOOTSTRAP_PACKAGE_PREFIX)) {
+            return null;
+        }
         if (classBeingRedefined != null && pendingAmbientRetransformations.contains(dottedClassName)) {
             try {
                 byte[] instrumented = ambientClassInstrumenter.instrument(dottedClassName, classfileBuffer);

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
@@ -73,6 +73,22 @@ class DependencyTrackingAgentTest {
     }
 
     @Test
+    void jdkInvokeBootstrapClassesAreNotTracked() {
+        // Found running against a real apache/shenyu build: computing a checksum here is
+        // reentrant class-loading work (MessageDigest, ConcurrentHashMap) happening in the
+        // middle of the JVM's own MethodHandle/invokedynamic bootstrap sequence for this
+        // exact class shape, which threw ClassCircularityError once a second, dynamically
+        // self-attached javaagent (Mockito's inline mock maker) was also active in the same
+        // fork. These classes are pure JDK platform plumbing, identical for any two commits
+        // built with the same JDK, so tracking their checksums has no test-selection value
+        // — skipping them removes a real crash risk for free.
+        currentTest.set(FOO_TEST);
+        agent.transform(null, "java/lang/invoke/MethodHandleImpl$CountingWrapper$1", null, null,
+                "x".getBytes(StandardCharsets.UTF_8));
+        assertTrue(agent.recordedDependencies().isEmpty());
+    }
+
+    @Test
     void executedTestWithNoClassLoadsHasAnEmptyBaseline() {
         agent.recordTestExecution(FOO_TEST);
 


### PR DESCRIPTION
## Summary
- The tracking agent's shutdown hook crashed with `ClassCircularityError` on `java/lang/invoke/MethodHandleImpl$CountingWrapper$1` when run against a real apache/shenyu build, before it could write any dependency data
- Root cause: computing a checksum in `transform()` (touching `MessageDigest`/`ConcurrentHashMap`) is reentrant class-loading work happening mid-bootstrap for `java.lang.invoke.*` machinery, and it raced with a second, dynamically self-attached javaagent (Mockito's inline mock maker attaching its own byte-buddy agent) instrumenting the same classes in the same fork
- Fix: skip `java.lang.invoke.*` early in `transform()` — these are pure JDK platform plumbing, identical across commits built with the same JDK, so they carry no test-selection value anyway

## Test plan
- [x] New unit test `jdkInvokeBootstrapClassesAreNotTracked` (TDD RED→GREEN)
- [x] Full test suite: blastradius-core (96 tests) and blastradius-validator (75 tests), no regressions
- [x] Verified against the exact shenyu commit (`ea4f1770`) that previously crashed: `shenyu-common`'s full test module (393 tests) now builds clean with the agent attached, and the shutdown hook writes real dependency data (no crash marker)

Co-authored-by: Codex <codex@openai.com>