### PR TITLE
fix: stop ambient instrumentation from corrupting StackMapTable frames

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,8 +81,39 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: coverage/target/site/jacoco-aggregate
-      - name: Save Blastradius index from main
+      - name: Check Blastradius index refresh actually succeeded
+        id: blastradius-track-check
         if: ${{ github.ref == 'refs/heads/main' && success() && steps.blastradius-index.outputs.cache-hit != 'true' }}
+        run: |
+          # A TRACK attempt that fails internally (e.g. an instrumentation bug) falls back
+          # to running the full suite without ever refreshing the index, but the outer Maven
+          # build still exits 0 — so success() alone can't tell a real refresh from a silent
+          # fallback. Without this check, "Save Blastradius index from main" below would keep
+          # re-saving an unrefreshed, increasingly stale index under each new commit's cache
+          # key, and every later PR would silently inherit that staleness.
+          report_paths=(
+            blastradius-core/.blastradius/last-build-report.json
+            blastradius-s3-index-store/.blastradius/last-build-report.json
+            blastradius-validator/.blastradius/last-build-report.json
+            blastradius-maven-plugin/.blastradius/last-build-report.json
+          )
+          track_ok=true
+          for report_path in "${report_paths[@]}"; do
+            if [[ ! -f "$report_path" ]]; then
+              echo "::warning::Blastradius index refresh check: $report_path is missing, cannot confirm TRACK succeeded"
+              track_ok=false
+              continue
+            fi
+            mode="$(jq -r '.mode' "$report_path")"
+            if [[ "$mode" != "TRACK" ]]; then
+              applicability="$(jq -r '.indexApplicability' "$report_path")"
+              echo "::warning::Blastradius index refresh check: $report_path reports mode=$mode (indexApplicability=$applicability), expected TRACK"
+              track_ok=false
+            fi
+          done
+          echo "track-ok=$track_ok" >> "$GITHUB_OUTPUT"
+      - name: Save Blastradius index from main
+        if: ${{ github.ref == 'refs/heads/main' && success() && steps.blastradius-index.outputs.cache-hit != 'true' && steps.blastradius-track-check.outputs.track-ok == 'true' }}
         uses: actions/cache/save@v6
         with:
           path: |

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenter.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenter.java
@@ -18,9 +18,29 @@ final class AmbientClassInstrumenter {
     private static final String AGENT_INTERNAL_NAME =
             "io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent";
 
-    byte[] instrument(String className, byte[] bytecode) {
+    byte[] instrument(String className, byte[] bytecode, ClassLoader loader) {
         ClassReader reader = new ClassReader(bytecode);
-        ClassWriter writer = new ClassWriter(reader, ClassWriter.COMPUTE_MAXS);
+        // COMPUTE_FRAMES, not just COMPUTE_MAXS: every NEW/CHECKCAST/etc. we rewrite in
+        // visitTypeInsn shifts bytecode offsets, and COMPUTE_MAXS leaves the class's existing
+        // StackMapTable untouched — its Uninitialized(offset) entries (tracking an object
+        // between NEW and its <init> call) then point past the instructions ASM just inserted,
+        // which JDK 21/25's stricter verifier rejects as "bad offset for Uninitialized" (found
+        // self-hosting: SelectMojo.registerTimingRecorder()'s
+        // `new TimingHistoryRecorder(existing == null ? new AbstractExecutionListener() : existing, ...)`
+        // leaves the outer NEW's Uninitialized(offset) on the stack across the ternary's branch —
+        // see AmbientClassInstrumenterTest for a minimal repro of this exact shape). COMPUTE_FRAMES
+        // recomputes the whole table from the rewritten bytecode instead of patching stale
+        // offsets, at the cost of needing loader to resolve common superclasses below.
+        ClassWriter writer = new ClassWriter(reader, ClassWriter.COMPUTE_FRAMES) {
+            @Override
+            protected ClassLoader getClassLoader() {
+                // Defaults to this ClassWriter's own (agent/ASM) loader, which can't see a
+                // target project's classes when the agent jar and the instrumented class live
+                // in different classloader realms (e.g. a Maven plugin realm during self-host)
+                // — resolving common superclasses would then throw ClassNotFoundException.
+                return loader != null ? loader : super.getClassLoader();
+            }
+        };
         AtomicBoolean changed = new AtomicBoolean();
         reader.accept(new ClassVisitor(Opcodes.ASM9, writer) {
             @Override

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
@@ -191,7 +191,7 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
         }
         if (classBeingRedefined != null && pendingAmbientRetransformations.contains(dottedClassName)) {
             try {
-                byte[] instrumented = ambientClassInstrumenter.instrument(dottedClassName, classfileBuffer);
+                byte[] instrumented = ambientClassInstrumenter.instrument(dottedClassName, classfileBuffer, loader);
                 if (instrumented != null) {
                     ambientChecksums.put(dottedClassName, sha256Hex(classfileBuffer));
                     transformedAmbientClasses.add(dottedClassName);
@@ -219,7 +219,7 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
                 // reuses an already-loaded instance (e.g. a cached Spring bean) still gets
                 // attributed via the injected callback instead of silently missing it.
                 try {
-                    instrumented = ambientClassInstrumenter.instrument(dottedClassName, classfileBuffer);
+                    instrumented = ambientClassInstrumenter.instrument(dottedClassName, classfileBuffer, loader);
                     if (instrumented != null) {
                         ambientChecksums.put(dottedClassName, checksum);
                     }

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenterTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenterTest.java
@@ -1,0 +1,56 @@
+package io.github.baokhang83.blastradius.core.tracking;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+
+class AmbientClassInstrumenterTest {
+
+    private final AmbientClassInstrumenter instrumenter = new AmbientClassInstrumenter();
+
+    @Test
+    void instrumentingAConstructorArgumentThatBranchesOnAnotherConstructorProducesVerifiableBytecode()
+            throws Exception {
+        // NestedConstructorArgConstruction's `new Wrapper(flag ? new ArrayList<>() : existing)`
+        // leaves the outer NEW's Uninitialized(offset) on the operand stack while evaluating the
+        // ternary argument, which itself branches through a second NEW. That's the exact shape
+        // blastradius's own SelectMojo.registerTimingRecorder() has —
+        // `new TimingHistoryRecorder(existing == null ? new AbstractExecutionListener() : existing, ...)`
+        // — where COMPUTE_MAXS alone leaves the original StackMapTable's Uninitialized(offset)
+        // entry pointing at the pre-instrumentation bytecode position once visitTypeInsn's
+        // injected callbacks shift it, which JDK 21/25's verifier rejects as "bad offset for
+        // Uninitialized". A simpler single-branch `if (flag) return new X(); return new Y();`
+        // shape does NOT reproduce this — confirmed by reverting to COMPUTE_MAXS and rerunning.
+        byte[] original;
+        try (InputStream stream = NestedConstructorArgConstruction.class
+                .getResourceAsStream("AmbientClassInstrumenterTest$NestedConstructorArgConstruction.class")) {
+            assertNotNull(stream, "fixture class bytes must be available as a resource");
+            original = stream.readAllBytes();
+        }
+
+        byte[] instrumented = instrumenter.instrument(NestedConstructorArgConstruction.class.getName(), original,
+                NestedConstructorArgConstruction.class.getClassLoader());
+
+        assertNotNull(instrumented, "expected the instrumenter to have rewritten the method");
+        // defineHiddenClass performs full JVM bytecode verification — unlike a bare
+        // instrument() call, this is what actually catches a corrupt StackMapTable.
+        assertNotNull(MethodHandles.lookup().defineHiddenClass(instrumented, false).lookupClass());
+    }
+
+    static final class Wrapper {
+        final Object value;
+
+        Wrapper(Object value) {
+            this.value = value;
+        }
+    }
+
+    static final class NestedConstructorArgConstruction {
+        static Object make(boolean flag, Object existing) {
+            return new Wrapper(flag ? new ArrayList<>() : existing);
+        }
+    }
+}


### PR DESCRIPTION
## What

`AmbientClassInstrumenter` used `ClassWriter.COMPUTE_MAXS`, which leaves a class's existing `StackMapTable` untouched. Every `NEW`/`CHECKCAST`/etc. we rewrite in `visitTypeInsn` shifts bytecode offsets, so once a class has an `Uninitialized(offset)` entry that survives a branch (e.g. a constructor call whose argument is a ternary with `new` on one side, as in `SelectMojo.registerTimingRecorder()`'s `new TimingHistoryRecorder(existing == null ? new AbstractExecutionListener() : existing, ...)`), `COMPUTE_MAXS` leaves that offset pointing past the inserted instructions. JDK 21/25's stricter verifier rejects the result as `StackMapTable format error: bad offset for Uninitialized`.

This silently broke every TRACK-mode index refresh on self-hosted CI since blastradius started instrumenting its own classes (#148): `SelectMojo.class` itself failed to retransform, `TrackRunner`'s subprocess exited non-zero, `SelectMojo` caught the failure and fell back to a full build without ever writing a fresh index — so main's cached `.blastradius` index has been stale since, and every later PR (including #150) inherits an increasingly stale baseline and trips `FALLBACK_AMBIENT_DEPENDENCY` for every test.

## Fix

Switch to `COMPUTE_FRAMES`, which recomputes the whole `StackMapTable` from the rewritten bytecode instead of patching stale offsets, and thread the transforming class's `ClassLoader` through so `COMPUTE_FRAMES` can resolve common superclasses correctly even when the agent jar and the instrumented class live in different classloader realms (self-hosting's Maven plugin realm).

## Testing

- Verified directly against blastradius's own compiled `SelectMojo.class` bytes, loaded via an isolated classloader (not `defineHiddenClass`, which has an unrelated hidden-class-naming verification quirk that fails even on unmodified bytecode — ruled that out first): the old `COMPUTE_MAXS` code reproduces the exact reported `ClassFormatError`, the `COMPUTE_FRAMES` fix resolves it.
- New `AmbientClassInstrumenterTest` fixture mirrors the real trigger shape (a constructor argument that branches on another `new`). Confirmed it fails under the old code and passes under the fix — an earlier, simpler `if (flag) return new X(); return new Y();` fixture did *not* reproduce the bug, so it was replaced.
- Full `blastradius-core` + `blastradius-maven-plugin` suites: green, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)