### PR TITLE
feat: add --maven-threads flag for parallel target-project builds

### DIFF
--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/GroundTruthResolver.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/GroundTruthResolver.java
@@ -30,6 +30,11 @@ public final class GroundTruthResolver {
         this(new MavenBuildRunner(), new SurefireReportParser());
     }
 
+    /** Shares one {@link MavenBuildRunner} (e.g. its {@code -T} setting) with a caller's own. */
+    public GroundTruthResolver(MavenBuildRunner buildRunner) {
+        this(buildRunner, new SurefireReportParser());
+    }
+
     GroundTruthResolver(MavenBuildRunner buildRunner, SurefireReportParser reportParser) {
         this.buildRunner = buildRunner;
         this.reportParser = reportParser;

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunner.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunner.java
@@ -22,6 +22,28 @@ public final class MavenBuildRunner {
 
     private static final long TIMEOUT_MINUTES = 5;
 
+    private final Integer parallelThreads;
+
+    /** No {@code -T} flag: the target project's reactor builds serially, as it always has. */
+    public MavenBuildRunner() {
+        this(null);
+    }
+
+    /**
+     * @param parallelThreads value passed to Maven's own {@code -T} reactor-parallelism
+     *                        flag (e.g. {@code 4}), or {@code null} to omit it and build
+     *                        serially. Each module still builds in dependency order and
+     *                        the tracking agent attaches identically per fork; the risk
+     *                        this trades in is target projects with non-thread-safe
+     *                        build plugins that only misbehave under a parallel reactor.
+     */
+    public MavenBuildRunner(Integer parallelThreads) {
+        if (parallelThreads != null && parallelThreads < 1) {
+            throw new IllegalArgumentException("parallelThreads must be positive, got: " + parallelThreads);
+        }
+        this.parallelThreads = parallelThreads;
+    }
+
     /**
      * How long to wait for a Surefire-forked JVM that outlives {@code mvn} itself to exit
      * on its own before it gets forcibly killed (research.md #1 / apache/shenyu finding,
@@ -156,12 +178,16 @@ public final class MavenBuildRunner {
         descendants.stream().filter(ProcessHandle::isAlive).forEach(ProcessHandle::destroyForcibly);
     }
 
-    private static String[] command(String testSelector) {
+    String[] command(String testSelector) {
         // `clean` is required, not cosmetic: CommitCheckout reuses one scratch working
         // copy across every commit in the window, and `target/` is untracked — a
         // previous commit's build artifacts (including surefire-reports) would
         // otherwise silently survive a `git checkout` to a different commit.
         List<String> args = new ArrayList<>(List.of("mvn", "-B", "--no-transfer-progress", "clean", "test"));
+        if (parallelThreads != null) {
+            args.add("-T");
+            args.add(String.valueOf(parallelThreads));
+        }
         if (testSelector != null) {
             args.add("-Dtest=" + testSelector);
         }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/Main.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/Main.java
@@ -9,13 +9,15 @@ import java.nio.file.Path;
 
 /**
  * CLI entry point. Usage:
- * {@code blastradius-validator run --project-path <path> --commits <N> --report-out <path> [--summary-out <path>]}
+ * {@code blastradius-validator run --project-path <path> --commits <N> --report-out <path>
+ * [--summary-out <path>] [--maven-threads <N>]}
  */
 public final class Main {
 
     public static void main(String[] args) {
         if (args.length == 0 || !"run".equals(args[0])) {
-            System.err.println("usage: run --project-path <path> --commits <N> --report-out <path> [--summary-out <path>]");
+            System.err.println("usage: run --project-path <path> --commits <N> --report-out <path> "
+                    + "[--summary-out <path>] [--maven-threads <N>]");
             System.exit(2);
             return;
         }
@@ -24,6 +26,7 @@ public final class Main {
         Integer commits = null;
         Path reportOut = null;
         Path summaryOut = null;
+        Integer mavenThreads = null;
 
         for (int i = 1; i < args.length; i++) {
             switch (args[i]) {
@@ -31,6 +34,7 @@ public final class Main {
                 case "--commits" -> commits = Integer.parseInt(args[++i]);
                 case "--report-out" -> reportOut = Path.of(args[++i]);
                 case "--summary-out" -> summaryOut = Path.of(args[++i]);
+                case "--maven-threads" -> mavenThreads = Integer.parseInt(args[++i]);
                 default -> {
                     System.err.println("unknown argument: " + args[i]);
                     System.exit(2);
@@ -46,7 +50,7 @@ public final class Main {
         }
 
         try {
-            RunConfig config = new RunConfig(projectPath, commits, reportOut);
+            RunConfig config = new RunConfig(projectPath, commits, reportOut, mavenThreads);
             int exitCode = new RunCommand().run(config);
             printSummary(reportOut, summaryOut, exitCode);
             System.exit(exitCode);

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
@@ -53,16 +53,19 @@ public final class RunCommand {
 
     private final CommitWindowResolver commitWindowResolver = new CommitWindowResolver();
     private final ChangedFileClassifier changedFileClassifier = new ChangedFileClassifier();
-    private final GroundTruthResolver groundTruthResolver = new GroundTruthResolver();
     private final SelectionEngine selectionEngine = new SelectionEngine();
     private final NewOrModifiedTestSelector newOrModifiedTestSelector = new NewOrModifiedTestSelector();
     private final WouldMissComparator wouldMissComparator = new WouldMissComparator();
     private final VerdictCalculator verdictCalculator = new VerdictCalculator();
     private final SavingsSummaryAggregator savingsSummaryAggregator = new SavingsSummaryAggregator();
     private final ReportWriter reportWriter = new ReportWriter();
-    private final MavenBuildRunner buildRunner = new MavenBuildRunner();
     private final BuildFailureDetector buildFailureDetector = new BuildFailureDetector();
     private final JdkMismatchDetector jdkMismatchDetector = new JdkMismatchDetector();
+
+    // Set at the start of each run() from RunConfig#mavenParallelThreads, so the base/head
+    // builds and GroundTruthResolver's own build all share one -T setting for that run.
+    private MavenBuildRunner buildRunner = new MavenBuildRunner();
+    private GroundTruthResolver groundTruthResolver = new GroundTruthResolver();
 
     /** Runs with this tool's own jar self-located for {@code -javaagent} attachment. */
     public int run(RunConfig config) {
@@ -77,6 +80,9 @@ public final class RunCommand {
      */
     public int run(RunConfig config, Path agentJar) {
         try {
+            buildRunner = new MavenBuildRunner(config.mavenParallelThreads());
+            groundTruthResolver = new GroundTruthResolver(buildRunner);
+
             jdkMismatchDetector.detect(config.projectPath()).ifPresent(System.err::println);
 
             List<CommitPair> window =

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunConfig.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunConfig.java
@@ -7,12 +7,19 @@ import java.util.Objects;
 /**
  * The operator-supplied input for a single validator run (FR-001, FR-012).
  *
- * @param projectPath       local git working copy of the target project
- * @param commitWindowSize  number of most-recent commits to analyze; operator-chosen,
- *                          no fixed default (FR-012)
- * @param reportOutputPath  file path to write the JSON {@code AnalysisReport} to
+ * @param projectPath          local git working copy of the target project
+ * @param commitWindowSize     number of most-recent commits to analyze; operator-chosen,
+ *                             no fixed default (FR-012)
+ * @param reportOutputPath     file path to write the JSON {@code AnalysisReport} to
+ * @param mavenParallelThreads value for the target project's own {@code mvn -T} reactor
+ *                             parallelism, or {@code null} to build serially (the default)
  */
-public record RunConfig(Path projectPath, int commitWindowSize, Path reportOutputPath) {
+public record RunConfig(
+        Path projectPath, int commitWindowSize, Path reportOutputPath, Integer mavenParallelThreads) {
+
+    public RunConfig(Path projectPath, int commitWindowSize, Path reportOutputPath) {
+        this(projectPath, commitWindowSize, reportOutputPath, null);
+    }
 
     public RunConfig {
         Objects.requireNonNull(projectPath, "projectPath");
@@ -28,6 +35,10 @@ public record RunConfig(Path projectPath, int commitWindowSize, Path reportOutpu
         Objects.requireNonNull(reportOutputPath, "reportOutputPath");
         if (Files.isDirectory(reportOutputPath)) {
             throw new IllegalArgumentException("reportOutputPath must be a file path, not a directory: " + reportOutputPath);
+        }
+        if (mavenParallelThreads != null && mavenParallelThreads < 1) {
+            throw new IllegalArgumentException(
+                    "mavenParallelThreads must be positive, got: " + mavenParallelThreads);
         }
     }
 }

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunnerTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunnerTest.java
@@ -1,6 +1,8 @@
 package io.github.baokhang83.blastradius.validator.build;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
@@ -116,6 +118,26 @@ class MavenBuildRunnerTest {
         assertEquals(0, result.exitCode());
         assertTrue(result.output().contains("Tests run: 1"),
                 "expected exactly one test to run:\n" + result.output());
+    }
+
+    @Test
+    void noParallelThreadsOmitsTheTFlag() {
+        assertArrayEquals(
+                new String[] {"mvn", "-B", "--no-transfer-progress", "clean", "test"},
+                new MavenBuildRunner().command(null));
+    }
+
+    @Test
+    void parallelThreadsAddsTheTFlagToTheMavenCommand() {
+        assertArrayEquals(
+                new String[] {"mvn", "-B", "--no-transfer-progress", "clean", "test", "-T", "4"},
+                new MavenBuildRunner(4).command(null));
+    }
+
+    @Test
+    void nonPositiveParallelThreadsIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> new MavenBuildRunner(0));
+        assertThrows(IllegalArgumentException.class, () -> new MavenBuildRunner(-1));
     }
 
     private static Path findOwnAgentJar() throws IOException {

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/cli/RunConfigTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/cli/RunConfigTest.java
@@ -1,6 +1,7 @@
 package io.github.baokhang83.blastradius.validator.cli;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -55,6 +56,25 @@ class RunConfigTest {
         Files.createDirectories(aDirectory);
 
         assertThrows(IllegalArgumentException.class, () -> new RunConfig(repo, 10, aDirectory));
+    }
+
+    @Test
+    void mavenParallelThreadsDefaultsToNullWhenNotSupplied(@TempDir Path tempDir) throws Exception {
+        Path repo = initGitRepo(tempDir.resolve("repo"));
+
+        RunConfig config = new RunConfig(repo, 10, tempDir.resolve("report.json"));
+
+        assertNull(config.mavenParallelThreads());
+    }
+
+    @Test
+    void mavenParallelThreadsMustBePositiveWhenSupplied(@TempDir Path tempDir) throws Exception {
+        Path repo = initGitRepo(tempDir.resolve("repo"));
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new RunConfig(repo, 10, tempDir.resolve("report.json"), 0));
+        assertThrows(IllegalArgumentException.class,
+                () -> new RunConfig(repo, 10, tempDir.resolve("report.json"), -3));
     }
 
     private static Path initGitRepo(Path dir) throws Exception {


### PR DESCRIPTION
## Summary
- The validator runs a target project's full `mvn clean test` up to three times per commit pair (base tracking build, head build-probe, head ground-truth build), each serially by default
- On a large multi-module reactor (e.g. apache/shenyu, ~307 modules) this made a single commit pair take 30-45+ minutes, which doesn't scale to validating many commits
- Adds an optional `--maven-threads <N>` CLI flag that passes Maven's own `-T <N>` reactor-parallelism flag through to every build the validator runs

## Design
- Each module still builds in dependency order and the tracking agent attaches identically per fork, so this carries no correctness risk from our side — the tradeoff is entirely the target project's: some multi-module builds have non-thread-safe plugins that only misbehave under a parallel reactor
- Defaults to `null`/off (unchanged, serial behavior) rather than being always-on, for that reason
- `MavenBuildRunner` and `GroundTruthResolver` now share one build runner per `RunCommand#run()` invocation, so a single `--maven-threads` value applies consistently to every `mvn` invocation in that run

## Usage
```
java -jar blastradius-validator.jar run \
  --project-path <path> --commits <N> --report-out <path> \
  --maven-threads 4
```

## Test plan
- [x] New unit tests: `MavenBuildRunner` command construction (`-T` flag present/absent, rejects non-positive values), `RunConfig` validation
- [x] Full test suite: blastradius-core (96 tests) and blastradius-validator (80 tests), no regressions
- [ ] Not re-verified against real shenyu per explicit instruction — this PR is unverified against a live large-repo build

Co-authored-by: Codex <codex@openai.com>