### PR TITLE
Support Java 17 target JVMs in tracking agent

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "cut-shadow-mode-validator-time-below-2-min-per-commit-pair-a",
-  "branch": "feature/cut-shadow-mode-validator-time-below-2-min-per-commit-pair-a",
+  "feature": "support-java-17-target-test-jvms-with-a-compatible-tracking",
+  "branch": "feature/support-java-17-target-test-jvms-with-a-compatible-tracking",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/cut-shadow-mode-validator-time-below-2-min-per-commit-pair-a/sessions/split-runcommand-into-concurrent-build-phase-then-serial-ana.md",
-  "base_ref": "feature/scope-the-non-source-fallback-to-the-changed-module-plus-its",
-  "updated": "2026-07-30"
+  "last_session": "docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/sessions/compile-the-injected-tracking-agent-for-java-17-while-retain.md",
+  "base_ref": "main",
+  "updated": "2026-07-31"
 }

--- a/blastradius-core/pom.xml
+++ b/blastradius-core/pom.xml
@@ -18,6 +18,14 @@
         shadow-mode validator (T061) and reused unchanged by both the validator and the
         CI-gating Maven plugin.</description>
 
+    <properties>
+        <!-- This module contains DependencyTrackingAgent, which is loaded into target-test
+             JVMs through -javaagent. Compile it for Java 17 so Maven targets such as Gson
+             can load it, while the parent still requires a Java-21-or-later build JDK and
+             the validator CLI retains its Java 21 bytecode baseline. -->
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
@@ -55,6 +63,9 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler.plugin.version}</version>
                 <configuration>
+                    <!-- Test sources can keep using the Java 21 baseline. Only production
+                         classes cross the -javaagent boundary into target JVMs. -->
+                    <testRelease>21</testRelease>
                     <!-- Retains record/constructor parameter names in bytecode, so
                          Jackson can deserialize records via their canonical
                          constructor without @JsonCreator/@JsonProperty annotations. -->

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/Java17AgentCompatibilityTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/Java17AgentCompatibilityTest.java
@@ -1,0 +1,22 @@
+package io.github.baokhang83.blastradius.core.tracking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+
+class Java17AgentCompatibilityTest {
+
+    @Test
+    void trackingAgentEntryPointIsLoadableByJava17() throws IOException {
+        String resourceName = "/" + DependencyTrackingAgent.class.getName().replace('.', '/') + ".class";
+        try (InputStream resource = DependencyTrackingAgent.class.getResourceAsStream(resourceName);
+                DataInputStream classFile = new DataInputStream(resource)) {
+            assertEquals(0xCAFEBABE, classFile.readInt());
+            classFile.readUnsignedShort(); // minor version
+            assertEquals(61, classFile.readUnsignedShort()); // Java 17
+        }
+    }
+}

--- a/docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/design.md
+++ b/docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/design.md
@@ -1,0 +1,100 @@
+# Design: Support Java 17 target test JVMs with a compatible tracking agent without weakening Java 21+ validator support
+
+started: 2026-07-31
+
+## Problem
+
+The validator is deliberately built for Java 21 and runs correctly on a current JDK. Its
+shaded jar is also the `-javaagent` supplied to each target-build JVM. Consequently the agent
+entry point is currently class-file version 65 (Java 21). A Maven target such as Gson must run
+on Java 17, whose JVM rejects that entry point before any tests start.
+
+The compatibility boundary is the injected agent, not the validator CLI. The validator must
+continue to require Java 21 or later, while target JVMs from Java 17 upward must be able to load
+the tracking code.
+
+## Approach
+
+Compile `blastradius-core` to Java 17 bytecode while continuing to build the reactor with a
+Java-21-or-later JDK. The tracking agent and every project-owned helper it reaches live in core,
+so its `Premain-Class` will then be loadable by a Java 17 target JVM. The validator module stays
+on the existing Java 21 release and its shaded CLI jar remains the distribution and self-location
+mechanism.
+
+This is an intentionally narrow compatibility expansion:
+
+- The agent records and writes exactly the same dependency data. No selection or fallback rule
+  changes.
+- Java 21 and newer target JVMs, including Shenyu, can load Java 17 bytecode normally.
+- The parent enforcer still requires the development/build JDK to be Java 21 or newer. We are
+  not lowering Blastradius's own runtime baseline.
+- A regression test will assert the tracking-agent entry point is class-file version 61, making
+  the Gson failure mode visible without requiring a locally installed Java 17 in CI.
+
+## Constitution check
+
+- **I. Test-driven development:** add the bytecode-compatibility assertion before changing the
+  core compiler release.
+- **III. Safety over speed:** preserve the agent's data format and behavior; this feature only
+  changes which target JVMs can load it.
+- **VI. Maintainable, modern foundations:** retain the Java-21-or-later build/validator baseline
+  while supporting the still-current Java 17 LTS target runtime.
+- **VIII. No avoidable work on the hot path:** compiler targeting changes startup compatibility,
+  not the per-class-load transformer path.
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class ParentBuild {
+    +maven.compiler.release: 21
+    +enforceBuildJdk(): 21+
+  }
+  class CoreTrackingAgent {
+    +DependencyTrackingAgent.premain()
+    +classFileVersion: 61
+  }
+  class ValidatorCli {
+    +classFileVersion: 65
+    +RunCommand.run()
+  }
+  class Java17TargetJvm {
+    +loadAgent()
+    +runTests()
+  }
+  class Java21PlusTargetJvm {
+    +loadAgent()
+    +runTests()
+  }
+  ParentBuild --> CoreTrackingAgent : compiles with release 17
+  ParentBuild --> ValidatorCli : compiles with release 21
+  ValidatorCli --> CoreTrackingAgent : shaded agent entry point
+  Java17TargetJvm --> CoreTrackingAgent : loads
+  Java21PlusTargetJvm --> CoreTrackingAgent : loads
+```
+
+## Sequence: validator tracks a Java 17 target build
+
+```mermaid
+sequenceDiagram
+  participant V as Java 21+ Validator
+  participant M as Maven on Java 17
+  participant A as Java 17-compatible Agent
+  participant T as Target Tests
+  participant R as Dependency Record
+
+  V->>M: launch target build with -javaagent
+  M->>A: load Premain-Class version 61
+  A->>M: install transformer and listener
+  M->>T: execute tests
+  T->>A: report loaded dependencies
+  A->>R: write dependency record on shutdown
+  R-->>V: validator reads unchanged record
+```
+
+## Rejected alternative
+
+Lowering the entire reactor and validator to Java 17 would make the immediate error disappear,
+but it would weaken the established Java-21 build/runtime boundary and force unrelated validator
+code to give up its current baseline. A separate agent compatibility boundary is smaller,
+preserves Shenyu behavior, and makes the reason for supporting Java 17 explicit.

--- a/docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/sessions/compile-the-injected-tracking-agent-for-java-17-while-retain.md
+++ b/docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/sessions/compile-the-injected-tracking-agent-for-java-17-while-retain.md
@@ -1,0 +1,28 @@
+# Session: Compile the injected tracking agent for Java 17 while retaining the validator's Java 21 baseline
+
+- **intent:** Compile the injected tracking agent for Java 17 while retaining the validator's Java 21 baseline
+- **started:** 2026-07-31
+
+## Knowledge transfer
+
+- **The Java boundary is the injected agent, not the validator process.** The validator CLI
+  remains a Java-21 artifact, but Maven target JVMs load `DependencyTrackingAgent` through
+  `-javaagent`. A target that runs Java 17 can load class-file version 61 and rejects version 65
+  before any test begins. · status: documented
+- **Core production and test sources have different compatibility needs.** Core production code
+  crosses into target JVMs and therefore compiles with release 17. Its own tests still compile
+  with release 21, preserving existing use of Java-21 test conveniences such as `List.getFirst()`
+  without expanding the agent's runtime requirement. · status: documented
+- **The compatibility regression is bytecode-level and directly testable.**
+  `Java17AgentCompatibilityTest` reads the agent entry point's class-file header and requires
+  major version 61. A real Java-17 `-javaagent` launch of the shaded validator jar additionally
+  verifies that loading the entry point and its startup path succeeds. · status: documented
+
+## Decision: compile the tracking core for Java 17 while retaining Java 21 validator and test baselines
+
+- **where:** `blastradius-core/pom.xml compiler configuration and tracking-agent packaging`
+- **why:** the tracking agent is injected into the target build JVM, so Java 17 targets reject a Java 21 agent before tests begin; compiling core production classes to release 17 makes the existing agent entry point loadable while the validator CLI and build enforcer remain Java 21 or later
+- **alternative:** lower the entire Blastradius reactor to Java 17 — rejected: it needlessly weakens the validator's established Java 21 baseline and forces unrelated code and tests to give up Java 21 features
+- **design:** ../design.md#approach
+- **constitution:** §I, §III, §VI
+- **trust:** ✓ verified


### PR DESCRIPTION
## Summary

Compile `blastradius-core` production classes to Java 17 so the injected `DependencyTrackingAgent` can load in Java-17 Maven targets such as Gson. The validator CLI and project build baseline remain Java 21+.

## Decision

Kept test sources at Java 21 while lowering only core production bytecode. This preserves existing Java-21 test ergonomics and avoids lowering the validator runtime.

## Validation

- `mvn -pl blastradius-validator -am clean package`
- Verified `DependencyTrackingAgent` is class-file version 61
- Verified the packaged validator agent loads under JDK 17
- Gson JDK-17 one-pair smoke test is running separately

## FluencyLoop

- [Design](docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/design.md)
- One verified decision, checked against Constitution I, III, and VI.