### PR TITLE
fix: scope out reactor-wide abort in single-test confirmation reruns

### DIFF
--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunner.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunner.java
@@ -190,6 +190,15 @@ public final class MavenBuildRunner {
         }
         if (testSelector != null) {
             args.add("-Dtest=" + testSelector);
+            // Without this, a multi-module reactor aborts the whole build at the first
+            // module that has test sources but none matching testSelector (found running
+            // against apache/shenyu, whose shenyu-common module has no test named after
+            // any admin-module class) — the named test's own module is never reached, so
+            // confirmFailure (FR-013) always reads back no report and misclassifies a
+            // genuinely flaky test as CONFIRMED_FAILED. Two properties because Surefire
+            // has used both names for this switch across versions.
+            args.add("-DfailIfNoTests=false");
+            args.add("-Dsurefire.failIfNoSpecifiedTests=false");
         }
         return args.toArray(new String[0]);
     }

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunnerTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunnerTest.java
@@ -121,6 +121,48 @@ class MavenBuildRunnerTest {
     }
 
     @Test
+    void runSingleTestFindsAndPassesAMatchInTheCorrectModuleOfAReactorWhereOtherModulesHaveUnrelatedTests(
+            @TempDir Path projectDir) {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.twoModuleReactor(projectDir);
+        fixture.writeClassInModule("moduleA", "com.example.a.Widget",
+                "package com.example.a; public class Widget { public int value() { return 1; } }");
+        fixture.writeTestInModule("moduleA", "com.example.a.WidgetTest", """
+                package com.example.a;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class WidgetTest {
+                    @Test
+                    void passes() {
+                        assertEquals(1, new Widget().value());
+                    }
+                }
+                """);
+        fixture.writeClassInModule("moduleB", "com.example.b.Gadget",
+                "package com.example.b; public class Gadget { public int value() { return 2; } }");
+        fixture.writeTestInModule("moduleB", "com.example.b.GadgetTest", """
+                package com.example.b;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class GadgetTest {
+                    @Test
+                    void passes() {
+                        assertEquals(2, new Gadget().value());
+                    }
+                }
+                """);
+        fixture.commit("initial");
+
+        // moduleA has test sources but none named GadgetTest — without failIfNoTests=false
+        // this aborts the whole reactor at moduleA before moduleB (the test's real home)
+        // is ever reached.
+        BuildResult result = runner.runSingleTest(projectDir, new TestIdentity("com.example.b.GadgetTest", "passes"));
+
+        assertEquals(0, result.exitCode(), "expected the reactor build to reach moduleB and pass:\n" + result.output());
+        assertTrue(result.output().contains("Tests run: 1"),
+                "expected exactly one test to run:\n" + result.output());
+    }
+
+    @Test
     void noParallelThreadsOmitsTheTFlag() {
         assertArrayEquals(
                 new String[] {"mvn", "-B", "--no-transfer-progress", "clean", "test"},


### PR DESCRIPTION
## What

`MavenBuildRunner.runSingleTest()` (used by `GroundTruthResolver.confirmFailure`, FR-013's "confirm a failure isn't flaky" mechanism) built its command as `mvn clean test -Dtest=<selector>` against the whole reactor, with no `failIfNoTests` override.

In a multi-module target project, that aborts the entire build at the first module that has test sources but none matching the selector — Surefire raises `No tests were executed! (Set -DfailIfNoTests=false to ignore this error.)` and the build stops before the test's own module is ever reached. `confirmFailure` then reads back **no report at all** for the test it's trying to confirm, and treats that as "still failed" — so it always returns `CONFIRMED_FAILED`, never `FLAKY`, regardless of whether the test is actually flaky. The confirmation rerun can never succeed for any test outside the first module in build order.

## How this was found

Running `blastradius-validator --fast-ground-truth` against `apache/shenyu` produced a FAIL verdict with 230 would-miss cases, all confined to `org.apache.shenyu.admin.mapper.*`. Manually running one of them (`PluginMapperTest#selectAll`) standalone against the exact same commit passed cleanly — so it wasn't a real regression. Reproducing the exact command `runSingleTest` builds showed why: `mvn clean test -Dtest=PluginMapperTest#selectAll` from the shenyu repo root fails immediately in `shenyu-common` (no matching test there), before ever reaching `shenyu-admin`. These mapper tests are genuinely order/state-sensitive under a full-suite run (shared H2/Spring context) — legitimately flaky — but the confirmation mechanism could never observe an isolated pass to prove it.

## Fix

Add `-DfailIfNoTests=false` and `-Dsurefire.failIfNoSpecifiedTests=false` when a test selector is present, so unrelated modules are skipped rather than aborting the reactor. Both properties are included since Surefire has used different names for this switch across versions; an unrecognized `-D` property is harmless.

## Testing

- New `MavenBuildRunnerTest` case: a 2-module reactor fixture where module A has an unrelated test and module B has the target test — reproduces the exact abort-before-reaching-the-real-module scenario, asserts the fixed command reaches module B and passes.
- Verified directly against apache/shenyu: the fixed command (`clean test -Dtest=PluginMapperTest#selectAll -DfailIfNoTests=false -Dsurefire.failIfNoSpecifiedTests=false`) now reaches `shenyu-admin` and passes (`Tests run: 1, Failures: 0`), where the unfixed command aborted at `shenyu-common`.
- Full `blastradius-core` + `blastradius-validator` + `blastradius-maven-plugin` suite: green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
