### PR TITLE
feat: cache commit build results across the sliding window to cut redundant validator builds

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "attribute-a-project-class-s-runtime-use-to-every-test-that-e",
-  "branch": "feature/attribute-a-project-class-s-runtime-use-to-every-test-that-e",
+  "feature": "cache-commit-build-results-across-the-sliding-window-to-elim",
+  "branch": "feature/cache-commit-build-results-across-the-sliding-window-to-elim",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/attribute-a-project-class-s-runtime-use-to-every-test-that-e/sessions/fix-stale-would-miss-fixtures-broken-by-the-broadened-instru.md",
-  "base_ref": "feat/maven-parallel-build-threads",
+  "last_session": "docs/fluencyloop/features/cache-commit-build-results-across-the-sliding-window-to-elim/sessions/add-fast-ground-truth-integration-tests-and-verify-the-full.md",
+  "base_ref": "main",
   "updated": "2026-07-28"
 }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/GroundTruthResolution.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/GroundTruthResolution.java
@@ -1,0 +1,11 @@
+package io.github.baokhang83.blastradius.validator.build;
+
+import java.util.List;
+
+/**
+ * {@link GroundTruthResolver#resolve}'s full outcome: the {@link BuildResult} of the build
+ * it ran to derive ground truth, alongside the per-test results parsed from it. Exposing
+ * {@code initialBuild} lets a caller detect a build failure without running its own separate,
+ * otherwise-identical probe build first.
+ */
+public record GroundTruthResolution(BuildResult initialBuild, List<GroundTruthResult> results) {}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/GroundTruthResolver.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/GroundTruthResolver.java
@@ -40,8 +40,8 @@ public final class GroundTruthResolver {
         this.reportParser = reportParser;
     }
 
-    public List<GroundTruthResult> resolve(Path projectDir, Path agentJar, Path dependencyRecordOutputFile) {
-        buildRunner.run(projectDir, agentJar, dependencyRecordOutputFile);
+    public GroundTruthResolution resolve(Path projectDir, Path agentJar, Path dependencyRecordOutputFile) {
+        BuildResult initialBuild = buildRunner.run(projectDir, agentJar, dependencyRecordOutputFile);
         Map<TestIdentity, Boolean> initialResults = parseAllReports(projectDir);
 
         List<GroundTruthResult> results = new ArrayList<>();
@@ -54,7 +54,7 @@ public final class GroundTruthResolver {
             }
             results.add(new GroundTruthResult(test, confirmFailure(projectDir, test)));
         }
-        return results;
+        return new GroundTruthResolution(initialBuild, results);
     }
 
     private Outcome confirmFailure(Path projectDir, TestIdentity test) {

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/Main.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/Main.java
@@ -10,14 +10,14 @@ import java.nio.file.Path;
 /**
  * CLI entry point. Usage:
  * {@code blastradius-validator run --project-path <path> --commits <N> --report-out <path>
- * [--summary-out <path>] [--maven-threads <N>]}
+ * [--summary-out <path>] [--maven-threads <N>] [--fast-ground-truth]}
  */
 public final class Main {
 
     public static void main(String[] args) {
         if (args.length == 0 || !"run".equals(args[0])) {
             System.err.println("usage: run --project-path <path> --commits <N> --report-out <path> "
-                    + "[--summary-out <path>] [--maven-threads <N>]");
+                    + "[--summary-out <path>] [--maven-threads <N>] [--fast-ground-truth]");
             System.exit(2);
             return;
         }
@@ -27,6 +27,7 @@ public final class Main {
         Path reportOut = null;
         Path summaryOut = null;
         Integer mavenThreads = null;
+        boolean fastGroundTruth = false;
 
         for (int i = 1; i < args.length; i++) {
             switch (args[i]) {
@@ -35,6 +36,7 @@ public final class Main {
                 case "--report-out" -> reportOut = Path.of(args[++i]);
                 case "--summary-out" -> summaryOut = Path.of(args[++i]);
                 case "--maven-threads" -> mavenThreads = Integer.parseInt(args[++i]);
+                case "--fast-ground-truth" -> fastGroundTruth = true;
                 default -> {
                     System.err.println("unknown argument: " + args[i]);
                     System.exit(2);
@@ -50,7 +52,7 @@ public final class Main {
         }
 
         try {
-            RunConfig config = new RunConfig(projectPath, commits, reportOut, mavenThreads);
+            RunConfig config = new RunConfig(projectPath, commits, reportOut, mavenThreads, fastGroundTruth);
             int exitCode = new RunCommand().run(config);
             printSummary(reportOut, summaryOut, exitCode);
             System.exit(exitCode);

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
@@ -2,6 +2,7 @@ package io.github.baokhang83.blastradius.validator.cli;
 
 import io.github.baokhang83.blastradius.validator.build.BuildFailureDetector;
 import io.github.baokhang83.blastradius.validator.build.BuildResult;
+import io.github.baokhang83.blastradius.validator.build.GroundTruthResolution;
 import io.github.baokhang83.blastradius.validator.build.GroundTruthResolver;
 import io.github.baokhang83.blastradius.validator.build.GroundTruthResult;
 import io.github.baokhang83.blastradius.validator.build.JdkMismatchDetector;
@@ -28,10 +29,13 @@ import io.github.baokhang83.blastradius.validator.verdict.Verdict;
 import io.github.baokhang83.blastradius.validator.verdict.VerdictCalculator;
 import io.github.baokhang83.blastradius.validator.verdict.WouldMissCase;
 import io.github.baokhang83.blastradius.validator.verdict.WouldMissComparator;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -93,13 +97,18 @@ public final class RunCommand {
             List<WouldMissCase> allMisses = new ArrayList<>();
             List<SelectionDecision> allDecisions = new ArrayList<>();
             List<FlakyFailure> allFlaky = new ArrayList<>();
+            // Only ever populated when config.fastGroundTruth() is true (§III — see
+            // RunConfig#fastGroundTruth): the safe, default path never unifies build types
+            // across pairs, so there is nothing to cache.
+            Map<String, CommitBuild> commitCache = new HashMap<>();
 
             Path scratchParent = Files.createTempDirectory("blastradius-scratch-");
             try (CommitCheckout checkout = CommitCheckout.forTargetProject(config.projectPath(), scratchParent)) {
                 for (CommitPair pair : window) {
                     PairAnalysis analysis;
                     try {
-                        analysis = analyzePair(pair, config.projectPath(), checkout, agentJar);
+                        analysis = analyzePair(
+                                pair, config.projectPath(), checkout, agentJar, config.fastGroundTruth(), commitCache);
                     } catch (Exception e) {
                         analysis = excluded(pair, "analysis failed: " + e.getMessage());
                     }
@@ -133,17 +142,55 @@ public final class RunCommand {
             List<SelectionDecision> decisions,
             List<FlakyFailure> flakyFailures) {}
 
-    private PairAnalysis analyzePair(CommitPair pair, Path targetRepo, CommitCheckout checkout, Path agentJar)
-            throws Exception {
-        // Baseline: build the BASE commit with the agent attached, to learn what each
-        // test depended on as of that commit.
-        Path baseWorkDir = checkout.checkoutCommit(pair.baseCommit());
-        Path baseDepsFile = Files.createTempFile("blastradius-base-deps-", ".json");
-        BuildResult baseResult = buildRunner.run(baseWorkDir, agentJar, baseDepsFile);
-        if (buildFailureDetector.isBuildFailure(baseResult, baseWorkDir)) {
-            return excluded(pair, "base commit " + pair.baseCommit() + " failed to build");
+    /**
+     * One commit's canonical build outcome under {@code --fast-ground-truth} (RunConfig
+     * #fastGroundTruth): a single agent-attached build serving both the "dependency
+     * baseline" role and the "ground truth" role, cached across every pair in the window
+     * that references this commit. Never populated in the safe, default mode.
+     */
+    private record CommitBuild(
+            boolean failed, String failureReason, DependencyRecordSet dependencyRecordSet,
+            List<GroundTruthResult> groundTruth) {}
+
+    private PairAnalysis analyzePair(
+            CommitPair pair, Path targetRepo, CommitCheckout checkout, Path agentJar,
+            boolean fastGroundTruth, Map<String, CommitBuild> commitCache) throws Exception {
+        DependencyRecordSet baseRecordSet;
+        List<GroundTruthResult> groundTruth;
+
+        if (fastGroundTruth) {
+            CommitBuild base = buildCommit(pair.baseCommit(), checkout, agentJar, commitCache);
+            if (base.failed()) {
+                return excluded(pair, base.failureReason());
+            }
+            CommitBuild head = buildCommit(pair.headCommit(), checkout, agentJar, commitCache);
+            if (head.failed()) {
+                return excluded(pair, head.failureReason());
+            }
+            baseRecordSet = base.dependencyRecordSet();
+            groundTruth = head.groundTruth();
+        } else {
+            // Baseline: build the BASE commit with the agent attached, to learn what each
+            // test depended on as of that commit.
+            Path baseWorkDir = checkout.checkoutCommit(pair.baseCommit());
+            Path baseDepsFile = Files.createTempFile("blastradius-base-deps-", ".json");
+            BuildResult baseResult = buildRunner.run(baseWorkDir, agentJar, baseDepsFile);
+            if (buildFailureDetector.isBuildFailure(baseResult, baseWorkDir)) {
+                return excluded(pair, "base commit " + pair.baseCommit() + " failed to build");
+            }
+            baseRecordSet = new DependencyRecordReader().readAll(baseDepsFile);
+
+            // Ground truth: GroundTruthResolver's own build result tells us whether the
+            // HEAD commit built at all, so a compile failure is caught here rather than
+            // silently looking like "zero tests" — without a second, separate probe build.
+            Path headWorkDir = checkout.checkoutCommit(pair.headCommit());
+            GroundTruthResolution resolution = groundTruthResolver.resolve(headWorkDir, null, null);
+            if (buildFailureDetector.isBuildFailure(resolution.initialBuild(), headWorkDir)) {
+                return excluded(pair, "head commit " + pair.headCommit() + " failed to build");
+            }
+            groundTruth = resolution.results();
         }
-        DependencyRecordSet baseRecordSet = new DependencyRecordReader().readAll(baseDepsFile);
+
         Map<TestIdentity, Map<String, String>> baseRecord = baseRecordSet.tests();
         // Keyed by baselineKey(), not the raw tracked identity, so a ground-truth lookup
         // (which may carry a parameterized-test's Surefire-style invocation suffix) can
@@ -158,16 +205,6 @@ public final class RunCommand {
                             union.addAll(b);
                             return union;
                         }));
-
-        // Ground truth: check the HEAD commit builds before delegating to
-        // GroundTruthResolver's own (separate) full run, since a compile failure there
-        // would otherwise silently look like "zero tests" rather than EXCLUDED.
-        Path headWorkDir = checkout.checkoutCommit(pair.headCommit());
-        BuildResult headProbe = buildRunner.run(headWorkDir, null, null);
-        if (buildFailureDetector.isBuildFailure(headProbe, headWorkDir)) {
-            return excluded(pair, "head commit " + pair.headCommit() + " failed to build");
-        }
-        List<GroundTruthResult> groundTruth = groundTruthResolver.resolve(headWorkDir, null, null);
 
         // Changed files, classified, against the real target repo's git history.
         List<ChangedFile> changedFiles =
@@ -193,6 +230,33 @@ public final class RunCommand {
                 .toList();
 
         return new PairAnalysis(enrichedPair, misses, decisions, flakyFailures);
+    }
+
+    /**
+     * {@code --fast-ground-truth} only: one canonical, agent-attached build per commit,
+     * memoized in {@code commitCache} for the lifetime of this {@code run()} call. A cache
+     * hit means the commit was already checked out and built by an earlier pair — it is
+     * <em>not</em> re-checked-out (see {@link CommitCheckout}, which wipes {@code target/}
+     * on every checkout), so a hit returns the results extracted the first time, never a
+     * stale working directory.
+     */
+    private CommitBuild buildCommit(
+            String commitSha, CommitCheckout checkout, Path agentJar, Map<String, CommitBuild> commitCache) {
+        return commitCache.computeIfAbsent(commitSha, sha -> {
+            Path workDir = checkout.checkoutCommit(sha);
+            Path depsFile;
+            try {
+                depsFile = Files.createTempFile("blastradius-commit-deps-", ".json");
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            GroundTruthResolution resolution = groundTruthResolver.resolve(workDir, agentJar, depsFile);
+            if (buildFailureDetector.isBuildFailure(resolution.initialBuild(), workDir)) {
+                return new CommitBuild(true, "commit " + sha + " failed to build", null, List.of());
+            }
+            DependencyRecordSet recordSet = new DependencyRecordReader().readAll(depsFile);
+            return new CommitBuild(false, null, recordSet, resolution.results());
+        });
     }
 
     private static PairAnalysis excluded(CommitPair pair, String reason) {

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunConfig.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunConfig.java
@@ -13,12 +13,24 @@ import java.util.Objects;
  * @param reportOutputPath     file path to write the JSON {@code AnalysisReport} to
  * @param mavenParallelThreads value for the target project's own {@code mvn -T} reactor
  *                             parallelism, or {@code null} to build serially (the default)
+ * @param fastGroundTruth      opt-in, default {@code false}. When {@code true}, every commit
+ *                             in the window gets one canonical, agent-attached build cached
+ *                             and reused across every pair that references it — trading the
+ *                             ground-truth build's independence from the tracking agent for
+ *                             fewer builds. Never implied by anything else; must be requested
+ *                             explicitly (constitution §III — see design.md for the full
+ *                             reasoning).
  */
 public record RunConfig(
-        Path projectPath, int commitWindowSize, Path reportOutputPath, Integer mavenParallelThreads) {
+        Path projectPath, int commitWindowSize, Path reportOutputPath, Integer mavenParallelThreads,
+        boolean fastGroundTruth) {
 
     public RunConfig(Path projectPath, int commitWindowSize, Path reportOutputPath) {
-        this(projectPath, commitWindowSize, reportOutputPath, null);
+        this(projectPath, commitWindowSize, reportOutputPath, null, false);
+    }
+
+    public RunConfig(Path projectPath, int commitWindowSize, Path reportOutputPath, Integer mavenParallelThreads) {
+        this(projectPath, commitWindowSize, reportOutputPath, mavenParallelThreads, false);
     }
 
     public RunConfig {

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/FastGroundTruthIntegrationTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/FastGroundTruthIntegrationTest.java
@@ -1,0 +1,138 @@
+package io.github.baokhang83.blastradius.validator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.baokhang83.blastradius.validator.cli.RunCommand;
+import io.github.baokhang83.blastradius.validator.cli.RunConfig;
+import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * {@code --fast-ground-truth} (RunConfig#fastGroundTruth) unifies build types and caches
+ * per-commit results across the sliding window instead of building each commit's role
+ * independently — these tests exercise that path end to end, through the same pipeline
+ * {@link EndToEndVerdictIntegrationTest} exercises in the default, safe mode.
+ */
+class FastGroundTruthIntegrationTest {
+
+    /**
+     * A 3-commit, 2-pair window means the middle commit (c1) is BOTH pair 0's HEAD and
+     * pair 1's BASE — exactly the cache-hit case the feature exists for. Correctness here
+     * proves a cache hit doesn't feed a pair a stale or partial result.
+     */
+    @Test
+    void middleCommitReusedAcrossPairsStillProducesACorrectPassVerdict(
+            @TempDir Path projectDir, @TempDir Path outDir) throws Exception {
+        Path agentJar = findOwnAgentJar();
+        Path reportFile = outDir.resolve("report.json");
+
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.addSystemDependency(null, agentJar);
+        fixture.writeClass("com.example.Foo",
+                "package com.example; public class Foo { public int value() { return 1; } }");
+        fixture.writeTest("com.example.FooTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class FooTest {
+                    @Test
+                    void checksValue() {
+                        assertEquals(1, new Foo().value());
+                    }
+                }
+                """);
+        fixture.commit("initial");
+
+        fixture.writeClass("com.example.UnrelatedA",
+                "package com.example; public class UnrelatedA { public int value() { return 1; } }");
+        fixture.commit("add unrelated class A");
+
+        fixture.writeClass("com.example.UnrelatedB",
+                "package com.example; public class UnrelatedB { public int value() { return 2; } }");
+        fixture.commit("add unrelated class B");
+
+        RunConfig config = new RunConfig(projectDir, 2, reportFile, null, true);
+        int exitCode = new RunCommand().run(config, agentJar);
+
+        assertEquals(0, exitCode, "expected PASS verdict (exit code 0)");
+        JsonNode report = new ObjectMapper().readTree(reportFile.toFile());
+        assertEquals("PASS", report.get("verdict").asText());
+        assertTrue(report.get("wouldMissCases").isEmpty());
+        assertEquals(2, report.get("analyzedCommitPairs").size());
+    }
+
+    /**
+     * Same would-miss fixture {@link EndToEndVerdictIntegrationTest} uses, run through
+     * {@code --fast-ground-truth} instead: the ground-truth build is now agent-attached,
+     * so this confirms attaching the agent to that build doesn't change pass/fail
+     * detection for a test whose dependency was never tracked in the first place.
+     */
+    @Test
+    void untrackedBeforeAllDependencyStillProducesAFailVerdict(
+            @TempDir Path projectDir, @TempDir Path outDir) throws Exception {
+        Path agentJar = findOwnAgentJar();
+        Path reportFile = outDir.resolve("report.json");
+
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.addSystemDependency(null, agentJar);
+        fixture.writeClass("com.example.Shared",
+                "package com.example; public class Shared { public static int value() { return 1; } }");
+        fixture.writeTest("com.example.AaaWarmupTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                class AaaWarmupTest {
+                    @Test
+                    void warmsUpTheFork() {}
+                }
+                """);
+        fixture.writeTest("com.example.GapTest", """
+                package com.example;
+                import org.junit.jupiter.api.BeforeAll;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class GapTest {
+                    static int cached;
+                    @BeforeAll
+                    static void warmUp() {
+                        cached = Shared.value();
+                    }
+                    @Test
+                    void checksSharedValue() {
+                        assertEquals(1, cached);
+                    }
+                }
+                """);
+        fixture.commit("initial");
+
+        fixture.writeClass("com.example.Shared",
+                "package com.example; public class Shared { public static int value() { return 2; } }");
+        fixture.commit("break Shared");
+
+        RunConfig config = new RunConfig(projectDir, 1, reportFile, null, true);
+        int exitCode = new RunCommand().run(config, agentJar);
+
+        assertEquals(1, exitCode, "expected FAIL verdict (exit code 1)");
+        JsonNode report = new ObjectMapper().readTree(reportFile.toFile());
+        assertEquals("FAIL", report.get("verdict").asText());
+        assertEquals(1, report.get("wouldMissCases").size());
+        assertEquals("com.example.GapTest", report.get("wouldMissCases").get(0).get("test").get("className").asText());
+    }
+
+    private static Path findOwnAgentJar() throws IOException {
+        Path targetDir = Path.of("target");
+        try (var stream = Files.list(targetDir)) {
+            return stream
+                    .filter(p -> p.getFileName().toString().matches("blastradius-validator-.*\\.jar"))
+                    .filter(p -> !p.getFileName().toString().contains("sources"))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("agent jar not found in target/"));
+        }
+    }
+}

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/GroundTruthResolverTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/GroundTruthResolverTest.java
@@ -29,7 +29,7 @@ class GroundTruthResolverTest {
                 """);
         fixture.commit("initial");
 
-        List<GroundTruthResult> results = resolver.resolve(projectDir, null, null);
+        List<GroundTruthResult> results = resolver.resolve(projectDir, null, null).results();
 
         assertEquals(Outcome.PASSED, outcomeOf(results, "com.example.GoodTest", "alwaysPasses"));
     }
@@ -50,7 +50,7 @@ class GroundTruthResolverTest {
                 """);
         fixture.commit("initial");
 
-        List<GroundTruthResult> results = resolver.resolve(projectDir, null, null);
+        List<GroundTruthResult> results = resolver.resolve(projectDir, null, null).results();
 
         assertEquals(Outcome.CONFIRMED_FAILED, outcomeOf(results, "com.example.AlwaysFailsTest", "alwaysFails"));
     }
@@ -81,7 +81,7 @@ class GroundTruthResolverTest {
                 """.formatted(counterFile));
         fixture.commit("initial");
 
-        List<GroundTruthResult> results = resolver.resolve(projectDir, null, null);
+        List<GroundTruthResult> results = resolver.resolve(projectDir, null, null).results();
 
         assertEquals(Outcome.FLAKY, outcomeOf(results, "com.example.FlakyTest", "failsFirstThenPasses"));
     }
@@ -115,7 +115,7 @@ class GroundTruthResolverTest {
                 """);
         fixture.commit("initial");
 
-        List<GroundTruthResult> results = resolver.resolve(projectDir, null, null);
+        List<GroundTruthResult> results = resolver.resolve(projectDir, null, null).results();
 
         assertEquals(Outcome.PASSED, outcomeOf(results, "com.example.a.FooTest", "checksValue"));
         assertEquals(Outcome.PASSED, outcomeOf(results, "com.example.b.BarTest", "checksSomething"));

--- a/docs/fluencyloop/features/cache-commit-build-results-across-the-sliding-window-to-elim/design.md
+++ b/docs/fluencyloop/features/cache-commit-build-results-across-the-sliding-window-to-elim/design.md
@@ -1,0 +1,121 @@
+# Design: cache commit build results across the sliding window to eliminate redundant validator builds
+
+started: 2026-07-28
+
+Today each analyzed commit pair triggers up to 3 full `mvn clean test` invocations: an
+agent-attached base build, a discardable agent-free head "probe" build, and
+`GroundTruthResolver`'s own internal agent-free build — the last two are the same build type,
+run back-to-back, purely because `GroundTruthResolver` never exposed its `BuildResult` to the
+caller.
+
+This feature ships two tiers:
+
+- **Safe (default, no flag):** removes the redundant probe build unconditionally. `2N` builds
+  instead of `3N`. Zero behavior change — `GroundTruthResolver` was always going to run that
+  build; it just wasn't telling `RunCommand` what happened.
+- **`--fast-ground-truth` (opt-in):** goes further by unifying build types — every commit gets
+  one canonical, agent-attached build, cached in-memory for the run and reused across every
+  pair that references it. `N+1` builds. This trades the ground-truth build's independence from
+  the tracking agent for speed, so it is never the default — see the decision below.
+
+## Class diagram
+
+```mermaid
+classDiagram
+    class RunConfig {
+      +boolean fastGroundTruth
+    }
+    class RunCommand {
+      -Map~String, CommitBuild~ commitCache
+      +run(RunConfig) int
+      -analyzePair(CommitPair) PairAnalysis
+      -buildCommit(String sha) CommitBuild
+    }
+    class CommitBuild {
+      +boolean failed
+      +String failureReason
+      +DependencyRecordSet dependencyRecordSet
+      +List~GroundTruthResult~ groundTruth
+    }
+    class GroundTruthResolver {
+      +resolve(Path, Path agentJar, Path depsFile) GroundTruthResolution
+    }
+    class GroundTruthResolution {
+      +BuildResult initialBuild
+      +List~GroundTruthResult~ results
+    }
+    class CommitCheckout {
+      +checkoutCommit(String sha) Path
+    }
+    RunConfig --> RunCommand : fastGroundTruth toggles the path below
+    RunCommand --> CommitBuild : fast mode only, caches keyed by commit SHA
+    RunCommand --> CommitCheckout : checkout on cache miss (fast) or every role (safe)
+    RunCommand --> GroundTruthResolver : agentJar non-null only in fast mode
+    GroundTruthResolver --> GroundTruthResolution : always exposes its BuildResult now
+    CommitBuild --> GroundTruthResolution : built from, fast mode only
+```
+
+## Sequence: safe mode (default) — probe eliminated, roles stay separate
+
+```mermaid
+sequenceDiagram
+    participant RC as RunCommand
+    participant CO as CommitCheckout
+    participant GTR as GroundTruthResolver
+
+    Note over RC: Pair i = (base, head)
+    RC->>CO: checkoutCommit(base)
+    RC->>RC: full agent-attached build (dependency baseline)
+    RC->>CO: checkoutCommit(head)
+    RC->>GTR: resolve(head, agentJar=null, depsFile)
+    GTR-->>RC: GroundTruthResolution(build, results)
+    Note over RC: build.succeeded() replaces the old separate probe build
+```
+
+## Sequence: --fast-ground-truth — a commit shared by two pairs
+
+```mermaid
+sequenceDiagram
+    participant RC as RunCommand
+    participant Cache as commitCache
+    participant CO as CommitCheckout
+    participant GTR as GroundTruthResolver
+
+    Note over RC: Pair 0 = (c0, c1)
+    RC->>Cache: get(c1)
+    Cache-->>RC: miss
+    RC->>CO: checkoutCommit(c1)
+    RC->>GTR: resolve(c1, agentJar, depsFile)
+    GTR-->>RC: GroundTruthResolution(build, results)
+    RC->>Cache: put(c1, CommitBuild)
+    Note over RC: c1 used as Pair 0's HEAD (ground truth)
+
+    Note over RC: Pair 1 = (c1, c2)
+    RC->>Cache: get(c1)
+    Cache-->>RC: hit
+    Note over RC: no checkout, no build — reused as Pair 1's BASE (dependency baseline)
+```
+
+## Constitution tension and how the design resolves it
+
+Constitution §III (Safety Over Speed) forbids a design decision that *silently* weakens
+soundness in favor of speed. Unifying build types unconditionally would do exactly that: the
+validator's ground-truth oracle would stop being independent of the agent it's validating, for
+every run, without anyone asking for it.
+
+Gating the unification behind `--fast-ground-truth` (default off) resolves the tension rather
+than relocating it: the safe path is exactly as sound as it is today for any run that doesn't
+pass the flag, and passing it is a visible, explicit, per-run choice — not an inherited weaker
+default. This is read as compliance with §III's actual concern (silence), not an exception to
+it.
+
+Rejected alternative: unify unconditionally, no flag. Same `N+1` build count on every run, but
+applies the trade to runs that never asked for it.
+
+## Known accepted inefficiency (fast mode only)
+
+Under `--fast-ground-truth`, the window's very first commit (base-only, never anyone's head)
+still goes through the full ground-truth path, including flaky-confirmation reruns for any of
+its failing tests — work nobody consults. Bounded by that one commit's failing-test count;
+keeping `buildCommit` uniform (no lookahead into "will this SHA ever be a head") is the simpler
+shape. Safe mode is unaffected.

--- a/docs/fluencyloop/features/cache-commit-build-results-across-the-sliding-window-to-elim/sessions/add-fast-ground-truth-integration-tests-and-verify-the-full.md
+++ b/docs/fluencyloop/features/cache-commit-build-results-across-the-sliding-window-to-elim/sessions/add-fast-ground-truth-integration-tests-and-verify-the-full.md
@@ -1,0 +1,39 @@
+# Session: add fast-ground-truth integration tests and verify the full suite
+
+- **intent:** add fast-ground-truth integration tests and verify the full suite
+- **started:** 2026-07-28
+
+<!--
+FluencyLoop Stage 3 — a session is a slice of the build. One block per meaningful decision,
+appended at the slice boundary as it's taught. No `commits:` field: the feature is a branch,
+so the PR view derives commits live from git.
+
+Each decision is a `## Decision:` heading followed by a bullet list — one bullet per field, so
+it renders one-per-line as real Markdown (plain `key: value` lines collapse into a single
+paragraph when rendered). Fields:
+
+  where        — file/area the decision lives in (NOT a line number — survives refactoring)
+  why          — the rationale, taught live before it was written
+  alternative  — the rejected option and why (this is what makes it rationale, not description)
+  design       — (optional) ../design.md#anchor — the diagram this decision shaped or used
+  constitution — (optional) §N — the principle this decision serves or trades off against
+  trust        — ✓ verified | ⚠ not independently verified  (about the DECISION, never the person)
+
+Delete this comment and the example below once real decisions land.
+-->
+
+---
+
+## Knowledge transfer
+
+- **`FastGroundTruthIntegrationTest`** covers the two things worth verifying specifically
+  about `--fast-ground-truth` beyond what the safe-mode tests already prove: (1) a 3-commit,
+  2-pair window where the middle commit is both pair 0's HEAD and pair 1's BASE — the actual
+  cache-hit case — still yields a correct PASS verdict, proving a cache hit doesn't feed a
+  pair a stale or partial `CommitBuild`; (2) the existing untracked-`@BeforeAll`-dependency
+  would-miss fixture still produces a correct FAIL verdict when its ground-truth build is
+  agent-attached instead of agent-free, proving the mode switch doesn't change pass/fail
+  detection. status: documented.
+- **Full suite result:** `blastradius-core` + `blastradius-validator`, 82/82 passing, 0
+  failures — both new tests included, no regressions in the safe-mode (default) path.
+  status: documented.

--- a/docs/fluencyloop/features/cache-commit-build-results-across-the-sliding-window-to-elim/sessions/design-the-safe-default-opt-in-fast-ground-truth-split.md
+++ b/docs/fluencyloop/features/cache-commit-build-results-across-the-sliding-window-to-elim/sessions/design-the-safe-default-opt-in-fast-ground-truth-split.md
@@ -1,0 +1,59 @@
+# Session: design the safe-default / opt-in fast-ground-truth split
+
+- **intent:** design the safe-default / opt-in fast-ground-truth split
+- **started:** 2026-07-28
+
+<!--
+FluencyLoop Stage 3 — a session is a slice of the build. One block per meaningful decision,
+appended at the slice boundary as it's taught. No `commits:` field: the feature is a branch,
+so the PR view derives commits live from git.
+
+Each decision is a `## Decision:` heading followed by a bullet list — one bullet per field, so
+it renders one-per-line as real Markdown (plain `key: value` lines collapse into a single
+paragraph when rendered). Fields:
+
+  where        — file/area the decision lives in (NOT a line number — survives refactoring)
+  why          — the rationale, taught live before it was written
+  alternative  — the rejected option and why (this is what makes it rationale, not description)
+  design       — (optional) ../design.md#anchor — the diagram this decision shaped or used
+  constitution — (optional) §N — the principle this decision serves or trades off against
+  trust        — ✓ verified | ⚠ not independently verified  (about the DECISION, never the person)
+
+Delete this comment and the example below once real decisions land.
+-->
+
+---
+
+## Knowledge transfer
+
+- **The redundancy that's free to remove:** `RunCommand.analyzePair` currently checks out a
+  pair's head commit and runs a discardable, agent-free "probe" build purely to detect a build
+  failure before delegating to `GroundTruthResolver.resolve()` — which then runs its *own*
+  separate agent-free full build internally and discards the `BuildResult`, keeping only the
+  per-test outcomes. Those two builds are identical in every respect (same commit, same command,
+  no agent) and always were — the duplication exists only because `GroundTruthResolver` never
+  told its caller what its own build did. Exposing that `BuildResult` via a new
+  `GroundTruthResolution` wrapper removes an entire build with zero change to what's measured.
+  status: documented.
+- **Why the deeper win (unifying build types) is a real trade, not just an optimization:** in a
+  strictly linear sliding window, every (commit, build-type) pair is only ever requested once —
+  a base build for commit N is agent-attached, a ground-truth build for the same commit N (when
+  it's also some other pair's head) is agent-free. Caching only pays off across pairs if those
+  two build types collapse into one, which means the ground-truth oracle stops being built
+  independently of the tracking agent it's meant to validate. That's a genuine soundness/speed
+  fork, not a free win like the probe dedup. status: documented.
+- **Why gating it behind a flag resolves the constitution tension instead of just moving it:**
+  §III's actual language forbids a design decision that *silently* weakens soundness in favor of
+  speed. A default-off, explicitly named `--fast-ground-truth` flag means the default run stays
+  exactly as sound as today, and anyone who opts in is making a visible, per-run choice — the
+  opposite of silent. status: documented.
+
+
+## Decision: safe mode stays the default; unifying build types is gated behind --fast-ground-truth
+
+- **where:** `blastradius-validator/.../cli/RunConfig.java, RunCommand.java`
+- **why:** unifying build types unconditionally would make every default run trade away the ground-truth build's independence from the tracking agent — exactly the silently-weakens-soundness-for-speed failure constitution §III names. A default-off, explicit flag keeps the default run's soundness unchanged and makes the trade visible and opt-in on runs that ask for it; read as compliance with §III's concern (silence), not an exception to it.
+- **alternative:** unify build types unconditionally, no flag, agent always attached — rejected: reaches the same N+1 build count on every run, but applies the trade to runs that never asked for it
+- **design:** ../design.md#constitution-tension-and-how-the-design-resolves-it
+- **constitution:** §III
+- **trust:** ✓ verified

--- a/docs/fluencyloop/features/cache-commit-build-results-across-the-sliding-window-to-elim/sessions/expose-groundtruthresolver-s-buildresult-drop-the-redundant.md
+++ b/docs/fluencyloop/features/cache-commit-build-results-across-the-sliding-window-to-elim/sessions/expose-groundtruthresolver-s-buildresult-drop-the-redundant.md
@@ -1,0 +1,36 @@
+# Session: expose GroundTruthResolver's BuildResult, drop the redundant probe build
+
+- **intent:** expose GroundTruthResolver's BuildResult, drop the redundant probe build
+- **started:** 2026-07-28
+
+<!--
+FluencyLoop Stage 3 — a session is a slice of the build. One block per meaningful decision,
+appended at the slice boundary as it's taught. No `commits:` field: the feature is a branch,
+so the PR view derives commits live from git.
+
+Each decision is a `## Decision:` heading followed by a bullet list — one bullet per field, so
+it renders one-per-line as real Markdown (plain `key: value` lines collapse into a single
+paragraph when rendered). Fields:
+
+  where        — file/area the decision lives in (NOT a line number — survives refactoring)
+  why          — the rationale, taught live before it was written
+  alternative  — the rejected option and why (this is what makes it rationale, not description)
+  design       — (optional) ../design.md#anchor — the diagram this decision shaped or used
+  constitution — (optional) §N — the principle this decision serves or trades off against
+  trust        — ✓ verified | ⚠ not independently verified  (about the DECISION, never the person)
+
+Delete this comment and the example below once real decisions land.
+-->
+
+---
+
+## Knowledge transfer
+
+- **`GroundTruthResolution`** wraps `GroundTruthResolver.resolve()`'s `BuildResult` alongside
+  its `List<GroundTruthResult>` — mechanical execution of the shape agreed in the design
+  session (`design-the-safe-default-opt-in-fast-ground-truth-split.md`), no new fork here.
+  `RunCommand.analyzePair` now runs `buildFailureDetector.isBuildFailure(resolution.initialBuild(), ...)`
+  against the build `GroundTruthResolver` already ran, instead of first running its own
+  separate, identical, agent-free probe build. Behavior is unchanged — a compile failure is
+  still caught before `groundTruth` results are trusted — this only removes one redundant `mvn`
+  invocation per pair. status: documented.


### PR DESCRIPTION
## What

Cuts the number of Maven builds `blastradius-validator` runs per sliding-window commit pair:

- **Today:** up to 3N builds per N pairs — an agent-attached base build, a discardable agent-free "probe" build to detect head-commit build failure, and `GroundTruthResolver`'s own separate internal agent-free build (the last two are identical and redundant).
- **Safe, default, no flag (2N builds):** eliminates the redundant probe build unconditionally by exposing `GroundTruthResolver`'s own `BuildResult` to its caller via a new `GroundTruthResolution` wrapper. Zero behavior change.
- **`--fast-ground-truth`, opt-in, default off (N+1 builds):** unifies every commit's build into one canonical, always-agent-attached build, cached in-memory per `run()` call and reused across every pair that references that commit.

## Why gated behind a flag

Unifying build types unconditionally would make every default run trade away the ground-truth build's independence from the tracking agent — the failure mode constitution §III names (silently weakening soundness for speed). A default-off, explicitly named flag keeps the default run exactly as sound as before; opting in is a visible, per-run choice, not a silent one. This is compliance with §III's actual concern, not an exception carved out of it.

**Rejected alternative:** unify unconditionally, no flag — reaches the same N+1 build count on every run, but applies the trade to runs that never asked for it.

## Constitution check

One decision cites a principle: `constitution: §III` (Safety Over Speed), journaled with `trust: verified`. No conflicts found — the design was built specifically to satisfy §III rather than trade against it.

## Design

`docs/fluencyloop/features/cache-commit-build-results-across-the-sliding-window-to-elim/design.md` — class diagram, both sequence diagrams (probe elimination, cache-hit across two pairs), and the full constitution-tension writeup.

## Testing

`FastGroundTruthIntegrationTest` (new): cache-hit correctness across a 2-pair window where the middle commit is both a HEAD and a BASE, and would-miss detection under agent-attached ground-truth builds. Full suite: `blastradius-core` + `blastradius-validator`, 82/82 passing, 0 failures, no regressions in the default (safe) path.

## Note for reviewers

While staging this PR, found that `.gitignore`'s bare `build/` pattern also matches the validator's `build` *package* directory (`.../validator/build/`), not just Gradle output dirs — new files there (like the new `GroundTruthResolution.java` in this PR) are silently ignored unless force-added. Existing files in that package were previously force-added too. Not fixed in this PR (out of scope) — worth a follow-up to scope the gitignore pattern (e.g. `/build/` or a Gradle-specific path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
