### PR TITLE
Fix JUnit Platform isolation in tracking agent

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -2,7 +2,7 @@
   "feature": "support-java-17-target-test-jvms-with-a-compatible-tracking",
   "branch": "feature/support-java-17-target-test-jvms-with-a-compatible-tracking",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/sessions/compile-the-injected-tracking-agent-for-java-17-while-retain.md",
+  "last_session": "docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/sessions/keep-junit-platform-out-of-the-shaded-tracking-agent-while-r.md",
   "base_ref": "main",
   "updated": "2026-07-31"
 }

--- a/blastradius-core/pom.xml
+++ b/blastradius-core/pom.xml
@@ -123,6 +123,17 @@
                     <shadedArtifactAttached>true</shadedArtifactAttached>
                     <shadedClassifierName>agent</shadedClassifierName>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <artifactSet>
+                        <!-- The target Surefire/Failsafe fork owns this SPI. Keeping our compile
+                             dependency out of the agent prevents its older Platform classes from
+                             shadowing a target project's newer ones on the system classpath. -->
+                        <excludes>
+                            <exclude>org.junit.platform:*</exclude>
+                            <exclude>org.junit.jupiter:*</exclude>
+                            <exclude>org.opentest4j:*</exclude>
+                            <exclude>org.apiguardian:*</exclude>
+                        </excludes>
+                    </artifactSet>
                     <filters>
                         <!-- Strip signature files from shaded dependencies — a merged
                              uber-jar no longer matches their original signatures,

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
@@ -112,7 +112,10 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
     private final AtomicBoolean ambientSnapshotTaken = new AtomicBoolean(false);
 
     public DependencyTrackingAgent() {
-        this(TestBoundaryListener::currentTest);
+        // Maven's outer JVM receives JAVA_TOOL_OPTIONS too, but has no JUnit Platform on its
+        // classpath. Keep premain JUnit-free; the target fork's SPI listener publishes into this
+        // context only once JUnit has started there.
+        this(TestExecutionContext::currentTest);
     }
 
     /** Visible for testing: inject a fake "current test" source instead of the real listener. */

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/TestBoundaryListener.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/TestBoundaryListener.java
@@ -17,12 +17,11 @@ import org.junit.platform.launcher.TestIdentifier;
  */
 public final class TestBoundaryListener implements TestExecutionListener {
 
-    private static final InheritableThreadLocal<TestIdentity> CURRENT_TEST = new InheritableThreadLocal<>();
     private static final ThreadLocal<Set<Class<?>>> CLASSES_AT_TEST_START = new ThreadLocal<>();
 
     /** The test currently executing on this thread, or {@code null} if none. */
     public static TestIdentity currentTest() {
-        return CURRENT_TEST.get();
+        return TestExecutionContext.currentTest();
     }
 
     @Override
@@ -38,7 +37,7 @@ public final class TestBoundaryListener implements TestExecutionListener {
             // generated hash code may load JVM support classes; while no test is current those
             // loads are intentionally ignored instead of recursively recording themselves.
             DependencyTrackingAgent.recordTestStarted(test);
-            CURRENT_TEST.set(test);
+            TestExecutionContext.start(test);
             CLASSES_AT_TEST_START.set(DependencyTrackingAgent.loadedClasses());
         }
     }
@@ -46,12 +45,12 @@ public final class TestBoundaryListener implements TestExecutionListener {
     @Override
     public void executionFinished(TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
         if (testIdentifier.isTest()) {
-            TestIdentity currentTest = CURRENT_TEST.get();
+            TestIdentity currentTest = TestExecutionContext.currentTest();
             if (currentTest != null) {
                 DependencyTrackingAgent.recordHiddenClassesLoadedSince(
                         currentTest, CLASSES_AT_TEST_START.get());
             }
-            CURRENT_TEST.remove();
+            TestExecutionContext.finish();
             CLASSES_AT_TEST_START.remove();
         }
     }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/TestExecutionContext.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/TestExecutionContext.java
@@ -1,0 +1,28 @@
+package io.github.baokhang83.blastradius.core.tracking;
+
+/**
+ * JUnit-free handoff between the agent and the JUnit Platform listener.
+ *
+ * <p>The agent is installed in Maven's outer JVM as well as in Surefire forks. Maven itself does
+ * not provide JUnit Platform classes, so its premain path must be able to ask for the current test
+ * without loading {@link TestBoundaryListener}. A Surefire fork loads that listener later through
+ * its own JUnit Platform service-provider interface and publishes boundaries here.
+ */
+final class TestExecutionContext {
+
+    private static final InheritableThreadLocal<TestIdentity> CURRENT_TEST = new InheritableThreadLocal<>();
+
+    private TestExecutionContext() {}
+
+    static TestIdentity currentTest() {
+        return CURRENT_TEST.get();
+    }
+
+    static void start(TestIdentity test) {
+        CURRENT_TEST.set(test);
+    }
+
+    static void finish() {
+        CURRENT_TEST.remove();
+    }
+}

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/AgentJarIsolationTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/AgentJarIsolationTest.java
@@ -1,0 +1,52 @@
+package io.github.baokhang83.blastradius.core.tracking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.JarFile;
+import org.junit.jupiter.api.Test;
+
+class AgentJarIsolationTest {
+
+    @Test
+    void agentUsesTheTargetJunitPlatformInsteadOfBundlingOne() throws Exception {
+        Path agentJar = findOwnAgentJar();
+
+        try (JarFile jar = new JarFile(agentJar.toFile())) {
+            assertFalse(jar.stream().anyMatch(entry -> entry.getName().startsWith("org/junit/")),
+                    "the agent must not shadow a target project's JUnit Platform");
+            assertFalse(jar.stream().anyMatch(entry -> entry.getName().startsWith("org/opentest4j/")),
+                    "OpenTest4J belongs to the target test runtime too");
+            assertFalse(jar.stream().anyMatch(entry -> entry.getName().startsWith("org/apiguardian/")),
+                    "API Guardian belongs to the target test runtime too");
+        }
+
+        Process process = new ProcessBuilder(
+                Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+                "-javaagent:" + agentJar,
+                "-version")
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        if (!process.waitFor(30, TimeUnit.SECONDS)) {
+            process.destroyForcibly();
+            fail("standalone agent JVM timed out");
+        }
+        assertEquals(0, process.exitValue(), () -> "agent premain must not require JUnit:\n" + output);
+    }
+
+    private static Path findOwnAgentJar() throws IOException {
+        try (var files = Files.list(Path.of("target"))) {
+            return files
+                    .filter(path -> path.getFileName().toString().matches("blastradius-core-.*-agent\\.jar"))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("agent jar not found in target/"));
+        }
+    }
+}

--- a/blastradius-validator/pom.xml
+++ b/blastradius-validator/pom.xml
@@ -104,6 +104,17 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>${shade.plugin.version}</version>
                 <configuration>
+                    <artifactSet>
+                        <!-- JUnit Platform is supplied by each target Surefire/Failsafe fork.
+                             Do not put our compile-time copy ahead of that runtime on the system
+                             classpath, or JUnit's alignment check rejects mixed versions. -->
+                        <excludes>
+                            <exclude>org.junit.platform:*</exclude>
+                            <exclude>org.junit.jupiter:*</exclude>
+                            <exclude>org.opentest4j:*</exclude>
+                            <exclude>org.apiguardian:*</exclude>
+                        </excludes>
+                    </artifactSet>
                     <filters>
                         <!-- Strip signature files from shaded dependencies — a merged
                              uber-jar no longer matches their original signatures,
@@ -132,8 +143,8 @@
                          "[INFO] Scanning for projects..." line and any real build/test
                          failure Maven would otherwise report vanish, leaving only "failed
                          to read dependency record" with no clue why. org.junit,
-                         org.opentest4j and org.apiguardian are deliberately excluded here:
-                         TestBoundaryListener registers as a real
+                         org.opentest4j and org.apiguardian are deliberately excluded from the
+                         shaded artifact above: TestBoundaryListener registers as a real
                          org.junit.platform.launcher.TestExecutionListener via the
                          target's own JUnit Platform SPI, which requires exact interface
                          identity with the target's own (unrelocated) JUnit Platform

--- a/docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/design.md
+++ b/docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/design.md
@@ -98,3 +98,56 @@ Lowering the entire reactor and validator to Java 17 would make the immediate er
 but it would weaken the established Java-21 build/runtime boundary and force unrelated validator
 code to give up its current baseline. A separate agent compatibility boundary is smaller,
 preserves Shenyu behavior, and makes the reason for supporting Java 17 explicit.
+
+## JUnit Platform classpath ownership
+
+The agent must not ship a copy of JUnit Platform classes. Maven's outer JVM starts the agent, but
+does not execute tests; a target's Surefire fork subsequently supplies and owns the JUnit Platform
+API that discovers `TestBoundaryListener` through the normal service-provider file. A JUnit-free
+`TestExecutionContext` gives the agent its current-test lookup without resolving that listener in
+Maven's outer JVM.
+
+```mermaid
+classDiagram
+  class AgentJar {
+    +DependencyTrackingAgent.premain()
+    +TestExecutionContext.currentTest()
+    no org.junit.platform classes
+  }
+  class TargetJUnitPlatform {
+    +TestExecutionListener SPI
+    +TestBoundaryListener
+  }
+  class MavenJvm {
+    +load agent
+  }
+  class SurefireFork {
+    +load target JUnit classes
+    +discover listener
+  }
+  MavenJvm --> AgentJar : starts safely without JUnit
+  SurefireFork --> TargetJUnitPlatform : owns platform classes
+  TargetJUnitPlatform --> AgentJar : discovers listener from SPI
+  TestBoundaryListener --> TestExecutionContext : publishes test boundary
+  DependencyTrackingAgent --> TestExecutionContext : reads current test
+```
+
+```mermaid
+sequenceDiagram
+  participant M as Maven JVM
+  participant A as Agent
+  participant S as Surefire Fork
+  participant J as Target JUnit Platform
+  participant L as TestBoundaryListener
+
+  M->>A: premain without resolving JUnit
+  M->>S: start test fork
+  S->>J: load target platform version
+  J->>L: discover listener through SPI
+  L->>A: publish test boundary
+  A->>A: attribute class loads
+```
+
+Bundling a fixed JUnit Platform version is rejected because the agent JAR is on the parent system
+classpath and can shadow a target's newer Platform classes, producing the alignment failure seen
+with Commons Lang.

--- a/docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/sessions/keep-junit-platform-out-of-the-shaded-tracking-agent-while-r.md
+++ b/docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/sessions/keep-junit-platform-out-of-the-shaded-tracking-agent-while-r.md
@@ -1,0 +1,13 @@
+# Session: Keep JUnit Platform out of the shaded tracking agent, while retaining JUnit-free premain startup for Java 17 target builds.
+
+- **intent:** Keep JUnit Platform out of the shaded tracking agent, while retaining JUnit-free premain startup for Java 17 target builds.
+- **started:** 2026-07-31
+
+## Decision: Keep JUnit Platform out of the shaded tracking agent
+
+- **where:** `blastradius-core/pom.xml, blastradius-validator/pom.xml, tracking startup`
+- **why:** The target Surefire/Failsafe fork owns the JUnit Platform SPI; bundling Blastradius's compile-time copy into the agent can shadow a target's newer Platform classes. A JUnit-free context lets the agent start in Maven's outer JVM, which has no JUnit runtime.
+- **alternative:** Bundle a fixed JUnit Platform version — rejected: it can shadow or mix with the target runtime and makes cross-version JUnit 5 interoperability unsafe.
+- **design:** ../design.md#junit-platform-classpath-ownership
+- **constitution:** §III, §VI
+- **trust:** ✓ verified


### PR DESCRIPTION
Keep JUnit Platform out of the shaded tracking agent so each target Surefire/Failsafe fork owns its SPI version. Adds a JUnit-free premain handoff and agent-jar isolation regression coverage.

Validated:
- core targeted tests: AgentJarIsolationTest and DependencyTrackingIntegrationTest
- full reactor packaging compiled the core and validator successfully before its long validator integration suite was deliberately stopped after an accidental duplicate launch
- inspected the packaged validator: no JUnit, OpenTest4J, or API Guardian classes are embedded.