### PR TITLE
fix: attribute a project class's reuse to every test, not just the one that first loaded it

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "fix-commitcheckout-to-clear-stale-target-dirs-in-every-submo",
-  "branch": "feature/fix-commitcheckout-to-clear-stale-target-dirs-in-every-submo",
+  "feature": "attribute-a-project-class-s-runtime-use-to-every-test-that-e",
+  "branch": "feature/attribute-a-project-class-s-runtime-use-to-every-test-that-e",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/fix-commitcheckout-to-clear-stale-target-dirs-in-every-submo/sessions/walk-the-whole-scratch-tree-pruning-git-and-target-subtrees.md",
-  "base_ref": "main",
-  "updated": "2026-07-27"
+  "last_session": "docs/fluencyloop/features/attribute-a-project-class-s-runtime-use-to-every-test-that-e/sessions/generalize-runtime-use-instrumentation-to-every-project-clas.md",
+  "base_ref": "feat/maven-parallel-build-threads",
+  "updated": "2026-07-28"
 }

--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -2,7 +2,7 @@
   "feature": "attribute-a-project-class-s-runtime-use-to-every-test-that-e",
   "branch": "feature/attribute-a-project-class-s-runtime-use-to-every-test-that-e",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/attribute-a-project-class-s-runtime-use-to-every-test-that-e/sessions/generalize-runtime-use-instrumentation-to-every-project-clas.md",
+  "last_session": "docs/fluencyloop/features/attribute-a-project-class-s-runtime-use-to-every-test-that-e/sessions/fix-stale-would-miss-fixtures-broken-by-the-broadened-instru.md",
   "base_ref": "feat/maven-parallel-build-threads",
   "updated": "2026-07-28"
 }

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,27 @@
 <!--
 Sync Impact Report
 ==================
+Version change: 2.2.0 → 2.3.0 (MINOR — new Principle VIII added)
+Added principles:
+  - VIII. No Avoidable Work on the Hot Path — code that runs once per class-load
+    event (DependencyTrackingAgent#transform and anything with a similar per-event
+    execution shape) MUST NOT do avoidable filesystem or syscall work on every
+    invocation; configuration fixed for a JVM's lifetime MUST be resolved once and
+    cached.
+    Rationale: found concretely when generalizing ambient-class instrumentation from
+    a one-time, pre-first-test snapshot to every project class's first load turned
+    configuredProjectRoot()'s System.getProperty + toRealPath() resolution from a
+    single call into one call per class load across the whole JVM — a real,
+    avoidable cost with no correctness benefit, since the underlying `-D` flag never
+    changes after JVM startup.
+Removed principles: none
+Added/removed sections: none
+Templates requiring updates:
+  - ✅ .specify/templates/plan-template.md — Constitution Check derived dynamically
+    from this file, no changes needed
+Follow-up TODOs: none
+
+Previous entry (2.1.0 → 2.2.0):
 Version change: 2.1.0 → 2.2.0 (MINOR — new Principle VII added)
 Added principles:
   - VII. Exhaustive Harness Cleanup — our own tooling that reuses a scratch/build
@@ -12,14 +33,8 @@ Added principles:
     a submodule's stale TEST-*.xml report survived into the next commit's failed
     build against a real multi-module project (apache/shenyu), fooling
     BuildFailureDetector's report-existence heuristic.
-Removed principles: none
-Added/removed sections: none
-Templates requiring updates:
-  - ✅ .specify/templates/plan-template.md — Constitution Check derived dynamically
-    from this file, no changes needed
-Follow-up TODOs: none
 
-Previous entry (2.0.0 → 2.1.0):
+Earlier entry (2.0.0 → 2.1.0):
 Version change: 2.0.0 → 2.1.0 (MINOR — Principle III materially refined)
 Modified principles:
   - III. Safety Over Speed — added the inert-change carve-out: a change that provably
@@ -169,6 +184,22 @@ concretely when `CommitCheckout` cleaned only the reactor root and a submodule's
 report survived into the next commit's (failed) build against a real multi-module
 project (apache/shenyu).
 
+### VIII. No Avoidable Work on the Hot Path
+
+Code that runs once per class-load event — `DependencyTrackingAgent#transform` and
+anything sharing that per-event execution shape — MUST NOT perform avoidable
+filesystem or syscall work on every invocation. Configuration that is fixed for a
+JVM's whole lifetime (e.g. a `-D` flag read once at startup) MUST be resolved once
+and cached, not re-resolved on each call.
+
+**Rationale**: found concretely when generalizing ambient-class instrumentation from
+a one-time, pre-first-test snapshot to every project class's first load turned
+`configuredProjectRoot()`'s `System.getProperty` + `toRealPath()` resolution from a
+single call into one call per class load across the whole JVM — a real, avoidable
+cost with no correctness benefit, since the underlying flag never changes after JVM
+startup. A class-load-frequency hot path is exactly where a small per-call cost
+compounds into a measurable build-time regression.
+
 ## Technology & Architecture Constraints
 
 - **Test execution model**: JUnit 5 Platform (Jupiter) is the primary, native
@@ -222,4 +253,4 @@ gate defined in `.specify/templates/plan-template.md`. Any violation MUST be
 explicitly justified in that plan's Complexity Tracking section or the design MUST
 be simplified until it complies.
 
-**Version**: 2.2.0 | **Ratified**: 2026-07-08 | **Last Amended**: 2026-07-28
+**Version**: 2.3.0 | **Ratified**: 2026-07-08 | **Last Amended**: 2026-07-28

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
@@ -89,6 +89,16 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
     private static final MessageDigest SHA_256 = initializeSha256();
     private static final char[] HEX_DIGITS = "0123456789abcdef".toCharArray();
 
+    /**
+     * Resolved once, here, rather than freshly on every {@link #transform} call: it's a
+     * {@code -D} flag fixed for the JVM's whole lifetime (set once, on the command line, by
+     * {@code TrackRunner}), but resolving it touches the filesystem ({@link #canonicalize}
+     * calls {@code toRealPath()}). Since every project-class fix below now runs this check on
+     * every single class load in the JVM — not just once, before the first test — repeating
+     * that syscall per class load would be a real cost for no benefit.
+     */
+    private static final Path CONFIGURED_PROJECT_ROOT = resolveConfiguredProjectRoot();
+
     private static volatile DependencyTrackingAgent installedAgent;
     private static volatile Instrumentation instrumentation;
 
@@ -194,19 +204,38 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
         }
 
         TestIdentity currentTest = currentTestSupplier.get();
-        if (currentTest == null) {
+        boolean isProjectClass = isAmbientInstrumentationCandidate(dottedClassName, protectionDomain);
+        if (currentTest == null && !isProjectClass) {
             return null;
         }
 
         RECORDING_CLASS_LOAD.set(true);
         try {
-            checksumsByTest
-                    .computeIfAbsent(currentTest, ignored -> new ConcurrentHashMap<>())
-                    .put(dottedClassName, sha256Hex(classfileBuffer));
+            String checksum = sha256Hex(classfileBuffer);
+            byte[] instrumented = null;
+            if (isProjectClass) {
+                // Every project class gets this at its first (and only) load — not just the
+                // ones the pre-first-test snapshot happens to catch — so a later test that
+                // reuses an already-loaded instance (e.g. a cached Spring bean) still gets
+                // attributed via the injected callback instead of silently missing it.
+                try {
+                    instrumented = ambientClassInstrumenter.instrument(dottedClassName, classfileBuffer);
+                    if (instrumented != null) {
+                        ambientChecksums.put(dottedClassName, checksum);
+                    }
+                } catch (RuntimeException ignored) {
+                    // Stays uninstrumented, same as any class the instrumenter can't rewrite.
+                }
+            }
+            if (currentTest != null) {
+                checksumsByTest
+                        .computeIfAbsent(currentTest, ignored -> new ConcurrentHashMap<>())
+                        .put(dottedClassName, checksum);
+            }
+            return instrumented;
         } finally {
             RECORDING_CLASS_LOAD.remove();
         }
-        return null;
     }
 
     /**
@@ -279,11 +308,18 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
         }
         Path projectRoot = configuredProjectRoot();
         for (Class<?> loadedClass : loadedClasses) {
+            String className = loadedClass.getName();
+            if (ambientChecksums.containsKey(className)) {
+                // Already instrumented at its original class-load (see #transform): this
+                // snapshot pass now mostly only catches what that inline path missed.
+                // Retransforming it again here would double-inject the runtime-use callback.
+                ambientDependencies.remove(className);
+                continue;
+            }
             if (!isAmbientInstrumentationCandidate(loadedClass, projectRoot)
                     || !currentInstrumentation.isModifiableClass(loadedClass)) {
                 continue;
             }
-            String className = loadedClass.getName();
             pendingAmbientRetransformations.add(className);
             try {
                 currentInstrumentation.retransformClasses(loadedClass);
@@ -314,6 +350,22 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
     }
 
     /**
+     * Same test as {@link #isAmbientInstrumentationCandidate(Class, Path)}, but usable from
+     * {@link #transform} itself: a class being defined has no {@link Class} object yet, only
+     * the {@link ProtectionDomain} the JVM hands the transformer directly. Array and primitive
+     * types never reach {@link #transform} (they're never defined from a classfile buffer), so
+     * unlike the {@code Class}-based check, this one doesn't need to filter them out.
+     */
+    private static boolean isAmbientInstrumentationCandidate(String dottedClassName, ProtectionDomain protectionDomain) {
+        if (dottedClassName.startsWith(TRACKING_PACKAGE_PREFIX)
+                || dottedClassName.startsWith(INSTRUMENTATION_LIBRARY_PACKAGE_PREFIX)) {
+            return false;
+        }
+        Path codeSource = codeSourceOf(protectionDomain);
+        return codeSource != null && isProjectCodeSource(codeSource, CONFIGURED_PROJECT_ROOT);
+    }
+
+    /**
      * A class belongs to the build under test when its code source lives under the reactor root —
      * whether that is a module's {@code target/classes} directory or another module's built jar,
      * which is how every downstream module sees its reactor dependencies. Without the reactor root
@@ -332,6 +384,10 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
     }
 
     private static Path configuredProjectRoot() {
+        return CONFIGURED_PROJECT_ROOT;
+    }
+
+    private static Path resolveConfiguredProjectRoot() {
         String configured = System.getProperty(PROJECT_ROOT_PROPERTY);
         if (configured == null || configured.isBlank()) {
             return null;
@@ -359,7 +415,10 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
     }
 
     private static Path codeSourceOf(Class<?> loadedClass) {
-        ProtectionDomain protectionDomain = loadedClass.getProtectionDomain();
+        return codeSourceOf(loadedClass.getProtectionDomain());
+    }
+
+    private static Path codeSourceOf(ProtectionDomain protectionDomain) {
         if (protectionDomain == null || protectionDomain.getCodeSource() == null
                 || protectionDomain.getCodeSource().getLocation() == null) {
             return null;

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
@@ -15,6 +15,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.ProtectionDomain;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -119,6 +120,50 @@ class DependencyTrackingAgentTest {
         agent.transform(Object.class.getModule(), null, "com/example/Foo", null, null, "x".getBytes(StandardCharsets.UTF_8));
 
         assertTrue(agent.recordedDependencies().get(FOO_TEST).containsKey("com.example.Foo"));
+    }
+
+    @Test
+    void projectClassIsInstrumentedAtLoadEvenWithNoTestRunning() throws Exception {
+        currentTest.set(null);
+
+        byte[] instrumented = agent.transform(
+                null, "com/example/SpringBean", null, ownProtectionDomain(), ownClassBytes());
+
+        assertTrue(instrumented != null,
+                "a project class must be instrumented on its very first load, whether or not a "
+                        + "test window happens to be open at that moment");
+        assertTrue(agent.recordedDependencies().isEmpty(), "no test was running, so nothing is attributed yet");
+    }
+
+    @Test
+    void laterTestReusingAnAlreadyLoadedProjectClassGetsAttributed() throws Exception {
+        // Simulates a Spring-managed singleton: TestA's window is the one that happens to
+        // trigger the class's only real transform() call; TestB reuses the same already-loaded
+        // instance (e.g. via a cached ApplicationContext) without ever reloading it. Only the
+        // callback injected into the instrumented bytecode — not a second transform() call —
+        // can attribute that reuse to TestB.
+        TestIdentity testA = new TestIdentity("com.example.BeanCreatingTest", "buildsContext");
+        TestIdentity testB = new TestIdentity("com.example.BeanReusingTest", "reusesCachedContext");
+
+        currentTest.set(testA);
+        agent.transform(null, "com/example/SpringBean", null, ownProtectionDomain(), ownClassBytes());
+
+        Field installedAgentField = DependencyTrackingAgent.class.getDeclaredField("installedAgent");
+        installedAgentField.setAccessible(true);
+        Object previousInstalledAgent = installedAgentField.get(null);
+        installedAgentField.set(null, agent);
+        try {
+            currentTest.set(testB);
+            DependencyTrackingAgent.recordAmbientExecution("com.example.SpringBean");
+        } finally {
+            installedAgentField.set(null, previousInstalledAgent);
+        }
+
+        Map<TestIdentity, Map<String, String>> all = agent.recordedDependencies();
+        assertTrue(all.get(testA).containsKey("com.example.SpringBean"));
+        assertTrue(all.get(testB).containsKey("com.example.SpringBean"),
+                "testB must be attributed via the injected runtime-use callback, since it never "
+                        + "triggered a transform() call of its own");
     }
 
     @Test
@@ -252,6 +297,19 @@ class DependencyTrackingAgentTest {
         assertFalse(Files.exists(outputFile));
         Path marker = Path.of(outputFile + DependencyRecordWriter.CRASH_MARKER_SUFFIX);
         assertTrue(Files.exists(marker), "expected a crash marker at " + marker);
+    }
+
+    private static byte[] ownClassBytes() throws Exception {
+        try (InputStream stream = DependencyTrackingAgentTest.class
+                .getResourceAsStream("DependencyTrackingAgentTest.class")) {
+            assertTrue(stream != null, "test class bytes must be available as a resource");
+            return stream.readAllBytes();
+        }
+    }
+
+    /** Compiled to {@code target/test-classes}: a real project code source for the tests below. */
+    private static ProtectionDomain ownProtectionDomain() {
+        return DependencyTrackingAgentTest.class.getProtectionDomain();
     }
 
     private static String sha256Hex(byte[] bytes) throws NoSuchAlgorithmException {

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/EndToEndVerdictIntegrationTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/EndToEndVerdictIntegrationTest.java
@@ -64,12 +64,16 @@ class EndToEndVerdictIntegrationTest {
 
     /**
      * A deterministic, honest way to trigger a real would-miss through the actual
-     * pipeline: a class loaded only inside {@code @BeforeAll} (a container-level
-     * callback, not a test) is never attributed to any test by
-     * {@code TestBoundaryListener} (its {@code executionStarted} only fires for actual
-     * tests) — so a dependency established solely during class-level setup is invisible
-     * to tracking. This is a real, narrow, documented limitation of container-level
-     * setup, not a contrived test artifact.
+     * pipeline: {@code Shared} is invoked <em>only</em> from {@code @BeforeAll} (a
+     * container-level callback, not a test) and its result cached into a static field —
+     * the {@code @Test} itself never calls {@code Shared} again, so the class never
+     * executes while {@code TestBoundaryListener} reports a current test. The agent's
+     * runtime-use callback (injected into every project class at its first load,
+     * regardless of whether a test is running) only attributes an execution when a test
+     * is actually current, so a dependency exercised solely during class-level setup
+     * stays invisible to tracking. This is a real, narrow, documented limitation of
+     * container-level setup, not a contrived test artifact — it would stop being
+     * "untracked" the moment the test body itself calls {@code Shared} again.
      */
     @Test
     void untrackedBeforeAllDependencyProducesAFailVerdict(@TempDir Path projectDir, @TempDir Path outDir)
@@ -99,13 +103,14 @@ class EndToEndVerdictIntegrationTest {
                 import org.junit.jupiter.api.Test;
                 import static org.junit.jupiter.api.Assertions.assertEquals;
                 class GapTest {
+                    static int cached;
                     @BeforeAll
                     static void warmUp() {
-                        Shared.value(); // loads Shared before any @Test's executionStarted fires
+                        cached = Shared.value(); // the only place Shared is ever invoked
                     }
                     @Test
                     void checksSharedValue() {
-                        assertEquals(1, Shared.value()); // already loaded; transform() won't refire
+                        assertEquals(1, cached); // reads the cached value; never calls Shared again
                     }
                 }
                 """);

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/MultiWouldMissIntegrationTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/MultiWouldMissIntegrationTest.java
@@ -40,8 +40,12 @@ class MultiWouldMissIntegrationTest {
         // safety-net-selected as "new/no baseline"). They are loaded with Class.forName
         // inside the test bodies: a direct bytecode reference can be eagerly resolved
         // while the test class is discovered, before the agent has a current test
-        // identity. Shared remains untracked because each class's @BeforeAll loads it
-        // before any test starts.
+        // identity. Shared remains untracked because each class's @BeforeAll is the
+        // only place that ever invokes it — its result is cached into a static field, so
+        // the @Test body itself never calls Shared again. The agent's runtime-use
+        // callback (injected at every project class's first load) only attributes an
+        // execution when a test is current, so a dependency exercised solely from
+        // @BeforeAll never re-fires it once a test starts.
         fixture.writeClass("com.example.MarkerA", "package com.example; public class MarkerA {}");
         fixture.writeClass("com.example.MarkerB", "package com.example; public class MarkerB {}");
         // Runs first (alphabetical runOrder, see FixtureProjectBuilder's pom), so the
@@ -62,12 +66,13 @@ class MultiWouldMissIntegrationTest {
                 import org.junit.jupiter.api.Test;
                 import static org.junit.jupiter.api.Assertions.assertEquals;
                 class GapATest {
+                    static int cached;
                     @BeforeAll
-                    static void warmUp() { Shared.value(); }
+                    static void warmUp() { cached = Shared.value(); }
                     @Test
                     void checksSharedA() throws ClassNotFoundException {
                         Class.forName("com.example.MarkerA");
-                        assertEquals(1, Shared.value());
+                        assertEquals(1, cached);
                     }
                 }
                 """);
@@ -77,12 +82,13 @@ class MultiWouldMissIntegrationTest {
                 import org.junit.jupiter.api.Test;
                 import static org.junit.jupiter.api.Assertions.assertEquals;
                 class GapBTest {
+                    static int cached;
                     @BeforeAll
-                    static void warmUp() { Shared.value(); }
+                    static void warmUp() { cached = Shared.value(); }
                     @Test
                     void checksSharedB() throws ClassNotFoundException {
                         Class.forName("com.example.MarkerB");
-                        assertEquals(1, Shared.value());
+                        assertEquals(1, cached);
                     }
                 }
                 """);

--- a/docs/fluencyloop/features/attribute-a-project-class-s-runtime-use-to-every-test-that-e/design.md
+++ b/docs/fluencyloop/features/attribute-a-project-class-s-runtime-use-to-every-test-that-e/design.md
@@ -1,0 +1,77 @@
+# Design: attribute a project class's runtime use to every test that exercises an already-loaded instance, not just the test whose window first loaded it
+
+started: 2026-07-28
+
+**Problem:** on real apache/shenyu, a change to `ConfigsServiceImpl.java` selected 0 of
+3627 tests. Root cause: it's a Spring-managed bean, instantiated once when the *first*
+test class needing that `ApplicationContext` runs — Spring then caches and reuses that
+context for every later test class with the same config. The agent's `transform()` only
+fires once per class-load, so only the first test that happened to trigger the load ever
+got attributed. Not Spring-specific: true of any singleton/cached/pooled project class.
+
+**Fix:** `AmbientClassInstrumenter` already injects a runtime-use callback into a class's
+bytecode — today wired up only for the one-time, pre-first-test "ambient snapshot". This
+generalizes it to run from `transform()`'s normal path, for every project class, the
+first time it loads, whether or not a test is currently running — so a later test that
+reuses an already-loaded instance still gets attributed via the injected callback.
+
+Full walkthrough (with the observed-bug context and the four decisions below) was shown
+as an Artifact during design review; this file is the durable copy of the two diagrams.
+
+## Class diagram
+
+```mermaid
+classDiagram
+    class DependencyTrackingAgent {
+      -Map~TestIdentity, Map~String,String~~ checksumsByTest
+      -Set~String~ ambientDependencies
+      -Map~String,String~ ambientChecksums
+      -AmbientClassInstrumenter ambientClassInstrumenter
+      +transform(loader, className, classBeingRedefined, protectionDomain, bytes) byte[]
+      +recordAmbientExecution(className) void
+      -isProjectClass(className, protectionDomain) boolean
+    }
+    class AmbientClassInstrumenter {
+      +instrument(className, bytecode) byte[]
+    }
+    class TestBoundaryListener {
+      +currentTest() TestIdentity
+    }
+    class AmbientDependencySelector {
+      +shouldFallback(changedClasses, ambient) boolean
+    }
+    DependencyTrackingAgent --> AmbientClassInstrumenter : NEW — every project class,\nnot just the pre-first-test snapshot
+    DependencyTrackingAgent --> TestBoundaryListener : "which test is running right now?"
+    AmbientDependencySelector --> DependencyTrackingAgent : reads ambientDependencies()\n(shrinks as more classes get instrumented)
+```
+
+## Sequence: two tests, one cached Spring context
+
+```mermaid
+sequenceDiagram
+    participant JVM
+    participant Agent as DependencyTrackingAgent
+    participant Inst as AmbientClassInstrumenter
+    participant Bean as ConfigsServiceImpl instance
+    participant TestA as ConfigsServiceImplTest
+    participant TestB as ConfigsExportImportControllerTest
+
+    TestA->>JVM: starts, builds Spring context (cold)
+    JVM->>Agent: transform("ConfigsServiceImpl", bytes)
+    Agent->>Agent: isProjectClass = true
+    Agent->>Inst: instrument(bytes)
+    Inst-->>Agent: instrumented bytes (+callback)
+    Agent->>Agent: ambientChecksums.put(class, sha256)
+    Agent->>Agent: checksumsByTest[TestA].put(class, sha256)
+    Agent-->>JVM: return instrumented bytes
+    JVM->>Bean: defines class from instrumented bytes
+    TestA->>Bean: exercises the bean directly
+
+    Note over TestA,TestB: Spring caches the context by config signature.<br/>TestB reuses the SAME bean instance — no reload,<br/>no second transform() call.
+
+    TestB->>Bean: calls a service method (via ConfigsService)
+    Bean->>Agent: recordAmbientExecution("ConfigsServiceImpl")
+    Agent->>Agent: currentTest = TestB, checksum found in ambientChecksums
+    Agent->>Agent: checksumsByTest[TestB].putIfAbsent(class, sha256)
+    Note right of Agent: Before this fix: no callback existed on Bean,<br/>so TestB's dependency map never<br/>recorded ConfigsServiceImpl at all.
+```

--- a/docs/fluencyloop/features/attribute-a-project-class-s-runtime-use-to-every-test-that-e/sessions/fix-stale-would-miss-fixtures-broken-by-the-broadened-instru.md
+++ b/docs/fluencyloop/features/attribute-a-project-class-s-runtime-use-to-every-test-that-e/sessions/fix-stale-would-miss-fixtures-broken-by-the-broadened-instru.md
@@ -1,0 +1,45 @@
+# Session: fix stale would-miss fixtures broken by the broadened instrumentation
+
+- **intent:** fix stale would-miss fixtures broken by the broadened instrumentation
+- **started:** 2026-07-28
+
+<!--
+FluencyLoop Stage 3 — a session is a slice of the build. One block per meaningful decision,
+appended at the slice boundary as it's taught. No `commits:` field: the feature is a branch,
+so the PR view derives commits live from git.
+
+Each decision is a `## Decision:` heading followed by a bullet list — one bullet per field, so
+it renders one-per-line as real Markdown (plain `key: value` lines collapse into a single
+paragraph when rendered). Fields:
+
+  where        — file/area the decision lives in (NOT a line number — survives refactoring)
+  why          — the rationale, taught live before it was written
+  alternative  — the rejected option and why (this is what makes it rationale, not description)
+  design       — (optional) ../design.md#anchor — the diagram this decision shaped or used
+  constitution — (optional) §N — the principle this decision serves or trades off against
+  trust        — ✓ verified | ⚠ not independently verified  (about the DECISION, never the person)
+
+Delete this comment and the example below once real decisions land.
+-->
+
+---
+
+## Decision: <chose X over Y>
+
+- **where:** `<path/to/File.ext>`
+- **why:** <the one-line why, engaged with — not post-hoc narration>
+- **alternative:** <the rejected option> — rejected: <why>
+- **trust:** ⚠ not independently verified
+
+## Knowledge transfer
+
+- **Why these two tests broke** — both fixtures relied on `Shared.value()` being called once during `@BeforeAll` (untracked, no current test) and then called *again* inside the `@Test` body, expecting that second call to be inert (already loaded, `transform()` never refires). That assumption held under the old narrow instrumentation but not the new one: `AmbientClassInstrumenter` injects its `recordAmbientExecution` callback at *every call* to an instrumented method, not just the load event, so the second call re-fires it — correctly, since the test genuinely does depend on `Shared`. Status: documented.
+- **What "untracked" now actually requires** — for a dependency to stay genuinely untracked under the new instrumentation, it must be invoked *only* while no test is current (i.e. only from `@BeforeAll`/`@BeforeEach` container callbacks), with the `@Test` body reading a cached result rather than re-invoking the dependency. This is a narrower, more honest characterization of the "documented limitation" than before. Status: documented.
+
+## Decision: fix the would-miss fixtures instead of the production code
+
+- **where:** `blastradius-validator/.../EndToEndVerdictIntegrationTest.java, MultiWouldMissIntegrationTest.java`
+- **why:** both fixtures called the shared class a second time from inside the @Test body — under the old narrow instrumentation that second call was inert, but the new inline transform() path instruments every project class at first load, so the injected runtime-use callback re-fires on that second call and correctly attributes the dependency to the test. The fix closes this exact gap too, not just the cached-Spring-bean case; the fixtures no longer construct a genuinely untracked dependency, so they were updated to cache the @BeforeAll result into a static field and never call the shared class again from the @Test body
+- **alternative:** treat it as a production bug and special-case @BeforeAll-triggered loads to skip instrumentation — rejected: there is no reliable signal in transform() that distinguishes a @BeforeAll-triggered load from any other no-test-running load, and the broader attribution is strictly more correct
+- **design:** ../design.md#sequence-diagram
+- **trust:** ✓ verified

--- a/docs/fluencyloop/features/attribute-a-project-class-s-runtime-use-to-every-test-that-e/sessions/generalize-runtime-use-instrumentation-to-every-project-clas.md
+++ b/docs/fluencyloop/features/attribute-a-project-class-s-runtime-use-to-every-test-that-e/sessions/generalize-runtime-use-instrumentation-to-every-project-clas.md
@@ -1,0 +1,47 @@
+# Session: generalize runtime-use instrumentation to every project class's first load
+
+- **intent:** generalize runtime-use instrumentation to every project class's first load
+- **started:** 2026-07-28
+
+---
+
+## Knowledge transfer
+
+- **`DependencyTrackingAgent#transform`** — a `ClassFileTransformer` callback the JVM fires exactly once per class-load event. Before this slice it recorded a class only when a JUnit test window was open (`currentTestSupplier.get() != null`); it now *also* runs `AmbientClassInstrumenter` over every project class regardless, so a class's later reuse (not reload) by a different test can still be attributed. Status: documented.
+- **Why the bug was invisible before** — Spring's `TestContext` framework caches an `ApplicationContext` by its config signature and reuses it across test classes; a bean like `ConfigsServiceImpl` is only ever instantiated (and class-loaded) once, by whichever test class first needs that context. Every later test reusing the cached context exercises the same instance with no new class-load event, so the old one-shot attribution model silently missed it. Not Spring-specific — applies to any cached/pooled/singleton project resource. Status: documented.
+- **`AmbientClassInstrumenter#instrument`** — unchanged in this slice. Injects a static `DependencyTrackingAgent.recordAmbientExecution(name)` call at method entry plus at every field/type/class-literal reference inside the method body, so a class's runtime execution records not just itself but every project class it directly references. Returns `null` (no-op) for an all-abstract/native class. Status: documented.
+- **`retransformProjectAmbientClasses`** — the pre-existing pre-first-test snapshot pass. Now guarded to skip (and un-ambient) any class already present in `ambientChecksums`, since the new inline path in `transform()` catches almost everything it used to. It remains as the fallback for classes the instrumenter can't rewrite, and for third-party classes (never instrumented, out of scope for this slice). Status: documented.
+- **`CONFIGURED_PROJECT_ROOT`** — the `blastradius.projectRoot` system property is set once, by `TrackRunner`, on the forked JVM's command line before the agent attaches; nothing in the codebase mutates it afterward (verified by grep across the repo). Safe to resolve once as a `static final` field rather than re-resolving (with a real `toRealPath()` filesystem call) on every class load. Status: documented.
+
+## Decision: instrument every project class inline at transform(), not just the pre-first-test snapshot
+
+- **where:** `blastradius-core/.../tracking/DependencyTrackingAgent.java#transform`
+- **why:** the JVM calls transform() exactly once per class-load; a cached/singleton instance (e.g. a Spring bean) only ever gets that one call, so only whichever test triggered it was ever attributed — this closes that gap for every project class, not just the narrow pre-first-test set
+- **alternative:** leave instrumentation scoped to the pre-first-test ambient snapshot only — rejected: that's exactly the mechanism that produced the observed 0-of-3627 selection on real shenyu
+- **design:** ../design.md#class-diagram
+- **constitution:** §III
+- **trust:** ✓ verified
+
+## Decision: additive-only: keep the old ambient-snapshot/retransform path as a fallback
+
+- **where:** `blastradius-core/.../tracking/DependencyTrackingAgent.java#retransformProjectAmbientClasses`
+- **why:** a full unification (retiring the old snapshot+retransform mechanism entirely) is cleaner in the abstract now that it's mostly redundant, but rewriting it risks the many passing tests built around it for a use case that hasn't happened yet
+- **alternative:** delete snapshotAmbientDependencies/retransformProjectAmbientClasses and rely solely on the new inline path — rejected: no second concrete need has forced that yet, and it's a much larger, riskier diff
+- **design:** ../design.md#class-diagram
+- **constitution:** §II
+- **trust:** ✓ verified
+
+## Decision: guard retransformProjectAmbientClasses against double-instrumenting classes already caught inline
+
+- **where:** `blastradius-core/.../tracking/DependencyTrackingAgent.java#retransformProjectAmbientClasses`
+- **why:** once transform() instruments a project class at its first load, the old pre-first-test snapshot pass would otherwise retransform the same class again, injecting the runtime-use callback twice
+- **alternative:** leave the snapshot pass unguarded — rejected: harmless functionally but wastefully double-injects callbacks into every project class discovery-loaded before the first test
+- **trust:** ✓ verified
+
+## Decision: cache the resolved project root as a static final field instead of resolving it per class-load
+
+- **where:** `blastradius-core/.../tracking/DependencyTrackingAgent.java#CONFIGURED_PROJECT_ROOT`
+- **why:** resolving it touches the filesystem (toRealPath()); that ran once before (pre-first-test snapshot only), but the generalized transform() now runs this check on every class load in the JVM, so a per-call syscall is a real cost. The property is a JVM-startup-fixed -D flag (set once by TrackRunner; grepped the whole repo, nothing mutates it dynamically), so eager caching is safe
+- **alternative:** keep resolving System.getProperty + toRealPath() fresh on every transform() call — rejected: real, avoidable per-class-load filesystem cost across the whole JVM
+- **constitution:** §VIII
+- **trust:** ✓ verified


### PR DESCRIPTION
## Summary

Attributes a project class's *reuse* to every test that exercises it, not just the test whose window first loaded it.

The dependency-tracking agent's `transform()` fires exactly once per class-load event, so a cached/singleton project class (e.g. a Spring bean reused across test classes via a shared `ApplicationContext`) was only ever attributed to whichever test triggered its original load. Every later test genuinely exercising it saw no dependency edge at all. Observed on real apache/shenyu: a change to `ConfigsServiceImpl.java` selected 0 of 3627 tests.

Design doc (diagrams + full decision rationale): [`design.md`](../blob/feature/attribute-a-project-class-s-runtime-use-to-every-test-that-e/docs/fluencyloop/features/attribute-a-project-class-s-runtime-use-to-every-test-that-e/design.md)

## Decisions

**Instrument every project class inline at `transform()`, not just the pre-first-test snapshot** (`DependencyTrackingAgent#transform`, constitution §III)
The JVM calls `transform()` exactly once per class-load; a cached/singleton instance only ever gets that one call, so only whichever test triggered it was ever attributed. Generalizing the existing `AmbientClassInstrumenter` callback injection to every project class's first load — test running or not — closes that gap.

**Additive-only: keep the old ambient-snapshot/retransform path as a fallback** (`retransformProjectAmbientClasses`, constitution §II)
A full unification (retiring the old snapshot+retransform mechanism, now mostly redundant) is cleaner in the abstract, but rewriting it risks the tests built around it for a use case that hasn't happened yet. Shipped the narrow fix; left the old mechanism as the fallback for classes the instrumenter can't rewrite and for third-party classes (out of scope here).

**Guard against double-instrumenting classes already caught inline** (`retransformProjectAmbientClasses`)
Once `transform()` instruments a class at its first load, the old pre-first-test snapshot pass would otherwise retransform it again, double-injecting the runtime-use callback. Now skips (and un-ambients) anything already in `ambientChecksums`.

**Cache the resolved project root** (`CONFIGURED_PROJECT_ROOT`, constitution §VIII — new)
Resolving `blastradius.projectRoot` touches the filesystem (`toRealPath()`); that ran once before, but the generalized `transform()` now runs this check on every class load in the JVM. The property is a JVM-startup-fixed `-D` flag (set once by `TrackRunner`; nothing mutates it dynamically), so it's now resolved once as a `static final` field.

**Fix stale would-miss fixtures broken by the broadened instrumentation** (`EndToEndVerdictIntegrationTest`, `MultiWouldMissIntegrationTest`)
Two integration tests both called their shared class a second time from inside the `@Test` body, expecting that call to be inert once already loaded. The broadened instrumentation now re-fires the runtime-use callback on every invocation, not just the first load, so that second call correctly attributed the dependency — closing the exact gap these fixtures relied on staying open. Updated both to cache the `@BeforeAll` result into a static field instead, so the dependency is genuinely never touched while a test is current.

## Constitution

Amended `.specify/memory/constitution.md`: added **§VIII — No Avoidable Work on the Hot Path** (v2.2.0 → v2.3.0), harvested from the project-root caching decision above. All four original decisions checked against existing principles (§II, §III) or the newly-added one (§VIII) — no conflicts.

## Test plan

- [x] `blastradius-core` full suite green, including two new regression tests: a project class is instrumented at load with no test running, and a second test that reuses an already-loaded instance (no reload) gets attributed purely via the injected callback.
- [x] `blastradius-validator` full suite green — including `EndToEndVerdictIntegrationTest` and `MultiWouldMissIntegrationTest`, which initially regressed (both expecting a would-miss FAIL got PASS) until their fixtures were updated; see the decision above.
- [ ] Not re-verified against real apache/shenyu in this PR — the original failing report was produced by a manual run; a follow-up manual re-run against shenyu would confirm `ConfigsServiceImpl.java` now selects `ConfigsExportImportControllerTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

