### PR TITLE
Fix nested test class instrumentation

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -2,7 +2,7 @@
   "feature": "support-java-17-target-test-jvms-with-a-compatible-tracking",
   "branch": "feature/support-java-17-target-test-jvms-with-a-compatible-tracking",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/sessions/keep-junit-platform-out-of-the-shaded-tracking-agent-while-r.md",
+  "last_session": "docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/sessions/avoid-re-entrant-class-definition-while-tracking-junit-test.md",
   "base_ref": "main",
   "updated": "2026-07-31"
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenter.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenter.java
@@ -1,5 +1,12 @@
 package io.github.baokhang83.blastradius.core.tracking;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -31,16 +38,7 @@ final class AmbientClassInstrumenter {
         // see AmbientClassInstrumenterTest for a minimal repro of this exact shape). COMPUTE_FRAMES
         // recomputes the whole table from the rewritten bytecode instead of patching stale
         // offsets, at the cost of needing loader to resolve common superclasses below.
-        ClassWriter writer = new ClassWriter(reader, ClassWriter.COMPUTE_FRAMES) {
-            @Override
-            protected ClassLoader getClassLoader() {
-                // Defaults to this ClassWriter's own (agent/ASM) loader, which can't see a
-                // target project's classes when the agent jar and the instrumented class live
-                // in different classloader realms (e.g. a Maven plugin realm during self-host)
-                // — resolving common superclasses would then throw ClassNotFoundException.
-                return loader != null ? loader : super.getClassLoader();
-            }
-        };
+        ClassWriter writer = new MetadataClassWriter(reader, loader);
         AtomicBoolean changed = new AtomicBoolean();
         reader.accept(new ClassVisitor(Opcodes.ASM9, writer) {
             @Override
@@ -98,5 +96,127 @@ final class AmbientClassInstrumenter {
             }
         }, 0);
         return changed.get() ? writer.toByteArray() : null;
+    }
+
+    /**
+     * Computes target-project stack-map-frame hierarchy relationships from class-file resources
+     * rather than {@link Class#forName(String, boolean, ClassLoader)}. A transformer runs while
+     * the target loader is defining the class, so defining a referenced nested class here can
+     * re-enter that loader and make its later normal definition fail with {@link LinkageError}.
+     */
+    private static final class MetadataClassWriter extends ClassWriter {
+
+        private final ClassLoader loader;
+        private final Map<String, ClassInfo> classes = new HashMap<>();
+
+        MetadataClassWriter(ClassReader reader, ClassLoader loader) {
+            super(reader, ClassWriter.COMPUTE_FRAMES);
+            this.loader = loader;
+        }
+
+        @Override
+        protected String getCommonSuperClass(String first, String second) {
+            if (first.startsWith("[") || second.startsWith("[")) {
+                return "java/lang/Object";
+            }
+            try {
+                if (first.equals(second) || isAssignableFrom(first, second)) {
+                    return first;
+                }
+                if (isAssignableFrom(second, first)) {
+                    return second;
+                }
+                if (classInfo(first).isInterface || classInfo(second).isInterface) {
+                    return "java/lang/Object";
+                }
+                String candidate = first;
+                do {
+                    candidate = classInfo(candidate).superName;
+                } while (!isAssignableFrom(candidate, second));
+                return candidate;
+            } catch (IOException e) {
+                // DependencyTrackingAgent treats an instrumentation failure as an ambient class,
+                // preserving the conservative selection fallback. Returning an invented frame
+                // type here could instead make the target class fail JVM verification.
+                throw new IllegalStateException("could not resolve frame hierarchy from class resources", e);
+            }
+        }
+
+        private boolean isAssignableFrom(String expectedSupertype, String candidate) throws IOException {
+            ArrayDeque<String> pending = new ArrayDeque<>();
+            Set<String> seen = new HashSet<>();
+            pending.add(candidate);
+            while (!pending.isEmpty()) {
+                String current = pending.removeFirst();
+                if (!seen.add(current)) {
+                    continue;
+                }
+                if (expectedSupertype.equals(current)) {
+                    return true;
+                }
+                ClassInfo info = classInfo(current);
+                if (info.superName != null) {
+                    pending.addLast(info.superName);
+                }
+                for (String implementedInterface : info.interfaces) {
+                    pending.addLast(implementedInterface);
+                }
+            }
+            return false;
+        }
+
+        private ClassInfo classInfo(String internalName) throws IOException {
+            ClassInfo known = classes.get(internalName);
+            if (known != null) {
+                return known;
+            }
+            if (internalName.startsWith("java/")) {
+                try {
+                    Class<?> type = Class.forName(internalName.replace('/', '.'), false, loader);
+                    Class<?> superclass = type.getSuperclass();
+                    Class<?>[] implementedInterfaces = type.getInterfaces();
+                    String[] interfaceNames = new String[implementedInterfaces.length];
+                    for (int index = 0; index < implementedInterfaces.length; index++) {
+                        interfaceNames[index] = implementedInterfaces[index].getName().replace('.', '/');
+                    }
+                    ClassInfo info = new ClassInfo(
+                            type.isInterface(),
+                            superclass == null ? null : superclass.getName().replace('.', '/'),
+                            interfaceNames);
+                    classes.put(internalName, info);
+                    return info;
+                } catch (ClassNotFoundException e) {
+                    throw new IOException("JDK class not found: " + internalName, e);
+                }
+            }
+            String resourceName = internalName + ".class";
+            InputStream stream = loader == null
+                    ? ClassLoader.getSystemResourceAsStream(resourceName)
+                    : loader.getResourceAsStream(resourceName);
+            if (stream == null) {
+                throw new IOException("class resource not found: " + resourceName);
+            }
+            try (stream) {
+                ClassReader reader = new ClassReader(stream);
+                ClassInfo info = new ClassInfo(
+                        (reader.getAccess() & Opcodes.ACC_INTERFACE) != 0,
+                        reader.getSuperName(),
+                        reader.getInterfaces());
+                classes.put(internalName, info);
+                return info;
+            }
+        }
+    }
+
+    private static final class ClassInfo {
+        private final boolean isInterface;
+        private final String superName;
+        private final String[] interfaces;
+
+        private ClassInfo(boolean isInterface, String superName, String[] interfaces) {
+            this.isInterface = isInterface;
+            this.superName = superName;
+            this.interfaces = interfaces;
+        }
     }
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
@@ -319,7 +319,7 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
                 ambientDependencies.remove(className);
                 continue;
             }
-            if (!isAmbientInstrumentationCandidate(loadedClass, projectRoot)
+            if (!isProjectClassForRetransformation(loadedClass, projectRoot)
                     || !currentInstrumentation.isModifiableClass(loadedClass)) {
                 continue;
             }
@@ -349,6 +349,22 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
             return false;
         }
         Path codeSource = codeSourceOf(loadedClass);
+        return codeSource != null && isTrackableProjectCodeSource(codeSource, projectRoot);
+    }
+
+    /**
+     * Retransformation happens only after JUnit has finished discovery and the class is already
+     * defined. At that point test classes are safe to instrument too: their method callbacks are
+     * needed to attribute application classes first loaded in {@code @BeforeAll}.
+     */
+    private static boolean isProjectClassForRetransformation(Class<?> loadedClass, Path projectRoot) {
+        if (loadedClass.getName().startsWith(TRACKING_PACKAGE_PREFIX)
+                || loadedClass.getName().startsWith(INSTRUMENTATION_LIBRARY_PACKAGE_PREFIX)
+                || loadedClass.isArray()
+                || loadedClass.isPrimitive()) {
+            return false;
+        }
+        Path codeSource = codeSourceOf(loadedClass);
         return codeSource != null && isProjectCodeSource(codeSource, projectRoot);
     }
 
@@ -365,15 +381,15 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
             return false;
         }
         Path codeSource = codeSourceOf(protectionDomain);
-        return codeSource != null && isProjectCodeSource(codeSource, CONFIGURED_PROJECT_ROOT);
+        return codeSource != null && isTrackableProjectCodeSource(codeSource, CONFIGURED_PROJECT_ROOT);
     }
 
     /**
-     * A class belongs to the build under test when its code source lives under the reactor root —
-     * whether that is a module's {@code target/classes} directory or another module's built jar,
-     * which is how every downstream module sees its reactor dependencies. Without the reactor root
-     * the only safe answer is the class-output directory shape: a jar cannot then be told apart
-     * from a third-party one, so it stays ambient and selection keeps its conservative fallback.
+     * A code source belongs to the build under test when it lives under the reactor root — whether
+     * that is a module's class-output directory or another module's built jar, which is how every
+     * downstream module sees its reactor dependencies. Without the reactor root the only safe
+     * answer is the class-output directory shape: a jar cannot then be told apart from a
+     * third-party one, so it stays ambient and selection keeps its conservative fallback.
      */
     static boolean isProjectCodeSource(Path codeSource, Path projectRoot) {
         if (projectRoot != null && codeSource.startsWith(projectRoot)) {
@@ -384,6 +400,19 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
                 || path.endsWith("/target/test-classes")
                 || path.endsWith("/build/classes/java/main")
                 || path.endsWith("/build/classes/java/test");
+    }
+
+    /**
+     * Test output is excluded only from initial class-definition instrumentation. JUnit discovery
+     * can trigger nested-class resolution while a test class is being defined; those classes are
+     * instead picked up by {@link #isProjectClassForRetransformation(Class, Path)} after discovery.
+     */
+    private static boolean isTrackableProjectCodeSource(Path codeSource, Path projectRoot) {
+        if (!isProjectCodeSource(codeSource, projectRoot)) {
+            return false;
+        }
+        String path = codeSource.toString().replace('\\', '/');
+        return !path.endsWith("/target/test-classes") && !path.endsWith("/build/classes/java/test");
     }
 
     private static Path configuredProjectRoot() {

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenterTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenterTest.java
@@ -1,6 +1,7 @@
 package io.github.baokhang83.blastradius.core.tracking;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
@@ -40,6 +41,29 @@ class AmbientClassInstrumenterTest {
         assertNotNull(MethodHandles.lookup().defineHiddenClass(instrumented, false).lookupClass());
     }
 
+    @Test
+    void instrumentingANestedClassReferenceDoesNotReenterItsDefiningLoader() throws Exception {
+        byte[] original;
+        try (InputStream stream = FrameMergingNestedType.class
+                .getResourceAsStream("AmbientClassInstrumenterTest$FrameMergingNestedType.class")) {
+            assertNotNull(stream, "fixture class bytes must be available as a resource");
+            original = stream.readAllBytes();
+        }
+
+        ClassLoader rejectingLoader = new ClassLoader(FrameMergingNestedType.class.getClassLoader()) {
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                if (name.equals(FrameMergingNestedType.Child.class.getName())) {
+                    throw new AssertionError("frame computation must not load a nested project class");
+                }
+                return super.loadClass(name, resolve);
+            }
+        };
+
+        assertDoesNotThrow(() -> instrumenter.instrument(
+                FrameMergingNestedType.class.getName(), original, rejectingLoader));
+    }
+
     static final class Wrapper {
         final Object value;
 
@@ -51,6 +75,14 @@ class AmbientClassInstrumenterTest {
     static final class NestedConstructorArgConstruction {
         static Object make(boolean flag, Object existing) {
             return new Wrapper(flag ? new ArrayList<>() : existing);
+        }
+    }
+
+    static final class FrameMergingNestedType {
+        static final class Child extends Thread {}
+
+        static Thread choose(boolean child) {
+            return child ? new Child() : new Thread();
         }
     }
 }

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
@@ -13,9 +13,11 @@ import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.CodeSource;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.ProtectionDomain;
+import java.security.cert.Certificate;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -127,7 +129,7 @@ class DependencyTrackingAgentTest {
         currentTest.set(null);
 
         byte[] instrumented = agent.transform(
-                null, "com/example/SpringBean", null, ownProtectionDomain(), ownClassBytes());
+                null, "com/example/SpringBean", null, productionProtectionDomain(), ownClassBytes());
 
         assertTrue(instrumented != null,
                 "a project class must be instrumented on its very first load, whether or not a "
@@ -146,7 +148,7 @@ class DependencyTrackingAgentTest {
         TestIdentity testB = new TestIdentity("com.example.BeanReusingTest", "reusesCachedContext");
 
         currentTest.set(testA);
-        agent.transform(null, "com/example/SpringBean", null, ownProtectionDomain(), ownClassBytes());
+        agent.transform(null, "com/example/SpringBean", null, productionProtectionDomain(), ownClassBytes());
 
         Field installedAgentField = DependencyTrackingAgent.class.getDeclaredField("installedAgent");
         installedAgentField.setAccessible(true);
@@ -307,9 +309,10 @@ class DependencyTrackingAgentTest {
         }
     }
 
-    /** Compiled to {@code target/test-classes}: a real project code source for the tests below. */
-    private static ProtectionDomain ownProtectionDomain() {
-        return DependencyTrackingAgentTest.class.getProtectionDomain();
+    private static ProtectionDomain productionProtectionDomain() throws Exception {
+        CodeSource codeSource = new CodeSource(
+                Path.of("/build/repo/module/target/classes").toUri().toURL(), (Certificate[]) null);
+        return new ProtectionDomain(codeSource, null);
     }
 
     private static String sha256Hex(byte[] bytes) throws NoSuchAlgorithmException {

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingIntegrationTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingIntegrationTest.java
@@ -167,6 +167,37 @@ class DependencyTrackingIntegrationTest {
     }
 
     @Test
+    void discoveryOfATestWithANestedClassDoesNotDefineItTwice(@TempDir Path projectDir, @TempDir Path outDir)
+            throws Exception {
+        Path agentJar = findOwnAgentJar();
+        Path recordFile = outDir.resolve("deps.json");
+
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.addSystemDependency(null, agentJar);
+        fixture.writeTest("com.example.NestedWorkerTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertEquals;
+                class NestedWorkerTest {
+                    private static final class Worker extends Thread {
+                        @Override public void run() {}
+                    }
+                    @Test void startsNestedWorker() {
+                        Thread worker = System.nanoTime() > 0 ? new Worker() : new Thread();
+                        assertEquals(Thread.State.NEW, worker.getState());
+                    }
+                }
+                """);
+        fixture.commit("initial");
+
+        runMvnTest(projectDir, agentJar, recordFile);
+
+        Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(recordFile).tests();
+        assertTrue(recorded.containsKey(new TestIdentity("com.example.NestedWorkerTest", "startsNestedWorker")),
+                "the nested test class must be discoverable and execute: " + recorded.keySet());
+    }
+
+    @Test
     void virtualThreadAttributionIncludesSealedAndHiddenClassLoadsOnJdk25(
             @TempDir Path projectDir, @TempDir Path outDir) throws Exception {
         Path agentJar = findOwnAgentJar();

--- a/docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/design.md
+++ b/docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/design.md
@@ -151,3 +151,33 @@ sequenceDiagram
 Bundling a fixed JUnit Platform version is rejected because the agent JAR is on the parent system
 classpath and can shadow a target's newer Platform classes, producing the alignment failure seen
 with Commons Lang.
+
+## Test discovery without re-entrant class definition
+
+JUnit discovery defines test classes before the first test boundary opens. Instrumenting one of
+those classes at definition time can make ASM resolve a nested test class through the same loader;
+on Java 17, Commons Lang's `ThreadUtilsTest$TestThread` then fails when JUnit later defines it
+normally. Test classes therefore stay unmodified during discovery and are retransformed only at
+the first test boundary, when they are already defined. Production classes remain instrumented on
+their first load. Frame computation reads target class metadata as resources instead of defining
+target classes; JDK hierarchy metadata may use the bootstrap loader safely.
+
+```mermaid
+sequenceDiagram
+  participant J as JUnit discovery
+  participant L as Target class loader
+  participant A as Tracking agent
+  participant B as First test boundary
+
+  J->>L: define test class and nested members
+  L->>A: transform test class
+  A-->>L: leave test bytecode unchanged
+  B->>A: snapshot loaded project classes
+  A->>L: retransform already-defined test classes
+  A->>A: read target hierarchy metadata without class definition
+  B->>A: record test and application dependencies
+```
+
+Rejecting all test-class instrumentation would avoid the linkage error but loses attribution for
+application classes first loaded in `@BeforeAll`. Retransformation after discovery preserves that
+attribution without violating the classloader's definition lifecycle.

--- a/docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/sessions/avoid-re-entrant-class-definition-while-tracking-junit-test.md
+++ b/docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/sessions/avoid-re-entrant-class-definition-while-tracking-junit-test.md
@@ -1,0 +1,13 @@
+# Session: Avoid re-entrant class definition while tracking JUnit test discovery, without losing before-all dependency attribution.
+
+- **intent:** Avoid re-entrant class definition while tracking JUnit test discovery, without losing before-all dependency attribution.
+- **started:** 2026-07-31
+
+## Decision: Defer test-class instrumentation until after JUnit discovery
+
+- **where:** `DependencyTrackingAgent and AmbientClassInstrumenter`
+- **why:** Defining a nested test class through its loader during ASM frame computation can re-enter that loader and cause a duplicate class definition. Retransforming already-defined tests at the first test boundary avoids the lifecycle hazard while preserving callbacks needed for classes loaded in BeforeAll.
+- **alternative:** Never instrument test classes — rejected: it loses attribution for application classes first loaded before a test boundary.
+- **design:** ../design.md#test-discovery-without-re-entrant-class-definition
+- **constitution:** §III, §VI
+- **trust:** ✓ verified


### PR DESCRIPTION
Defers test-class instrumentation until after JUnit discovery, preventing nested-class duplicate definitions while preserving BeforeAll attribution. Frame hierarchy reads target metadata without defining target classes.

Validation: all 118 core tests pass; Commons Lang ThreadUtilsTest passes 36 tests under JDK 17 with the validator agent.