### PR TITLE
docs: add ShenYu validator evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ train something probabilistic on historical flakiness. Blastradius does neither:
 uses that real, per-test dependency map to decide what to run next time. No training data,
 no heuristics, no opaque score.
 
+## Early validation: Apache ShenYu
+
+The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode, from [`ce3719d4d68cb51df0704a154fb1da8b2a1778ed`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) to [`3a411e017acfc47636e2bbfeb2958108d1f15a05`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases.
+
+| Metric | Result |
+| --- | --- |
+| Commit pairs analyzed | 300 / 300 |
+| Build exclusions | 0 |
+| Would-miss cases | 0 |
+| Test executions skipped | 514,077 / 747,680 (68.8%) |
+| Tests selected | 233,603 |
+| Flaky test observations | 42 (excluded from the verdict) |
+
+This is early evidence from one Maven project and one 300-pair history window, not a universal guarantee. The run stayed conservative: most selected tests came from fallback and module-scoped fallback rules rather than direct dependency matches. It also exposed recurring test flakiness, which the validator excludes from its soundness verdict. Full suites still remain the recommended daily safety net.
+
 ## How it works
 
 1. **Track.** On a build of your base branch, a `java.lang.instrument` agent watches every

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ no heuristics, no opaque score.
 
 ## Early validation: Apache ShenYu
 
-The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode, from [`ce3719d4d68cb51df0704a154fb1da8b2a1778ed`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) to [`3a411e017acfc47636e2bbfeb2958108d1f15a05`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases.
+The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode, from [`ce3719d4d68cb51df0704a154fb1da8b2a1778ed`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) to [`3a411e017acfc47636e2bbfeb2958108d1f15a05`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases. The full [machine-readable report](analyses/report_shenyu_300.json) and [human-readable summary](analyses/summary_shenyu_300.txt) are included in this repository.
 
 | Metric | Result |
 | --- | --- |

--- a/analyses/report_shenyu_300.json
+++ b/analyses/report_shenyu_300.json
@@ -1,0 +1,19800 @@
+{
+  "verdict" : "PASS",
+  "analyzedCommitPairs" : [ {
+    "baseCommit" : "ce3719d4d68cb51df0704a154fb1da8b2a1778ed",
+    "headCommit" : "415e58f60cfcb91f2a6f56dcc67c68943dac82ee",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-apache-dubbo/src/main/java/org/apache/shenyu/client/apache/dubbo/ApacheDubboServiceBeanListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.apache.dubbo.ApacheDubboServiceBeanListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-dubbo-common/src/main/java/org/apache/shenyu/client/dubbo/common/dto/DubboRpcExt.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.dubbo.common.dto.DubboRpcExt"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-annotation/src/main/java/org/apache/shenyu/examples/apache/dubbo/service/annotation/impl/DubboProtobufServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.apache.dubbo.service.annotation.impl.DubboProtobufServiceImpl"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/src/main/java/org/apache/shenyu/examples/apache/dubbo/service/xml/impl/DubboProtobufServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.apache.dubbo.service.xml.impl.DubboProtobufServiceImpl"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/src/main/resources/spring-dubbo.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/src/main/java/org/apache/shenyu/examples/apache/dubbo/service/impl/DubboProtobufServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.apache.dubbo.service.impl.DubboProtobufServiceImpl"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/src/main/resources/spring-dubbo.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-dubbo-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-dubbo-api/src/main/proto/DubboTestProto.proto",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/cache/ApacheDubboConfigCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.cache.ApacheDubboConfigCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/proxy/ApacheDubboProxyService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.proxy.ApacheDubboProxyService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/src/main/java/org/apache/shenyu/plugin/dubbo/common/cache/DubboParam.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.dubbo.common.cache.DubboParam"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "415e58f60cfcb91f2a6f56dcc67c68943dac82ee",
+    "headCommit" : "810e986cadbed357270bdc76d3f65d67fd074bb6",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/plugin/AiProxyConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.plugin.AiProxyConfig"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/rule/AiProxyHandle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.rule.AiProxyHandle"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/rule/GeneralContextHandle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.rule.GeneralContextHandle"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/rule/MockHandle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.rule.MockHandle"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/AiModelProviderEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.AiModelProviderEnum"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.PluginEnum"
+    }, {
+      "path" : "shenyu-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/handler/AiProxyPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/strategy/AiModel.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.strategy.AiModel"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/strategy/AiModelFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.strategy.AiModelFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/strategy/openai/OpenAI.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.strategy.openai.OpenAI"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/src/main/java/org/apache/shenyu/springboot/starter/plugin/ai/proxy/AiProxyPluginConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.ai.proxy.AiProxyPluginConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "810e986cadbed357270bdc76d3f65d67fd074bb6",
+    "headCommit" : "d52caa5eb665aa26f7f0246cc4ad38dfbbaa4a5a",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/src/test/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/rust-discovery-handler/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/rust-meta-data-handler/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/rust-plugin-data-handler/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/rust-shenyu-wasm-plugin/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d52caa5eb665aa26f7f0246cc4ad38dfbbaa4a5a",
+    "headCommit" : "4c70d0a88c5d417d89b99d6e10f738d0208b9ab2",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4c70d0a88c5d417d89b99d6e10f738d0208b9ab2",
+    "headCommit" : "c77d1b63e94cd1564b4d799d846d1c568062be71",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/main/java/org/apache/shenyu/infra/redis/RedisProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.RedisProperties"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/test/java/org/apache/shenyu/infra/redis/RedisPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.RedisPropertiesTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c77d1b63e94cd1564b4d799d846d1c568062be71",
+    "headCommit" : "5dcc2a30c81b36068751c19067cb76021519e3c3",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/rule/AiProxyHandle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.rule.AiProxyHandle"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.PluginEnum"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/RpcTypeEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.RpcTypeEnum"
+    }, {
+      "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/utils/PluginNameAdapterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.PluginNameAdapterTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/handler/AiProxyPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/strategy/AiModel.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.strategy.AiModel"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/strategy/openai/OpenAI.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.strategy.openai.OpenAI"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/ShenyuPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.api.ShenyuPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-response/src/main/java/org/apache/shenyu/plugin/response/strategy/NettyClientMessageWriter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.response.strategy.NettyClientMessageWriter"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-response/src/main/java/org/apache/shenyu/plugin/response/strategy/WebClientMessageWriter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.response.strategy.WebClientMessageWriter"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/src/main/java/org/apache/shenyu/springboot/starter/plugin/ai/proxy/AiProxyPluginConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.ai.proxy.AiProxyPluginConfiguration"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5dcc2a30c81b36068751c19067cb76021519e3c3",
+    "headCommit" : "8fc09d7499288cc795d923513676e09e756961f5",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-apache-dubbo/src/main/java/org/apache/shenyu/client/apache/dubbo/ApacheDubboServiceBeanListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.apache.dubbo.ApacheDubboServiceBeanListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-dubbo-common/src/main/java/org/apache/shenyu/client/dubbo/common/dto/DubboRpcExt.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.dubbo.common.dto.DubboRpcExt"
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-dubbo-common/src/main/java/org/apache/shenyu/client/dubbo/common/dto/DubboRpcMethodExt.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.dubbo.common.dto.DubboRpcMethodExt"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/cache/ApacheDubboConfigCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.cache.ApacheDubboConfigCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/proxy/ApacheDubboGrayLoadBalance.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.proxy.ApacheDubboGrayLoadBalance"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/src/main/java/org/apache/shenyu/plugin/dubbo/common/cache/DubboMethodParam.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.dubbo.common.cache.DubboMethodParam"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/src/main/java/org/apache/shenyu/plugin/dubbo/common/cache/DubboParam.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.dubbo.common.cache.DubboParam"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8fc09d7499288cc795d923513676e09e756961f5",
+    "headCommit" : "2ed687f65b7f4af07bfcce1bec095eee0006d278",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2ed687f65b7f4af07bfcce1bec095eee0006d278",
+    "headCommit" : "72c43ab02c0413a7566cab58470fe9e43f11abe9",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/client/AbstractContextRefreshedEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.client.AbstractContextRefreshedEventListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/register/registrar/AbstractApiDocRegistrar.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.register.registrar.AbstractApiDocRegistrar"
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/register/registrar/ApiDocRegistrarImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.register.registrar.ApiDocRegistrarImpl"
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/utils/OpenApiUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.utils.OpenApiUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "72c43ab02c0413a7566cab58470fe9e43f11abe9",
+    "headCommit" : "ca31ab0275b799a56d704b145960911f32b75d09",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/e2e-k8s.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/ShenyuAdminBootstrap.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.ShenyuAdminBootstrap"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterDivideServiceImpl"
+    }, {
+      "path" : "shenyu-e2e/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-http/compose/script/e2e-http-sync-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-http/k8s/script/e2e-http-sync.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-http/src/test/java/org/apache/shenyu/e2e/testcase/http/DividePluginCases.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.testcase.http.DividePluginCases"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-http/src/test/java/org/apache/shenyu/e2e/testcase/http/DividePluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.testcase.http.DividePluginTest"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/compose/script/e2e-logging-kafka-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/compose/shenyu-examples-http-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/compose/shenyu-kafka-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/k8s/script/e2e-http-sync.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/k8s/shenyu-kafka.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/src/test/java/org/apache/shenyu/e2e/testcase/logging/kafka/DividePluginCases.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.testcase.logging.kafka.DividePluginCases"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/src/test/java/org/apache/shenyu/e2e/testcase/logging/kafka/DividePluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.testcase.logging.kafka.DividePluginTest"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-rocketmq/compose/script/e2e-logging-rocketmq-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-rocketmq/compose/shenyu-examples-http-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-rocketmq/compose/shenyu-rocketmq-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-rocketmq/k8s/script/e2e-http-sync.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-rocketmq/k8s/shenyu-kafka.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-rocketmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-rocketmq/src/test/java/org/apache/shenyu/e2e/testcase/logging/rocketmq/DividePluginCases.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.testcase.logging.rocketmq.DividePluginCases"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-rocketmq/src/test/java/org/apache/shenyu/e2e/testcase/logging/rocketmq/DividePluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.testcase.logging.rocketmq.DividePluginTest"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-client/src/main/java/org/apache/shenyu/e2e/client/WaitDataSync.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.client.WaitDataSync"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-client/src/main/java/org/apache/shenyu/e2e/client/gateway/GatewayClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.client.gateway.GatewayClient"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/src/main/java/org/apache/shenyu/plugin/logging/kafka/client/KafkaLogCollectClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.kafka.client.KafkaLogCollectClient"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ca31ab0275b799a56d704b145960911f32b75d09",
+    "headCommit" : "7f50a51b37147c0d73beffe9ae3acbe5b75cceb9",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/strategy/openai/OpenAI.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.strategy.openai.OpenAI"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7f50a51b37147c0d73beffe9ae3acbe5b75cceb9",
+    "headCommit" : "c37b4854633efdf019c01805dd9a7e050a7a4e55",
+    "changedFiles" : [ {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-console/src/main/java/org/apache/shenyu/plugin/logging/console/LoggingConsolePlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.console.LoggingConsolePlugin"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c37b4854633efdf019c01805dd9a7e050a7a4e55",
+    "headCommit" : "3854267989135ed7941e0d38df221c953cde3c07",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/resources/application-mysql.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3854267989135ed7941e0d38df221c953cde3c07",
+    "headCommit" : "10fde9f90a1bf85d25bad6c471fb65aed6d055ad",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/PluginServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.PluginServiceImpl"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/AdminConstants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.AdminConstants"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "10fde9f90a1bf85d25bad6c471fb65aed6d055ad",
+    "headCommit" : "a76eedcbb8d18988014e376ff2df16dfec2ea4d1",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/integrated-test-k8s-ingress.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/APDiscoveryProcessor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.APDiscoveryProcessor"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/AbstractDiscoveryProcessor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.AbstractDiscoveryProcessor"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/DefaultDiscoveryProcessor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.DefaultDiscoveryProcessor"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/DiscoveryDataChangedEventSyncListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.DiscoveryDataChangedEventSyncListener"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/listener/DataChangedEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.listener.DataChangedEventListener"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/listener/DiscoveryDataChangedEvent.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.listener.DiscoveryDataChangedEvent"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/disruptor/subscriber/DiscoveryConfigRegisterExecutorSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.disruptor.subscriber.DiscoveryConfigRegisterExecutorSubscriber"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/DiscoveryMapper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.DiscoveryMapper"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/DiscoveryRelMapper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.DiscoveryRelMapper"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/converter/AbstractSelectorHandleConverter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.converter.AbstractSelectorHandleConverter"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/converter/SpringCloudSelectorHandleConverter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.converter.SpringCloudSelectorHandleConverter"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DiscoveryServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.DiscoveryServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSpringCloudServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterSpringCloudServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/utils/SelectorUtil.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.SelectorUtil"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/discovery-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/discovery/DefaultDiscoveryProcessorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.DefaultDiscoveryProcessorTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/discovery/DiscoveryDataChangedEventSyncListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.DiscoveryDataChangedEventSyncListenerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterSpringCloudServiceImplTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterSpringCloudServiceImplTest"
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/register/InstanceRegisterListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.register.InstanceRegisterListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/annotation/ShenyuDeleteMapping.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.annotation.ShenyuDeleteMapping"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/annotation/ShenyuGetMapping.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.annotation.ShenyuGetMapping"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/annotation/ShenyuPatchMapping.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.annotation.ShenyuPatchMapping"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/annotation/ShenyuPostMapping.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.annotation.ShenyuPostMapping"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/annotation/ShenyuPutMapping.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.annotation.ShenyuPutMapping"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/annotation/ShenyuRequestMapping.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.annotation.ShenyuRequestMapping"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/annotation/ShenyuSpringCloudClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.annotation.ShenyuSpringCloudClient"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/init/SpringCloudClientEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.init.SpringCloudClientEventListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/proceeor/extractor/RequestMappingProcessor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.proceeor.extractor.RequestMappingProcessor"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/proceeor/register/ShenyuSpringCloudClientProcessorImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.proceeor.register.ShenyuSpringCloudClientProcessorImpl"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/register/SpringCloudApiBeansExtractor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.register.SpringCloudApiBeansExtractor"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/main/java/org/apache/shenyu/client/springcloud/register/SpringCloudApiMetaRegister.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.register.SpringCloudApiMetaRegister"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/test/java/org/apache/shenyu/client/springcloud/annotation/ShenyuDeleteMappingTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.annotation.ShenyuDeleteMappingTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/test/java/org/apache/shenyu/client/springcloud/annotation/ShenyuGetMappingTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.annotation.ShenyuGetMappingTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/test/java/org/apache/shenyu/client/springcloud/annotation/ShenyuPatchMappingTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.annotation.ShenyuPatchMappingTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/test/java/org/apache/shenyu/client/springcloud/annotation/ShenyuPostMappingTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.annotation.ShenyuPostMappingTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/test/java/org/apache/shenyu/client/springcloud/annotation/ShenyuPutMappingTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.annotation.ShenyuPutMappingTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/test/java/org/apache/shenyu/client/springcloud/annotation/ShenyuRequestMappingTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.annotation.ShenyuRequestMappingTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/test/java/org/apache/shenyu/client/springcloud/init/SpringCloudClientEventListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.init.SpringCloudClientEventListenerTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/test/java/org/apache/shenyu/client/springcloud/register/SpringCloudApiBeansExtractorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.register.SpringCloudApiBeansExtractorTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springcloud/src/test/java/org/apache/shenyu/client/springcloud/register/SpringCloudApiMetaRegisterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springcloud.register.SpringCloudApiMetaRegisterTest"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/DiscoverySyncData.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.DiscoverySyncData"
+    }, {
+      "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/enums/RpcTypeEnumTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.RpcTypeEnumTest"
+    }, {
+      "path" : "shenyu-discovery/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-api/src/main/java/org/apache/shenyu/discovery/api/ShenyuDiscoveryService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.api.ShenyuDiscoveryService"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-api/src/main/java/org/apache/shenyu/discovery/api/config/DiscoveryConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.api.config.DiscoveryConfig"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-api/src/main/java/org/apache/shenyu/discovery/api/listener/DataChangedEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.api.listener.DataChangedEventListener"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-api/src/main/java/org/apache/shenyu/discovery/api/listener/DiscoveryDataChangedEvent.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.api.listener.DiscoveryDataChangedEvent"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-api/src/test/java/org/apache/shenyu/discovery/api/config/DiscoveryConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.api.config.DiscoveryConfigTest"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-api/src/test/java/org/apache/shenyu/discovery/api/listener/DataChangedEventListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.api.listener.DataChangedEventListenerTest"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-api/src/test/java/org/apache/shenyu/discovery/api/listener/DiscoveryDataChangedEventTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.api.listener.DiscoveryDataChangedEventTest"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-etcd/src/main/java/org/apache/shenyu/discovery/etcd/EtcdDiscoveryService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.etcd.EtcdDiscoveryService"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-etcd/src/main/resources/META-INF/shenyu/org.apache.shenyu.discovery.api.ShenyuDiscoveryService",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-etcd/src/test/java/org/apache/shenyu/discovery/etcd/EtcdDiscoveryServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.etcd.EtcdDiscoveryServiceTest"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-eureka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-eureka/src/main/java/org/apache/shenyu/discovery/eureka/CustomedEurekaConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.eureka.CustomedEurekaConfig"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-eureka/src/main/java/org/apache/shenyu/discovery/eureka/EurekaDiscoveryService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.eureka.EurekaDiscoveryService"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-eureka/src/main/resources/META-INF/shenyu/org.apache.shenyu.discovery.api.ShenyuDiscoveryService",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-eureka/src/test/java/org/apache/shenyu/discovery/eureka/EurekaDiscoveryServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.eureka.EurekaDiscoveryServiceTest"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-nacos/src/main/java/org/apache/shenyu/discovery/nacos/NacosDiscoveryService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.nacos.NacosDiscoveryService"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-nacos/src/main/resources/META-INF/shenyu/org.apache.shenyu.discovery.api.ShenyuDiscoveryService",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-nacos/src/test/java/org/apache/shenyu/discovery/nacos/NacosDiscoveryServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.nacos.NacosDiscoveryServiceTest"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-zookeeper/src/main/java/org/apache/shenyu/discovery/zookeeper/ZookeeperDiscoveryService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.zookeeper.ZookeeperDiscoveryService"
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-zookeeper/src/main/resources/META-INF/shenyu/org.apache.shenyu.discovery.api.ShenyuDiscoveryService",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-discovery/shenyu-discovery-zookeeper/src/test/java/org/apache/shenyu/discovery/zookeeper/ZookeeperDiscoveryServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.discovery.zookeeper.ZookeeperDiscoveryServiceTest"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/k8s/shenyu-examples-springcloud.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/src/test/java/org/apache/shenyu/e2e/testcase/springcloud/SpringCloudPluginCases.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.testcase.springcloud.SpringCloudPluginCases"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/src/test/java/org/apache/shenyu/e2e/testcase/springcloud/SpringCloudPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.testcase.springcloud.SpringCloudPluginTest"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http-swagger3/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/k8s/ingress.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/k8s/shenyu-examples-springcloud.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/src/main/java/org/apache/shenyu/examples/springcloud/controller/AllController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.springcloud.controller.AllController"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/src/main/java/org/apache/shenyu/examples/springcloud/controller/NewFeatureController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.springcloud.controller.NewFeatureController"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/src/main/java/org/apache/shenyu/examples/springcloud/controller/OrderController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.springcloud.controller.OrderController"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/src/main/java/org/apache/shenyu/examples/springcloud/controller/TestController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.springcloud.controller.TestController"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/src/main/java/org/apache/shenyu/examples/springcloud/controller/UploadController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.springcloud.controller.UploadController"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-native-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-spring-cloud/Dockerfile",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-spring-cloud/deploy/deploy-shenyu.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-spring-cloud/deploy/kind-config.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-spring-cloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-spring-cloud/script/build_k8s_cluster.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-spring-cloud/script/healthcheck.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-spring-cloud/script/services.list",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-spring-cloud/src/main/java/org/apache/shenyu/integrated/test/k8s/ingress/springcloud/SpringCloudIngressControllerIntegratedBootstrap.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.k8s.ingress.springcloud.SpringCloudIngressControllerIntegratedBootstrap"
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-spring-cloud/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-spring-cloud/src/test/java/org/apache/shenyu/integrated/test/k8s/ingress/springcloud/SpringCloudPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.k8s.ingress.springcloud.SpringCloudPluginTest"
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-spring-cloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-spring-cloud/src/main/resources/application-local.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-spring-cloud/src/test/java/org/apache/shenyu/integratedtest/springcloud/SpringCloudPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integratedtest.springcloud.SpringCloudPluginTest"
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-spring-cloud/src/test/java/org/apache/shenyu/integratedtest/springcloud/SpringCloudPluginUploadTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integratedtest.springcloud.SpringCloudPluginUploadTest"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/main/java/org/apache/shenyu/k8s/common/IngressConstants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.common.IngressConstants"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/main/java/org/apache/shenyu/k8s/parser/IngressParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.parser.IngressParser"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/main/java/org/apache/shenyu/k8s/parser/SpringCloudParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.parser.SpringCloudParser"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/main/java/org/apache/shenyu/k8s/reconciler/IngressReconciler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.reconciler.IngressReconciler"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/main/java/org/apache/shenyu/k8s/repository/ShenyuCacheRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.repository.ShenyuCacheRepository"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/test/java/org/apache/shenyu/k8s/SpringCloudReconcilerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.SpringCloudReconcilerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/context/ShenyuContext.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.api.context.ShenyuContext"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/result/ShenyuResultEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.api.result.ShenyuResultEnum"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/test/java/org/apache/shenyu/plugin/httpclient/NettyHttpClientPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.NettyHttpClientPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/test/java/org/apache/shenyu/plugin/httpclient/WebClientPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.WebClientPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-springcloud/src/main/java/org/apache/shenyu/plugin/springcloud/SpringCloudPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.springcloud.SpringCloudPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-springcloud/src/main/java/org/apache/shenyu/plugin/springcloud/cache/ServiceInstanceCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.springcloud.cache.ServiceInstanceCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-springcloud/src/main/java/org/apache/shenyu/plugin/springcloud/context/SpringCloudShenyuContextDecorator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.springcloud.context.SpringCloudShenyuContextDecorator"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-springcloud/src/main/java/org/apache/shenyu/plugin/springcloud/handler/SpringCloudPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.springcloud.handler.SpringCloudPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-springcloud/src/main/java/org/apache/shenyu/plugin/springcloud/listener/SpringCloudHeartBeatListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.springcloud.listener.SpringCloudHeartBeatListener"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-springcloud/src/main/java/org/apache/shenyu/plugin/springcloud/loadbalance/ShenyuSpringCloudServiceChooser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.springcloud.loadbalance.ShenyuSpringCloudServiceChooser"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-springcloud/src/test/java/org/apache/shenyu/plugin/springcloud/SpringCloudPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.springcloud.SpringCloudPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-springcloud/src/test/java/org/apache/shenyu/plugin/springcloud/context/SpringCloudShenyuContextDecoratorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.springcloud.context.SpringCloudShenyuContextDecoratorTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-springcloud/src/test/java/org/apache/shenyu/plugin/springcloud/handler/SpringCloudPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.springcloud.handler.SpringCloudPluginDataHandlerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-springcloud/src/test/java/org/apache/shenyu/plugin/springcloud/loadbalance/ShenyuSpringCloudServiceChooserTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.springcloud.loadbalance.ShenyuSpringCloudServiceChooserTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-response/src/test/java/org/apache/shenyu/plugin/response/ResponsePluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.response.ResponsePluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-uri/src/test/java/org/apache/shenyu/plugin/uri/URIPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.uri.URIPluginTest"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/dto/ApiDocRegisterDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.common.dto.ApiDocRegisterDTO"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/enums/RegisterTypeEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.common.enums.RegisterTypeEnum"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-api/src/main/java/org/apache/shenyu/registry/api/ShenyuInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.api.ShenyuInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-api/src/main/java/org/apache/shenyu/registry/api/entity/InstanceEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.api.entity.InstanceEntity"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-api/src/main/java/org/apache/shenyu/registry/api/event/ChangedEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.api.event.ChangedEventListener"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-apollo/src/main/java/org/apache/shenyu/registry/apollo/ApolloInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.apollo.ApolloInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/src/main/java/org/apache/shenyu/registry/etcd/EtcdClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.etcd.EtcdClient"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/src/main/java/org/apache/shenyu/registry/etcd/EtcdInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.etcd.EtcdInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-eureka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-eureka/src/main/java/org/apache/shenyu/registry/eureka/EurekaInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.eureka.EurekaInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-nacos/src/main/java/org/apache/shenyu/registry/nacos/NacosInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.nacos.NacosInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/src/main/java/org/apache/shenyu/registry/zookeeper/ZookeeperClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.zookeeper.ZookeeperClient"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/src/main/java/org/apache/shenyu/registry/zookeeper/ZookeeperInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.zookeeper.ZookeeperInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/src/test/java/org/apache/shenyu/registry/zookeeper/ZookeeperClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.zookeeper.ZookeeperClientTest"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-grpc/src/main/java/org/apache/springboot/starter/client/grpc/ShenyuGrpcDiscoveryConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.springboot.starter.client.grpc.ShenyuGrpcDiscoveryConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-spring-websocket/src/main/java/org/apache/shenyu/springboot/starter/client/spring/websocket/ShenyuSpringWebSocketDiscoveryConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.client.spring.websocket.ShenyuSpringWebSocketDiscoveryConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springcloud/src/main/java/org/apache/shenyu/springboot/starter/client/springcloud/ShenyuSpringCloudClientConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.client.springcloud.ShenyuSpringCloudClientConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springcloud/src/main/java/org/apache/shenyu/springboot/starter/client/springcloud/ShenyuSpringCloudClientInfoRegisterConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.client.springcloud.ShenyuSpringCloudClientInfoRegisterConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springcloud/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springcloud/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springcloud/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springcloud/src/test/java/org/apache/shenyu/springboot/starter/client/springcloud/ShenyuSpringCloudClientConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.client.springcloud.ShenyuSpringCloudClientConfigurationTest"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springmvc/src/main/java/org/apache/shenyu/springboot/starter/client/springmvc/ShenyuSpringMvcDiscoveryConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.client.springmvc.ShenyuSpringMvcDiscoveryConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-springcloud/src/main/java/org/apache/shenyu/springboot/starter/plugin/springcloud/SpringCloudPluginConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.springcloud.SpringCloudPluginConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-springcloud/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-springcloud/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-springcloud/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-springcloud/src/test/java/org/apache/shenyu/springboot/starter/plugin/springcloud/SpringCloudPluginConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.springcloud.SpringCloudPluginConfigurationTest"
+    }, {
+      "path" : "shenyu-web/src/main/java/org/apache/shenyu/web/controller/LocalPluginController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.controller.LocalPluginController"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a76eedcbb8d18988014e376ff2df16dfec2ea4d1",
+    "headCommit" : "c5cf2493535ef16f983990c91b5998a717b9dadb",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/ShenyuClientHttpRegistryController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.ShenyuClientHttpRegistryController"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c5cf2493535ef16f983990c91b5998a717b9dadb",
+    "headCommit" : "9232d5ae542f8cb96d238e621b879069c6f16661",
+    "changedFiles" : [ {
+      "path" : ".gitpod.Dockerfile",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : ".gitpod.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : ".licenserc.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9232d5ae542f8cb96d238e621b879069c6f16661",
+    "headCommit" : "8ae092152c4a4bb7eb6e7ca751aeae20a7c7b03e",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/rule/AiTokenLimiterHandle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.rule.AiTokenLimiterHandle"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/AiTokenLimiterEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.AiTokenLimiterEnum"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.PluginEnum"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/TimeWindowEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.TimeWindowEnum"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/utils/JsonUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.JsonUtils"
+    }, {
+      "path" : "shenyu-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/AiTokenLimiterPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.AiTokenLimiterPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/handler/AiTokenLimiterPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.handler.AiTokenLimiterPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/RedisConfigProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.RedisConfigProperties"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/RedisConnectionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.RedisConnectionFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/ShenyuReactiveRedisTemplate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.ShenyuReactiveRedisTemplate"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/ShenyuReactiveScriptExecutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.ShenyuReactiveScriptExecutor"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/serializer/ByteArrayRedisSerializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.serializer.ByteArrayRedisSerializer"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/serializer/ShenyuRedisSerializationContext.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.serializer.ShenyuRedisSerializationContext"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/resources/META-INF/scripts/check-limit.lua",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/resources/META-INF/scripts/increment-token.lua",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/springboot/starter/plugin/ai/token/limiter/AiTokenLimiterPluginConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.ai.token.limiter.AiTokenLimiterPluginConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-token-limiter/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-token-limiter/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-token-limiter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8ae092152c4a4bb7eb6e7ca751aeae20a7c7b03e",
+    "headCommit" : "3557781bea79fd40be8bab2d918ca2d2a4da2f4a",
+    "changedFiles" : [ {
+      "path" : "db/upgrade/2.5.1-upgrade-2.6.0-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.5.1-upgrade-2.6.0-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.5.1-upgrade-2.6.0-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.6.1-upgrade-2.7.0-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.6.1-upgrade-2.7.0-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.6.1-upgrade-2.7.0-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.6.1-upgrade-2.7.0-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3557781bea79fd40be8bab2d918ca2d2a4da2f4a",
+    "headCommit" : "2c98b75bf0155e899d7700162ba0ff3d36c1a708",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/PluginDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.PluginDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/NamespaceServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.NamespaceServiceImpl"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2c98b75bf0155e899d7700162ba0ff3d36c1a708",
+    "headCommit" : "fcad7062ae2fc6dec6649ea3b275dfe2f6b8adc3",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/disruptor/subscriber/URIRegisterExecutorSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.disruptor.subscriber.URIRegisterExecutorSubscriber"
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/disruptor/subcriber/ShenyuClientURIExecutorSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriber"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "fcad7062ae2fc6dec6649ea3b275dfe2f6b8adc3",
+    "headCommit" : "8813473d357147722b49d5a10ee07ccb24794ed8",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/plugin/AiPromptConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.plugin.AiPromptConfig"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/plugin/AiProxyConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.plugin.AiProxyConfig"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/rule/AiPromptHandle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.rule.AiPromptHandle"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/rule/AiProxyHandle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.rule.AiProxyHandle"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.PluginEnum"
+    }, {
+      "path" : "shenyu-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-prompt/src/main/java/org/apache/shenyu/plugin/ai/prompt/AiPromptPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.prompt.AiPromptPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-prompt/src/main/java/org/apache/shenyu/plugin/ai/prompt/handler/AiPromptPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.prompt.handler.AiPromptPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/strategy/openai/OpenAI.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.strategy.openai.OpenAI"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-prompt/src/main/java/org/apache/shenyu/springboot/starter/plugin/ai/prompt/AiPromptPluginConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.ai.prompt.AiPromptPluginConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-prompt/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-prompt/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-prompt/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8813473d357147722b49d5a10ee07ccb24794ed8",
+    "headCommit" : "4a75fec871c57c6f4411af49afbb24db65888448",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DashboardUserServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.DashboardUserServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/NamespaceUserServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.NamespaceUserServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/DashboardUserServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.DashboardUserServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4a75fec871c57c6f4411af49afbb24db65888448",
+    "headCommit" : "b9444302397e04e24124e74f6258f98f5908c34e",
+    "changedFiles" : [ {
+      "path" : "shenyu-alert/src/main/java/org/apache/shenyu/alert/strategy/DingTalkRobotAlertNotifyStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.alert.strategy.DingTalkRobotAlertNotifyStrategy"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/utils/GsonUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.GsonUtils"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/RedisConnectionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.RedisConnectionFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/ShenyuPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.api.ShenyuPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/utils/RequestUrlUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.api.utils.RequestUrlUtils"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/utils/WebFluxResultUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.api.utils.WebFluxResultUtils"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/src/main/java/org/apache/shenyu/plugin/cache/redis/RedisConnectionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.redis.RedisConnectionFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-context-path/src/main/java/org/apache/shenyu/plugin/context/path/ContextPathPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.context.path.ContextPathPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-hystrix/src/main/java/org/apache/shenyu/plugin/hystrix/HystrixPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.hystrix.HystrixPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-sentinel/src/main/java/org/apache/shenyu/plugin/sentinel/SentinelPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sentinel.SentinelPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/AbstractHttpClientPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.AbstractHttpClientPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/body/LoggingServerHttpResponse.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.common.body.LoggingServerHttpResponse"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-metrics/src/main/java/org/apache/shenyu/plugin/metrics/MetricsPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.metrics.MetricsPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-modify-response/src/main/java/org/apache/shenyu/plugin/modify/response/ModifyResponsePlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.modify.response.ModifyResponsePlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/src/main/java/org/apache/shenyu/plugin/divide/DividePlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.divide.DividePlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/src/test/java/org/apache/shenyu/plugin/divide/DividePluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.divide.DividePluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/src/main/java/org/apache/shenyu/plugin/dubbo/common/AbstractDubboPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.dubbo.common.AbstractDubboPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/GrpcPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.grpc.GrpcPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/MotanPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.MotanPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/src/main/java/org/apache/shenyu/plugin/sofa/SofaPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sofa.SofaPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/src/main/java/org/apache/shenyu/plugin/sofa/param/SofaParamResolveServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sofa.param.SofaParamResolveServiceImpl"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-tars/src/main/java/org/apache/shenyu/plugin/tars/TarsPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.tars.TarsPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-tars/src/main/java/org/apache/shenyu/plugin/tars/cache/ApplicationConfigCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.tars.cache.ApplicationConfigCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-response/src/main/java/org/apache/shenyu/plugin/response/ResponsePlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.response.ResponsePlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-rewrite/src/main/java/org/apache/shenyu/plugin/rewrite/RewritePlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.rewrite.RewritePlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-sign/src/main/java/org/apache/shenyu/plugin/sign/service/ComposableSignService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sign.service.ComposableSignService"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b9444302397e04e24124e74f6258f98f5908c34e",
+    "headCommit" : "f3fd88d6fc44ada465598efeca0a48943f078201",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/MetaDataCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.cache.MetaDataCache"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f3fd88d6fc44ada465598efeca0a48943f078201",
+    "headCommit" : "5be0bf6d7422bfc478ce122800f5c21960681352",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/src/main/java/org/apache/shenyu/plugin/logging/clickhouse/config/ClickHouseLogCollectConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.clickhouse.config.ClickHouseLogCollectConfig"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/src/test/java/org/apache/shenyu/plugin/logging/clickhouse/handler/LoggingClickHousePluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.clickhouse.handler.LoggingClickHousePluginDataHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5be0bf6d7422bfc478ce122800f5c21960681352",
+    "headCommit" : "909704f3e4bafdd5b48f81540f27633b9233cb10",
+    "changedFiles" : [ {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/HttpRetryBackoffSpecEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.HttpRetryBackoffSpecEnum"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/AbstractHttpClientPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.AbstractHttpClientPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/CustomRetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.CustomRetryStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/DefaultRetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.DefaultRetryStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/ExponentialRetryBackoffStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.ExponentialRetryBackoffStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/FixedRetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.FixedRetryStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/RetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.RetryStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/test/java/org/apache/shenyu/plugin/httpclient/RetryStrategyTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.RetryStrategyTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "909704f3e4bafdd5b48f81540f27633b9233cb10",
+    "headCommit" : "627bef3d83d12ab9661afc0996164f76358b2ff9",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/ci.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/e2e-k8s.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test-k8s-ingress.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/k8s-examples-http.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "627bef3d83d12ab9661afc0996164f76358b2ff9",
+    "headCommit" : "281a1a317bc4fb713269c467d8d95eb0ce6f15c7",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AppAuthServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.AppAuthServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DiscoveryServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.DiscoveryServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/MetaDataServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.MetaDataServiceImpl"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "281a1a317bc4fb713269c467d8d95eb0ce6f15c7",
+    "headCommit" : "c8e89a4952bac2ea84947d68f7f6c93b3b604138",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/AbstractDataChangedListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.AbstractDataChangedListener"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c8e89a4952bac2ea84947d68f7f6c93b3b604138",
+    "headCommit" : "ddbeda46ee3a3edc90f772bf4b8b1b8de817b81b",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AppAuthServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.AppAuthServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/AppAuthServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.AppAuthServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ddbeda46ee3a3edc90f772bf4b8b1b8de817b81b",
+    "headCommit" : "f7d4f51935c171635b4deca03faa51e4d7ac4eed",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AlertReceiverServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.AlertReceiverServiceImpl"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f7d4f51935c171635b4deca03faa51e4d7ac4eed",
+    "headCommit" : "9f487d717bd67fb813faa81ccdfbb0e04df43a08",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9f487d717bd67fb813faa81ccdfbb0e04df43a08",
+    "headCommit" : "1d665b76c886a3fa9ca712c0989840113bf89e00",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/PluginHandleServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.PluginHandleServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1d665b76c886a3fa9ca712c0989840113bf89e00",
+    "headCommit" : "d4f9a351ab9256ad8d2738d41083cec7602bed8c",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/src/main/java/org/apache/shenyu/plugin/logging/elasticsearch/config/ElasticSearchLogCollectConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.elasticsearch.config.ElasticSearchLogCollectConfig"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/src/test/java/org/apache/shenyu/plugin/logging/elasticsearch/handler/LoggingElasticSearchPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.elasticsearch.handler.LoggingElasticSearchPluginDataHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d4f9a351ab9256ad8d2738d41083cec7602bed8c",
+    "headCommit" : "a4ffd2ed092acc40e8b26b788c4ae59fd99101c5",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/e2e-k8s.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test-k8s-ingress.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/k8s-examples-http.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a4ffd2ed092acc40e8b26b788c4ae59fd99101c5",
+    "headCommit" : "34f4c1e4fa0b3fb97c5c56d1f84668961311fc94",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-tencent-cls/src/main/java/org/apache/shenyu/plugin/tencent/cls/config/TencentLogCollectConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.tencent.cls.config.TencentLogCollectConfig"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-tencent-cls/src/test/java/org/apache/shenyu/plugin/tencent/cls/handler/LoggingTencentClsPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.tencent.cls.handler.LoggingTencentClsPluginDataHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "34f4c1e4fa0b3fb97c5c56d1f84668961311fc94",
+    "headCommit" : "d07d2b8fece2d19f1fa5333dc9b39473effbcaed",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/src/main/java/org/apache/shenyu/plugin/aliyun/sls/config/AliyunLogCollectConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.aliyun.sls.config.AliyunLogCollectConfig"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/src/test/java/org/apache/shenyu/plugin/aliyun/sls/handler/LoggingAliyunSlsPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.aliyun.sls.handler.LoggingAliyunSlsPluginDataHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d07d2b8fece2d19f1fa5333dc9b39473effbcaed",
+    "headCommit" : "c34c3ec3155f65e495cd1c1179dfebe7f44caa39",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/src/main/java/org/apache/shenyu/plugin/logging/elasticsearch/client/ElasticSearchLogCollectClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.elasticsearch.client.ElasticSearchLogCollectClient"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c34c3ec3155f65e495cd1c1179dfebe7f44caa39",
+    "headCommit" : "ae1702bcfaf2d4b595becff9e3b683d785d9eece",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/plugin/AiProxyConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.plugin.AiProxyConfig"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/rule/AiTokenLimiterHandle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.rule.AiTokenLimiterHandle"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/AiTokenLimiterEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.AiTokenLimiterEnum"
+    }, {
+      "path" : "shenyu-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-prompt/src/main/java/org/apache/shenyu/plugin/ai/prompt/AiPromptPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.prompt.AiPromptPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-prompt/src/main/java/org/apache/shenyu/plugin/ai/prompt/handler/AiPromptPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.prompt.handler.AiPromptPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/handler/AiProxyPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/strategy/AiModel.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.strategy.AiModel"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/strategy/AiModelFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.strategy.AiModelFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/strategy/openai/OpenAI.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.strategy.openai.OpenAI"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/AiTokenLimiterPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.AiTokenLimiterPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/handler/AiTokenLimiterPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.handler.AiTokenLimiterPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/RedisConfigProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.RedisConfigProperties"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/RedisConnectionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.RedisConnectionFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/ShenyuReactiveRedisTemplate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.ShenyuReactiveRedisTemplate"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/ShenyuReactiveScriptExecutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.ShenyuReactiveScriptExecutor"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/serializer/ByteArrayRedisSerializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.serializer.ByteArrayRedisSerializer"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/serializer/ShenyuRedisSerializationContext.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.serializer.ShenyuRedisSerializationContext"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/resources/META-INF/scripts/check-limit.lua",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/resources/META-INF/scripts/increment-token.lua",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/config/AiCommonConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.config.AiCommonConfig"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/strategy/AiModel.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.AiModel"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/strategy/AiModelFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.AiModelFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/strategy/openai/OpenAI.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.openai.OpenAI"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/src/main/java/org/apache/shenyu/plugin/ai/prompt/AiPromptPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.prompt.AiPromptPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/src/main/java/org/apache/shenyu/plugin/ai/prompt/handler/AiPromptPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.prompt.handler.AiPromptPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/handler/AiProxyPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/AiTokenLimiterPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.AiTokenLimiterPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/handler/AiTokenLimiterPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.handler.AiTokenLimiterPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/RedisConfigProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.RedisConfigProperties"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/RedisConnectionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.RedisConnectionFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/ShenyuReactiveRedisTemplate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.ShenyuReactiveRedisTemplate"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/ShenyuReactiveScriptExecutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.ShenyuReactiveScriptExecutor"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/serializer/ByteArrayRedisSerializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.serializer.ByteArrayRedisSerializer"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/serializer/ShenyuRedisSerializationContext.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.serializer.ShenyuRedisSerializationContext"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/result/ShenyuResultEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.api.result.ShenyuResultEnum"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ae1702bcfaf2d4b595becff9e3b683d785d9eece",
+    "headCommit" : "d5acd11f0194a59f0aed8992c4166ddc325853d7",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/UpstreamCheckService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.UpstreamCheckService"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d5acd11f0194a59f0aed8992c4166ddc325853d7",
+    "headCommit" : "532461ede0f5a8e0e8460de8219f3bdd9cca36d7",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/CustomRetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.CustomRetryStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/DefaultRetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.DefaultRetryStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/ExponentialRetryBackoffStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.ExponentialRetryBackoffStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/FixedRetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.FixedRetryStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/RetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.RetryStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "532461ede0f5a8e0e8460de8219f3bdd9cca36d7",
+    "headCommit" : "bb269ff41dc487f0d58ca8860b2ec91eb33f5391",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bb269ff41dc487f0d58ca8860b2ec91eb33f5391",
+    "headCommit" : "cc28137c34373c0ee5d9cde4c74048822b1ab9c8",
+    "changedFiles" : [ {
+      "path" : "shenyu-dist/shenyu-admin-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cc28137c34373c0ee5d9cde4c74048822b1ab9c8",
+    "headCommit" : "37ec999f9b682e8d47ca9b02fa5f251d776f5463",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-alert/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-api-docs-annotations/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-autoconfig/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-disruptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-docker-compose-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-src-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-annotation/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-dubbo-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-eureka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http-swagger3/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-https/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc-tomcat/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-annotation-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-native-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-reactive-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-combination/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-https/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-spring-cloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-custom-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-integrated-test-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-integrated-test-upload-plugin-case/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-kubernetes-controller/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-loadbalancer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-handler/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-memory/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-spi/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-context-path/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-hystrix/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-resilience4j/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-sentinel/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-global/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-console/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-desensitize-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-huawei-lts/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-pulsar/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rocketmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-tencent-cls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-metrics/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mock/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-modify-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-param-mapping/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-general-context/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-transform/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-redirect/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-request/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-basic-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-casdoor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-cryptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-key-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-oauth2/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-sign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-uri/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-waf/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-eureka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-kubernetes/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-okhttp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-spring/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spi/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-spring-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-k8s/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-basic-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-casdoor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-context-path/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cryptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-divide/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-general-context/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-global/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-hystrix/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-jwt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-key-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-aliyun-sls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-clickhouse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-console/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-elasticsearch/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-huawei-lts/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-kafka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-pulsar/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rabbitmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rocketmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-tencent-cls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-metrics/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mock/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-modify-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-oauth2/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-param-mapping/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ratelimiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-redirect/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-resilience4j/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sentinel/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-transform/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-uri/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-waf/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-registry/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-web/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "37ec999f9b682e8d47ca9b02fa5f251d776f5463",
+    "headCommit" : "b4e89433053741bc5bb3938fc15b50153512fcda",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-alert/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-api-docs-annotations/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-autoconfig/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-disruptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-docker-compose-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-src-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-annotation/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-dubbo-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-eureka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http-swagger3/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-https/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc-tomcat/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-annotation-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-native-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-reactive-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-combination/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-https/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-spring-cloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-custom-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-integrated-test-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-integrated-test-upload-plugin-case/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-kubernetes-controller/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-loadbalancer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-handler/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-memory/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-spi/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-context-path/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-hystrix/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-resilience4j/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-sentinel/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-global/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-console/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-desensitize-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-huawei-lts/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-pulsar/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rocketmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-tencent-cls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-metrics/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mock/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-modify-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-param-mapping/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-general-context/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-transform/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-redirect/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-request/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-basic-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-casdoor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-cryptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-key-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-oauth2/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-sign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-uri/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-waf/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-eureka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-kubernetes/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-okhttp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-spring/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spi/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-spring-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-k8s/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-basic-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-casdoor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-context-path/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cryptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-divide/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-general-context/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-global/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-hystrix/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-jwt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-key-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-aliyun-sls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-clickhouse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-console/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-elasticsearch/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-huawei-lts/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-kafka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-pulsar/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rabbitmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rocketmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-tencent-cls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-metrics/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mock/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-modify-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-oauth2/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-param-mapping/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ratelimiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-redirect/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-resilience4j/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sentinel/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-transform/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-uri/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-waf/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-registry/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-web/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b4e89433053741bc5bb3938fc15b50153512fcda",
+    "headCommit" : "3aba6bce38c42fd707cd6a07ebfebdafdd308d13",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/manager/impl/LoadServiceDocEntryImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.manager.impl.LoadServiceDocEntryImpl"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3aba6bce38c42fd707cd6a07ebfebdafdd308d13",
+    "headCommit" : "b87557bd20120fbf5d459afb614c85f29145de58",
+    "changedFiles" : [ {
+      "path" : "README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b87557bd20120fbf5d459afb614c85f29145de58",
+    "headCommit" : "1968aded218d61b0627cc083e3bf996ce0913411",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1968aded218d61b0627cc083e3bf996ce0913411",
+    "headCommit" : "0cb6c2591b5fd504bfc7e39446b54d4fed0bb9b7",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0cb6c2591b5fd504bfc7e39446b54d4fed0bb9b7",
+    "headCommit" : "2454b94784207fd4db91ed77e59b392e4f7fa4b9",
+    "changedFiles" : [ {
+      "path" : "README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2454b94784207fd4db91ed77e59b392e4f7fa4b9",
+    "headCommit" : "6898a9282e41dc69a21d0b889b7e0f5c872d6cc5",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/AiTokenLimiterPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.AiTokenLimiterPlugin"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6898a9282e41dc69a21d0b889b7e0f5c872d6cc5",
+    "headCommit" : "9529642022c0ebf9f829631811f6798b8f5f3b9f",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/support/ResponseDecorator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.support.ResponseDecorator"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9529642022c0ebf9f829631811f6798b8f5f3b9f",
+    "headCommit" : "1df7ac815e8eb578bb23513240eb6dd8018d71f3",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/plugin/AiRequestTransformerConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.plugin.AiRequestTransformerConfig"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/rule/AiRequestTransformerHandle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.rule.AiRequestTransformerHandle"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.PluginEnum"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/spring/ai/AiModelFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.spring.ai.AiModelFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/spring/ai/factory/DeepSeekModelFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.spring.ai.factory.DeepSeekModelFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/spring/ai/factory/OpenAiModelFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.spring.ai.factory.OpenAiModelFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/spring/ai/registry/AiModelFactoryRegistry.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.spring.ai.registry.AiModelFactoryRegistry"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/AiRequestTransformerPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.AiRequestTransformerPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/cache/ChatClientCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.cache.ChatClientCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/handler/AiRequestTransformerPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.handler.AiRequestTransformerPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/template/AiRequestTransformerTemplate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.template.AiRequestTransformerTemplate"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-request-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/springboot/starter/plugin/ai/transformer/request/AiRequestTransformerPluginConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.ai.transformer.request.AiRequestTransformerPluginConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-request-transformer/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-request-transformer/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-request-transformer/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1df7ac815e8eb578bb23513240eb6dd8018d71f3",
+    "headCommit" : "374d7d11523c6eb34063c8faf638d0ab33210884",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/handler/AiRequestTransformerPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.handler.AiRequestTransformerPluginHandler"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "374d7d11523c6eb34063c8faf638d0ab33210884",
+    "headCommit" : "70f67f6036e778f84fb6a134c1e0b517b1663901",
+    "changedFiles" : [ {
+      "path" : "RELEASE-NOTES.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mock/src/test/java/org/apache/shenyu/plugin/mock/generator/RandomDoubleGeneratorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mock.generator.RandomDoubleGeneratorTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "70f67f6036e778f84fb6a134c1e0b517b1663901",
+    "headCommit" : "667f88fcd74563dd9693449e56152629ffc2642b",
+    "changedFiles" : [ {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/compose/shenyu-kafka-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "667f88fcd74563dd9693449e56152629ffc2642b",
+    "headCommit" : "5dfa3d11986ba2620d683c4f3cbe1f0f6d7ad7c1",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5dfa3d11986ba2620d683c4f3cbe1f0f6d7ad7c1",
+    "headCommit" : "ff289b43eb0b51edcd58a9dc72ba53ca315c57ca",
+    "changedFiles" : [ {
+      "path" : ".gitignore",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.6.1-upgrade-2.7.0-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/InstanceController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.InstanceController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/disruptor/subscriber/URIRegisterExecutorSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.disruptor.subscriber.URIRegisterExecutorSubscriber"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/InstanceInfoMapper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.InstanceInfoMapper"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/InstanceInfoDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.InstanceInfoDTO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/InstanceInfoDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.InstanceInfoDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/query/InstanceQuery.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.query.InstanceQuery"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/query/InstanceQueryCondition.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.query.InstanceQueryCondition"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/InstanceInfoVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.InstanceInfoVO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/InstanceInfoService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.InstanceInfoService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/InstanceInfoServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.InstanceInfoServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/application-mysql.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/instance-info-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/meta-data-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/disruptor/subcriber/ShenyuClientURIExecutorSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriber"
+    }, {
+      "path" : "shenyu-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/InstanceTypeConstants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.InstanceTypeConstants"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/utils/SystemInfoUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.SystemInfoUtils"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/type/DataType.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.common.type.DataType"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ff289b43eb0b51edcd58a9dc72ba53ca315c57ca",
+    "headCommit" : "03d3d1cc63124c64b44ece62af500032ab13ff96",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/main/java/org/apache/shenyu/plugin/logging/rabbitmq/config/RabbitmqLogCollectConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.config.RabbitmqLogCollectConfig"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plugin/logging/rabbitmq/LoggingRabbitmqPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.LoggingRabbitmqPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plugin/logging/rabbitmq/client/RabbitmqLogCollectClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.client.RabbitmqLogCollectClientTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plugin/logging/rabbitmq/collector/RabbitmqLogCollectorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.collector.RabbitmqLogCollectorTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plugin/logging/rabbitmq/config/RabbitmqLogCollectConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.config.RabbitmqLogCollectConfigTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plugin/logging/rabbitmq/handler/LoggingRabbitmqPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.handler.LoggingRabbitmqPluginDataHandlerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plulgin/logging/rabbitmq/LoggingRabbitmqPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plulgin.logging.rabbitmq.LoggingRabbitmqPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plulgin/logging/rabbitmq/client/RabbitmqLogCollectClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plulgin.logging.rabbitmq.client.RabbitmqLogCollectClientTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plulgin/logging/rabbitmq/collector/RabbitmqLogCollectorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plulgin.logging.rabbitmq.collector.RabbitmqLogCollectorTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plulgin/logging/rabbitmq/config/RabbitmqLogCollectConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plulgin.logging.rabbitmq.config.RabbitmqLogCollectConfigTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plulgin/logging/rabbitmq/handler/LoggingRabbitmqPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plulgin.logging.rabbitmq.handler.LoggingRabbitmqPluginDataHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "03d3d1cc63124c64b44ece62af500032ab13ff96",
+    "headCommit" : "9ac8659040e83a4b7c85d3c3aab632b3a380e275",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/ApacheDubboPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.ApacheDubboPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/cache/ApacheDubboConfigCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.cache.ApacheDubboConfigCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/handler/ApacheDubboMetaDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.handler.ApacheDubboMetaDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/handler/ApacheDubboPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.handler.ApacheDubboPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/proxy/ApacheDubboProxyService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.proxy.ApacheDubboProxyService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/test/java/org/apache/shenyu/plugin/apache/dubbo/proxy/ApacheDubboProxyServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.proxy.ApacheDubboProxyServiceTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/src/main/java/org/apache/shenyu/plugin/dubbo/common/handler/AbstractDubboMetaDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.dubbo.common.handler.AbstractDubboMetaDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/src/main/java/org/apache/shenyu/plugin/dubbo/common/handler/AbstractDubboPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.dubbo.common.handler.AbstractDubboPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/src/test/java/org/apache/shenyu/plugin/dubbo/common/handler/AbstractDubboPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.dubbo.common.handler.AbstractDubboPluginDataHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9ac8659040e83a4b7c85d3c3aab632b3a380e275",
+    "headCommit" : "cf7915992b6939523ede8a51f10ce7b79d4b1c55",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPlugin"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cf7915992b6939523ede8a51f10ce7b79d4b1c55",
+    "headCommit" : "602123b4c77582268227c9b7a7a75f6d5ec16ba7",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ProxySelectorServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.ProxySelectorServiceImpl"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "602123b4c77582268227c9b7a7a75f6d5ec16ba7",
+    "headCommit" : "f69767e4d71a828357991d3235f47f1c9cc210f4",
+    "changedFiles" : [ {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/springboot/starter/plugin/ai/transformer/request/AiRequestTransformerPluginConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.ai.transformer.request.AiRequestTransformerPluginConfiguration"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f69767e4d71a828357991d3235f47f1c9cc210f4",
+    "headCommit" : "fe7545c7bce14cce87d233326b9ac367a9a4db86",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "fe7545c7bce14cce87d233326b9ac367a9a4db86",
+    "headCommit" : "b38315977f35d106994491253cd428c8220b7387",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/resources/application-mysql.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b38315977f35d106994491253cd428c8220b7387",
+    "headCommit" : "e2cb6f3abc37bd9c1559f425cc991f8e0fbfa730",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/config/ShenyuConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.config.ShenyuConfig"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.PluginEnum"
+    }, {
+      "path" : "shenyu-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.cache.CommonPluginDataSubscriber"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/utils/ServerWebExchangeUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.utils.ServerWebExchangeUtils"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/McpServerPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.McpServerPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallback"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/definition/ShenyuToolDefinition.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.definition.ShenyuToolDefinition"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/handler/McpServerPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.handler.McpServerPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/holder/ShenyuMcpExchangeHolder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.holder.ShenyuMcpExchangeHolder"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/manager/ShenyuMcpServerManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.manager.ShenyuMcpServerManager"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/model/McpServerToolParameter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.model.McpServerToolParameter"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/model/ShenyuMcpServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.model.ShenyuMcpServer"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/model/ShenyuMcpServerTool.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.model.ShenyuMcpServerTool"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/request/BodyWriterExchange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.BodyWriterExchange"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/request/RequestConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.RequestConfig"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/request/RequestConfigHelper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.RequestConfigHelper"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/response/ShenyuMcpResponseDecorator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.response.ShenyuMcpResponseDecorator"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/session/McpSessionHelper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.session.McpSessionHelper"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/ShenyuSseServerTransportProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.ShenyuSseServerTransportProvider"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/SseEventFormatter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.SseEventFormatter"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/utils/JsonSchemaUtil.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.utils.JsonSchemaUtil"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-param-mapping/src/main/java/org/apache/shenyu/plugin/param/mapping/strategy/FormDataOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.param.mapping.strategy.FormDataOperator"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-param-mapping/src/main/java/org/apache/shenyu/plugin/param/mapping/strategy/JsonOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.param.mapping.strategy.JsonOperator"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mcp-server/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mcp-server/src/main/java/org/apache/shenyu/springboot/starter/plugin/mcp/server/McpServerPluginConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.mcp.server.McpServerPluginConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mcp-server/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mcp-server/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mcp-server/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-web/src/main/java/org/apache/shenyu/web/filter/FileSizeFilter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.filter.FileSizeFilter"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e2cb6f3abc37bd9c1559f425cc991f8e0fbfa730",
+    "headCommit" : "e40e30cd2d0e8a38330b81ecbf9645e992bf5ac6",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e40e30cd2d0e8a38330b81ecbf9645e992bf5ac6",
+    "headCommit" : "13c70320e708569a6fc95dde61f70db99c6183b1",
+    "changedFiles" : [ {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/strategy/openai/OpenAI.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.openai.OpenAI"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/AiTokenLimiterPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.AiTokenLimiterPlugin"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "13c70320e708569a6fc95dde61f70db99c6183b1",
+    "headCommit" : "2627a1251917ac4324cfadef397506509d2f0944",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/ConfigsExportImportController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.ConfigsExportImportController"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2627a1251917ac4324cfadef397506509d2f0944",
+    "headCommit" : "aca751ae9ae1e075c66d5441956aff09da3efd53",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/config/HttpUtilsConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.HttpUtilsConfiguration"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/SwaggerImportController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.SwaggerImportController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/SwaggerImportRequest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.SwaggerImportRequest"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/SwaggerImportService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.SwaggerImportService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SwaggerImportServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/manager/impl/SwaggerDocParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.manager.impl.SwaggerDocParser"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/utils/UrlSecurityUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.UrlSecurityUtils"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.2a428c0d.css",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.7892d888.css",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.c72b2a38.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.db384a79.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.html",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/SwaggerImportServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.SwaggerImportServiceTest"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/SwaggerVersion.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.SwaggerVersion"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "aca751ae9ae1e075c66d5441956aff09da3efd53",
+    "headCommit" : "7de25587883c26ce9e55f2c37d551a2308679ba6",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/MCP_TOOL_EXAMPLES.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/MCP_TOOL_EXAMPLES_EN.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/McpServerPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.McpServerPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallback"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/handler/McpServerPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.handler.McpServerPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/manager/ShenyuMcpServerManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.manager.ShenyuMcpServerManager"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/request/BodyWriterExchange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.BodyWriterExchange"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/request/ParameterFormatter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.ParameterFormatter"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/request/RequestConfigHelper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.RequestConfigHelper"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/response/NonCommittingMcpResponseDecorator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.response.NonCommittingMcpResponseDecorator"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/MessageHandlingResult.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.MessageHandlingResult"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/ShenyuStreamableHttpServerTransportProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.ShenyuStreamableHttpServerTransportProvider"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/StreamableHttpProviderBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.StreamableHttpProviderBuilder"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/utils/JsonSchemaUtil.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.utils.JsonSchemaUtil"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7de25587883c26ce9e55f2c37d551a2308679ba6",
+    "headCommit" : "8f65ce09475dd41315b95428febc3baf4e927fad",
+    "changedFiles" : [ {
+      "path" : "shenyu-infra/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/main/java/org/apache/shenyu/infra/etcd/config/EtcdConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.config.EtcdConfig"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/test/java/org/apache/shenyu/infra/etcd/EtcdTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.EtcdTests"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/src/main/java/org/apache/shenyu/infra/nacos/config/NacosACMConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.nacos.config.NacosACMConfig"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/src/main/java/org/apache/shenyu/infra/nacos/config/NacosConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.nacos.config.NacosConfig"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/src/test/java/org/apache/shenyu/infra/nacos/NacosTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.nacos.NacosTests"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-x-module/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-x-module/src/main/java/org/apache/shenyu/infra/x/XConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.x.XConfig"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-x-module/src/test/java/org/apache/shenyu/infra/x/XTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.x.XTests"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/main/java/org/apache/shenyu/infra/zookeeper/ZookeeperConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.zookeeper.ZookeeperConfig"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/test/java/org/apache/shenyu/infra/zookeeper/ZookeeperTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.zookeeper.ZookeeperTests"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8f65ce09475dd41315b95428febc3baf4e927fad",
+    "headCommit" : "0eaec1e63adef81d0bd5d8797f0e907778abcfea",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/handler/AiProxyPluginHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0eaec1e63adef81d0bd5d8797f0e907778abcfea",
+    "headCommit" : "9c8b78f782f95efb646bf3ad231d745b112fd7cd",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/ApiController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.ApiController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DashboardUserController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.DashboardUserController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DiscoveryController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.DiscoveryController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DiscoveryUpstreamController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.DiscoveryUpstreamController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/PluginController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.PluginController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/PluginHandleController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.PluginHandleController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/ProxySelectorController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.ProxySelectorController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/ResourceController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.ResourceController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/RoleController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.RoleController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/RuleController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.RuleController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/SelectorController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.SelectorController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/ShenyuDictController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.ShenyuDictController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/TagController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.TagController"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9c8b78f782f95efb646bf3ad231d745b112fd7cd",
+    "headCommit" : "d782a64e874d2ac1737d4509db4bffdc91844f28",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/e2e-k8s.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d782a64e874d2ac1737d4509db4bffdc91844f28",
+    "headCommit" : "319ca4fd9f824625ec609284d390f0236cdb3722",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/test/java/org/apache/shenyu/plugin/ai/common/spring/ai/factory/DeepSeekModelFactoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.spring.ai.factory.DeepSeekModelFactoryTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/test/java/org/apache/shenyu/plugin/ai/common/spring/ai/factory/OpenAiModelFactoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.spring.ai.factory.OpenAiModelFactoryTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/test/java/org/apache/shenyu/plugin/ai/common/spring/ai/registry/AiModelFactoryRegistryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.spring.ai.registry.AiModelFactoryRegistryTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/test/java/org/apache/shenyu/plugin/ai/common/strategy/AiModelFactoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.AiModelFactoryTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/test/java/org/apache/shenyu/plugin/ai/common/strategy/openai/OpenAITest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.openai.OpenAITest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "319ca4fd9f824625ec609284d390f0236cdb3722",
+    "headCommit" : "d0745961538abbcad9e60547f5aed181e00f29bb",
+    "changedFiles" : [ {
+      "path" : "shenyu-examples/shenyu-examples-http/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d0745961538abbcad9e60547f5aed181e00f29bb",
+    "headCommit" : "4f9e69c54f1f2abf67bb87d4abd8f612dad342b8",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/src/test/java/org/apache/shenyu/plugin/ai/prompt/AiPromptPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.prompt.AiPromptPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/src/test/java/org/apache/shenyu/plugin/ai/prompt/handler/AiPromptPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.prompt.handler.AiPromptPluginDataHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4f9e69c54f1f2abf67bb87d4abd8f612dad342b8",
+    "headCommit" : "7c1e43bf6fb8477352e7fb7f236255545f33e362",
+    "changedFiles" : [ {
+      "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/utils/AesUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.AesUtilsTest"
+    }, {
+      "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/utils/NamespaceIDUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.NamespaceIDUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7c1e43bf6fb8477352e7fb7f236255545f33e362",
+    "headCommit" : "85307386b9f3412a5afc6c504fc10bf64c859892",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/AiRequestTransformerPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.AiRequestTransformerPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/cache/ChatClientCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.cache.ChatClientCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/handler/AiRequestTransformerPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.handler.AiRequestTransformerPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/request/AiRequestTransformerPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.AiRequestTransformerPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/request/cache/ChatClientCacheTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.cache.ChatClientCacheTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/request/handler/AiRequestTransformerPluginHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.handler.AiRequestTransformerPluginHandlerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/request/template/AiRequestTransformerTemplateTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.template.AiRequestTransformerTemplateTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "85307386b9f3412a5afc6c504fc10bf64c859892",
+    "headCommit" : "15278cf6e66ec2b42023af21ba85538dbdeb64d0",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/AiRequestTransformerPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.AiRequestTransformerPlugin"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "15278cf6e66ec2b42023af21ba85538dbdeb64d0",
+    "headCommit" : "0933a2c450b4ad3c5d17284417ac026d8f0d6c27",
+    "changedFiles" : [ {
+      "path" : "shenyu-disruptor/src/test/java/org/apache/shenyu/disruptor/DisruptorProviderManagerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.disruptor.DisruptorProviderManagerTest"
+    }, {
+      "path" : "shenyu-disruptor/src/test/java/org/apache/shenyu/disruptor/consumer/QueueConsumerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.disruptor.consumer.QueueConsumerTest"
+    }, {
+      "path" : "shenyu-disruptor/src/test/java/org/apache/shenyu/disruptor/provider/DisruptorProviderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.disruptor.provider.DisruptorProviderTest"
+    }, {
+      "path" : "shenyu-disruptor/src/test/java/org/apache/shenyu/disruptor/thread/DisruptorThreadFactoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.disruptor.thread.DisruptorThreadFactoryTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0933a2c450b4ad3c5d17284417ac026d8f0d6c27",
+    "headCommit" : "1b245d325d3edb20bad33c3ae901eb46947b7183",
+    "changedFiles" : [ {
+      "path" : "shenyu-disruptor/src/main/java/org/apache/shenyu/disruptor/common/Data.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.disruptor.common.Data"
+    }, {
+      "path" : "shenyu-disruptor/src/main/java/org/apache/shenyu/disruptor/consumer/QueueConsumerExecutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.disruptor.consumer.QueueConsumerExecutor"
+    }, {
+      "path" : "shenyu-disruptor/src/main/java/org/apache/shenyu/disruptor/event/DataEvent.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.disruptor.event.DataEvent"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1b245d325d3edb20bad33c3ae901eb46947b7183",
+    "headCommit" : "bbd14bbda87a252639b840a89b8e736de3e9fa94",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/src/main/java/org/apache/shenyu/admin/config/EtcdSyncConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.EtcdSyncConfiguration"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/src/main/java/org/apache/shenyu/admin/config/properties/EtcdProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.EtcdProperties"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/src/main/java/org/apache/shenyu/admin/listener/etcd/EtcdClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.etcd.EtcdClient"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/src/main/java/org/apache/shenyu/admin/listener/etcd/EtcdDataChangedInit.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.etcd.EtcdDataChangedInit"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/src/main/java/org/apache/shenyu/admin/listener/etcd/EtcdDataDataChangedListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.etcd.EtcdDataDataChangedListener"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/src/test/java/org/apache/shenyu/admin/config/EtcdSyncConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.EtcdSyncConfigurationTest"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/src/test/java/org/apache/shenyu/admin/config/properties/EtcdPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.EtcdPropertiesTest"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/src/test/java/org/apache/shenyu/admin/listener/etcd/EtcdClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.etcd.EtcdClientTest"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/src/test/java/org/apache/shenyu/admin/listener/etcd/EtcdDataChangedInitTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.etcd.EtcdDataChangedInitTest"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/src/test/java/org/apache/shenyu/admin/listener/etcd/EtcdDataDataChangedListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.etcd.EtcdDataDataChangedListenerTest"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-nacos/src/main/java/org/apache/shenyu/admin/config/NacosSyncConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.NacosSyncConfiguration"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-nacos/src/main/java/org/apache/shenyu/admin/config/properties/NacosProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.NacosProperties"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-nacos/src/test/java/org/apache/shenyu/admin/config/NacosSyncConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.NacosSyncConfigurationTest"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-nacos/src/test/java/org/apache/shenyu/admin/config/properties/NacosPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.NacosPropertiesTest"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/ShenyuModuleConstants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.ShenyuModuleConstants"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-common/src/main/java/org/apache/shenyu/infra/common/InfraConstants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.common.InfraConstants"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-common/src/main/java/org/apache/shenyu/infra/common/InfraParentProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.common.InfraParentProperties"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/main/java/org/apache/shenyu/infra/etcd/autoconfig/ConditionOnSyncEtcd.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.autoconfig.ConditionOnSyncEtcd"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/main/java/org/apache/shenyu/infra/etcd/autoconfig/EtcdConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.autoconfig.EtcdConfiguration"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/main/java/org/apache/shenyu/infra/etcd/autoconfig/EtcdProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.autoconfig.EtcdProperties"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/main/java/org/apache/shenyu/infra/etcd/client/EtcdClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.client.EtcdClient"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/main/java/org/apache/shenyu/infra/etcd/config/EtcdConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.config.EtcdConfig"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/test/java/org/apache/shenyu/infra/etcd/EtcdTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.EtcdTests"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/src/main/java/org/apache/shenyu/infra/nacos/autoconfig/ConditionOnSyncNacos.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.nacos.autoconfig.ConditionOnSyncNacos"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/src/main/java/org/apache/shenyu/infra/nacos/autoconfig/NacosProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.nacos.autoconfig.NacosProperties"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/src/main/java/org/apache/shenyu/infra/nacos/config/NacosACMConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.nacos.config.NacosACMConfig"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/src/main/java/org/apache/shenyu/infra/nacos/config/NacosConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.nacos.config.NacosConfig"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/src/test/java/org/apache/shenyu/infra/nacos/NacosTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.nacos.NacosTests"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/src/test/java/org/apache/shenyu/infra/nacos/config/NacosACMConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.nacos.config.NacosACMConfigTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/src/test/java/org/apache/shenyu/infra/nacos/config/NacosConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.nacos.config.NacosConfigTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/main/java/org/apache/shenyu/infra/redis/RedisConfigProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.RedisConfigProperties"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/main/java/org/apache/shenyu/infra/redis/RedisConnectionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.RedisConnectionFactory"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/main/java/org/apache/shenyu/infra/redis/RedisProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.RedisProperties"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/main/java/org/apache/shenyu/infra/redis/ShenyuReactiveRedisTemplate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.ShenyuReactiveRedisTemplate"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/main/java/org/apache/shenyu/infra/redis/ShenyuReactiveScriptExecutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.ShenyuReactiveScriptExecutor"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/main/java/org/apache/shenyu/infra/redis/serializer/ByteArrayRedisSerializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.serializer.ByteArrayRedisSerializer"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/main/java/org/apache/shenyu/infra/redis/serializer/ShenyuRedisSerializationContext.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.serializer.ShenyuRedisSerializationContext"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/test/java/org/apache/shenyu/infra/redis/RedisConfigPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.RedisConfigPropertiesTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/test/java/org/apache/shenyu/infra/redis/RedisConnectionFactoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.RedisConnectionFactoryTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/test/java/org/apache/shenyu/infra/redis/RedisPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.RedisPropertiesTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/test/java/org/apache/shenyu/infra/redis/ShenyuRedisSerializationContextTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.ShenyuRedisSerializationContextTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/handler/AiTokenLimiterPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.handler.AiTokenLimiterPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/RedisConfigProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.RedisConfigProperties"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/RedisConnectionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.RedisConnectionFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/ShenyuReactiveRedisTemplate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.ShenyuReactiveRedisTemplate"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/ShenyuReactiveScriptExecutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.ShenyuReactiveScriptExecutor"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/serializer/ByteArrayRedisSerializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.serializer.ByteArrayRedisSerializer"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/serializer/ShenyuRedisSerializationContext.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.serializer.ShenyuRedisSerializationContext"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-handler/src/test/java/org/apache/shenyu/plugin/cache/CachePluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.CachePluginDataHandlerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/src/main/java/org/apache/shenyu/plugin/cache/redis/RedisCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.redis.RedisCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/src/main/java/org/apache/shenyu/plugin/cache/redis/RedisCacheBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.redis.RedisCacheBuilder"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/src/main/java/org/apache/shenyu/plugin/cache/redis/RedisConfigProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.redis.RedisConfigProperties"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/src/main/java/org/apache/shenyu/plugin/cache/redis/RedisConnectionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.redis.RedisConnectionFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/src/main/java/org/apache/shenyu/plugin/cache/redis/serializer/ByteArrayRedisSerializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.redis.serializer.ByteArrayRedisSerializer"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/src/main/java/org/apache/shenyu/plugin/cache/redis/serializer/ShenyuRedisSerializationContext.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.redis.serializer.ShenyuRedisSerializationContext"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/src/test/java/org/apache/shenyu/plugin/cache/redis/RedisCacheTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.redis.RedisCacheTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/src/test/java/org/apache/shenyu/plugin/cache/redis/RedisConfigPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.redis.RedisConfigPropertiesTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/src/test/java/org/apache/shenyu/plugin/cache/redis/RedisConnectionFactoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.redis.RedisConnectionFactoryTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/src/test/java/org/apache/shenyu/plugin/cache/redis/ShenyuRedisSerializationContextTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.redis.ShenyuRedisSerializationContextTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/java/org/apache/shenyu/plugin/ratelimiter/handler/RateLimiterPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ratelimiter.handler.RateLimiterPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/java/org/apache/shenyu/plugin/ratelimiter/handler/ShenyuReactiveRedisTemplate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ratelimiter.handler.ShenyuReactiveRedisTemplate"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/java/org/apache/shenyu/plugin/ratelimiter/handler/ShenyuReactiveScriptExecutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ratelimiter.handler.ShenyuReactiveScriptExecutor"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/test/java/org/apache/shenyu/plugin/ratelimiter/executor/RedisRateLimiterScriptsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ratelimiter.executor.RedisRateLimiterScriptsTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/test/java/org/apache/shenyu/plugin/ratelimiter/handler/RateLimiterPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ratelimiter.handler.RateLimiterPluginDataHandlerTest"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/src/main/java/org/apache/shenyu/registry/etcd/EtcdClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.etcd.EtcdClient"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/src/main/java/org/apache/shenyu/registry/etcd/EtcdInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.etcd.EtcdInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/src/test/java/org/apache/shenyu/registry/etcd/EtcdClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.etcd.EtcdClientTest"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/src/test/java/org/apache/shenyu/registry/etcd/EtcdInstanceRegisterRepositoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.etcd.EtcdInstanceRegisterRepositoryTest"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-etcd/src/main/java/org/apache/shenyu/springboot/sync/data/etcd/EtcdConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.sync.data.etcd.EtcdConfig"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-etcd/src/main/java/org/apache/shenyu/springboot/sync/data/etcd/EtcdSyncDataConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.sync.data.etcd.EtcdSyncDataConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-nacos/src/main/java/org/apache/shenyu/springboot/starter/sync/data/nacos/NacosSyncDataConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.sync.data.nacos.NacosSyncDataConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-nacos/src/test/java/org/apache/shenyu/springboot/starter/sync/data/nacos/NacosSyncDataConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.sync.data.nacos.NacosSyncDataConfigurationTest"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-etcd/src/main/java/org/apache/shenyu/sync/data/etcd/EtcdClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.etcd.EtcdClient"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-etcd/src/main/java/org/apache/shenyu/sync/data/etcd/EtcdSyncDataService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.etcd.EtcdSyncDataService"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-etcd/src/test/java/org/apache/shenyu/sync/data/etcd/EtcdClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.etcd.EtcdClientTest"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-etcd/src/test/java/org/apache/shenyu/sync/data/etcd/EtcdSyncDataServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.etcd.EtcdSyncDataServiceTest"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-nacos/src/main/java/org/apache/shenyu/sync/data/nacos/config/NacosACMConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.nacos.config.NacosACMConfig"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-nacos/src/main/java/org/apache/shenyu/sync/data/nacos/config/NacosConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.nacos.config.NacosConfig"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-nacos/src/test/java/org/apache/shenyu/sync/data/nacos/config/NacosACMConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.nacos.config.NacosACMConfigTest"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-nacos/src/test/java/org/apache/shenyu/sync/data/nacos/config/NacosConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.nacos.config.NacosConfigTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bbd14bbda87a252639b840a89b8e736de3e9fa94",
+    "headCommit" : "ff204b8ebf6c849b5c43aac01d5e95a0ea9224e6",
+    "changedFiles" : [ {
+      "path" : "shenyu-web/src/main/java/org/apache/shenyu/web/filter/LocalDispatcherFilter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.filter.LocalDispatcherFilter"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ff204b8ebf6c849b5c43aac01d5e95a0ea9224e6",
+    "headCommit" : "77f925def4a267ce5f0851ff7898e2f0747f4099",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/config/KubernetesConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.KubernetesConfiguration"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/spring/LocalDataSourceLoader.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.spring.LocalDataSourceLoader"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "77f925def4a267ce5f0851ff7898e2f0747f4099",
+    "headCommit" : "9c0124ccf55ca44d6957a2832ebc7005193138a6",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-nacos/src/test/java/org/apache/shenyu/admin/config/properties/AbstractConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.AbstractConfigurationTest"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-nacos/src/test/java/org/apache/shenyu/admin/config/properties/NacosPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.NacosPropertiesTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/src/test/java/org/apache/shenyu/infra/nacos/autoconfig/NacosPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.nacos.autoconfig.NacosPropertiesTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9c0124ccf55ca44d6957a2832ebc7005193138a6",
+    "headCommit" : "df133fc9501c9c799d7116ee1fd4f44157f29f13",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/AlertDispatchServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.AlertDispatchServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "df133fc9501c9c799d7116ee1fd4f44157f29f13",
+    "headCommit" : "e00098b2bff36117c991ba3b7d7ac69272a34fd0",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/src/test/java/org/apache/shenyu/admin/config/properties/EtcdPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.EtcdPropertiesTest"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/src/test/java/org/apache/shenyu/admin/listener/etcd/EtcdClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.etcd.EtcdClientTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/main/java/org/apache/shenyu/infra/etcd/autoconfig/EtcdConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.autoconfig.EtcdConfiguration"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/test/java/org/apache/shenyu/infra/etcd/autoconfig/EtcdPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.autoconfig.EtcdPropertiesTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/test/java/org/apache/shenyu/infra/etcd/client/EtcdClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.client.EtcdClientTest"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-etcd/src/test/java/org/apache/shenyu/sync/data/etcd/EtcdClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.etcd.EtcdClientTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e00098b2bff36117c991ba3b7d7ac69272a34fd0",
+    "headCommit" : "b829f1606aad66e97fafbf834f451b8350b4f79a",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/src/main/java/org/apache/shenyu/plugin/jwt/strategy/DefaultJwtConvertStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.jwt.strategy.DefaultJwtConvertStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/src/test/java/org/apache/shenyu/plugin/jwt/strategy/DefaultJwtConvertStrategyTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.jwt.strategy.DefaultJwtConvertStrategyTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b829f1606aad66e97fafbf834f451b8350b4f79a",
+    "headCommit" : "7d971dc52adc2c8f3d1b2d1223a765c3cabb0002",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/plugin/AiResponseTransformerConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.plugin.AiResponseTransformerConfig"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/rule/AiResponseTransformerHandle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.rule.AiResponseTransformerHandle"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.PluginEnum"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/utils/ResponseBodyCaptureUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.utils.ResponseBodyCaptureUtils"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/test/java/org/apache/shenyu/plugin/ai/common/utils/ResponseBodyCaptureUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.utils.ResponseBodyCaptureUtilsTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/response/AiResponseTransformerPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.response.AiResponseTransformerPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/response/cache/ChatClientCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.response.cache.ChatClientCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/response/handler/AiResponseTransformerPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.response.handler.AiResponseTransformerPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/response/template/AiResponseTransformerTemplate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.response.template.AiResponseTransformerTemplate"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/response/AiResponseTransformerPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.response.AiResponseTransformerPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/response/handler/AiResponseTransformerPluginHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.response.handler.AiResponseTransformerPluginHandlerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/response/template/AiResponseTransformerTemplateTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.response.template.AiResponseTransformerTemplateTest"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-response-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-response-transformer/src/main/java/org/apache/shenyu/springboot/starter/plugin/ai/transformer/response/AiResponseTransformerPluginConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.ai.transformer.response.AiResponseTransformerPluginConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-response-transformer/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-response-transformer/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-response-transformer/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7d971dc52adc2c8f3d1b2d1223a765c3cabb0002",
+    "headCommit" : "717cbe9f732a82a283c3da9e8c27b8985738f738",
+    "changedFiles" : [ {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/RoundRobinLoadBalanceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.RoundRobinLoadBalanceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "717cbe9f732a82a283c3da9e8c27b8985738f738",
+    "headCommit" : "ee6905711223e66676642168bb8763ff45e9306b",
+    "changedFiles" : [ {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ee6905711223e66676642168bb8763ff45e9306b",
+    "headCommit" : "d233ab4d451c8b5c3be685d83d213d1573c92cb2",
+    "changedFiles" : [ {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/utils/JsonUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.JsonUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d233ab4d451c8b5c3be685d83d213d1573c92cb2",
+    "headCommit" : "0a2b9f5eef2d3c71f5957571d50d4fa765d22eca",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/http/http-debug-registry-config-controller-api.http",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/RegistryController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.RegistryController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/RegistryMapper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.RegistryMapper"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/RegistryDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.RegistryDTO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/RegistryDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.RegistryDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/query/RegistryQuery.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.query.RegistryQuery"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/RegistryVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.RegistryVO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/RegistryService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.RegistryService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/RegistryServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.RegistryServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/RegistryTransfer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.transfer.RegistryTransfer"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/registry-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0a2b9f5eef2d3c71f5957571d50d4fa765d22eca",
+    "headCommit" : "e77f1f037cfae9cc57d95944caec5235cd4d0cd9",
+    "changedFiles" : [ {
+      "path" : "shenyu-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/utils/SystemInfoUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.SystemInfoUtils"
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e77f1f037cfae9cc57d95944caec5235cd4d0cd9",
+    "headCommit" : "c81ad832f0d2c582eb9e90bed639daa845949b8e",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/resources/static/index.b93e0e23.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.c72b2a38.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.html",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c81ad832f0d2c582eb9e90bed639daa845949b8e",
+    "headCommit" : "781e7222fe0ea8516747e32e420885e9c556fdb4",
+    "changedFiles" : [ {
+      "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/timer/TimerTaskListTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.timer.TimerTaskListTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "781e7222fe0ea8516747e32e420885e9c556fdb4",
+    "headCommit" : "69cd1d5721647a60007584983d96fc94452a4f6b",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-alert/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-api-docs-annotations/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-autoconfig/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-disruptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-docker-compose-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-src-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-annotation/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-dubbo-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-eureka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http-swagger3/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-https/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc-tomcat/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-annotation-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-native-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-reactive-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-x-module/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-combination/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-https/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-spring-cloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-custom-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-integrated-test-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-integrated-test-upload-plugin-case/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-kubernetes-controller/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-loadbalancer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-handler/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-memory/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-spi/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-context-path/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-hystrix/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-resilience4j/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-sentinel/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-global/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-console/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-desensitize-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-huawei-lts/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-pulsar/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rocketmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-tencent-cls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-metrics/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mock/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-modify-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-param-mapping/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-general-context/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-transform/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-redirect/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-request/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-basic-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-casdoor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-cryptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-key-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-oauth2/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-sign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-uri/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-waf/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-eureka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-kubernetes/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-okhttp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-spring/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spi/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-spring-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-k8s/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-request-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-response-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-basic-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-casdoor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-context-path/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cryptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-divide/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-general-context/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-global/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-hystrix/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-jwt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-key-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-aliyun-sls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-clickhouse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-console/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-elasticsearch/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-huawei-lts/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-kafka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-pulsar/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rabbitmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rocketmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-tencent-cls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mcp-server/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-metrics/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mock/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-modify-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-oauth2/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-param-mapping/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ratelimiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-redirect/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-resilience4j/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sentinel/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-transform/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-uri/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-waf/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-registry/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-web/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "69cd1d5721647a60007584983d96fc94452a4f6b",
+    "headCommit" : "caf382db580d8feb3cb51191aa6311f5777ee54f",
+    "changedFiles" : [ {
+      "path" : "shenyu-infra/shenyu-infra-nacos/src/test/java/org/apache/shenyu/infra/nacos/config/NacosConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.nacos.config.NacosConfigTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "caf382db580d8feb3cb51191aa6311f5777ee54f",
+    "headCommit" : "36d9fd2313cf1e44eb03a2ac6e88613d2f3e362c",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "36d9fd2313cf1e44eb03a2ac6e88613d2f3e362c",
+    "headCommit" : "9e8576a2aec00317076a18bb04933b4bfe42a366",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/java/org/apache/shenyu/plugin/ratelimiter/executor/RedisRateLimiter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ratelimiter.executor.RedisRateLimiter"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9e8576a2aec00317076a18bb04933b4bfe42a366",
+    "headCommit" : "eaa2f9503d4f213402f0ca8e1c3b9e9aef015a5d",
+    "changedFiles" : [ {
+      "path" : "shenyu-registry/shenyu-registry-etcd/src/test/java/org/apache/shenyu/registry/etcd/EtcdInstanceRegisterRepositoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.etcd.EtcdInstanceRegisterRepositoryTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "eaa2f9503d4f213402f0ca8e1c3b9e9aef015a5d",
+    "headCommit" : "0184d4b658729ac5e57fe74217461635f4295e41",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0184d4b658729ac5e57fe74217461635f4295e41",
+    "headCommit" : "cde3f548f7284fafd23ac8bb3c91ed716d4d9c51",
+    "changedFiles" : [ {
+      "path" : "shenyu-infra/shenyu-infra-nacos/src/main/java/org/apache/shenyu/infra/nacos/autoconfig/ConditionOnSyncNacos.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.nacos.autoconfig.ConditionOnSyncNacos"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-nacos/src/main/java/org/apache/shenyu/springboot/starter/sync/data/nacos/NacosSyncDataConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.sync.data.nacos.NacosSyncDataConfiguration"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cde3f548f7284fafd23ac8bb3c91ed716d4d9c51",
+    "headCommit" : "1f595adefabc529623c58565acafd7d7e9cbe74f",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallback"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/manager/ShenyuMcpServerManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.manager.ShenyuMcpServerManager"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/response/ShenyuMcpResponseDecorator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.response.ShenyuMcpResponseDecorator"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/McpServerPluginIntegrationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.McpServerPluginIntegrationTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/McpServerPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.McpServerPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallbackTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallbackTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/handler/McpServerPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.handler.McpServerPluginDataHandlerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/manager/ShenyuMcpServerManagerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.manager.ShenyuMcpServerManagerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/request/RequestConfigHelperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.RequestConfigHelperTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/utils/JsonSchemaUtilTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.utils.JsonSchemaUtilTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/resources/application-test.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1f595adefabc529623c58565acafd7d7e9cbe74f",
+    "headCommit" : "c25dc204c33f229ccc82cd23f4232f834ba0ba68",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/PluginServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.PluginServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/PluginServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.PluginServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c25dc204c33f229ccc82cd23f4232f834ba0ba68",
+    "headCommit" : "07453a26d20cd12a8997a331de2ffba5fe78d850",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/resources/static/index.7d0459c3.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.b93e0e23.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.html",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "07453a26d20cd12a8997a331de2ffba5fe78d850",
+    "headCommit" : "e624a19aae027361f309cb3e236d6345962ac811",
+    "changedFiles" : [ {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-api/src/main/java/org/apache/shenyu/sync/data/core/AbstractNodeDataSyncService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.core.AbstractNodeDataSyncService"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e624a19aae027361f309cb3e236d6345962ac811",
+    "headCommit" : "e4177b6c0e3e592a06f980b9025b90c5d1f909e8",
+    "changedFiles" : [ {
+      "path" : "shenyu-registry/shenyu-registry-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-api/src/test/java/org/apache/shenyu/registry/api/config/RegisterConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.api.config.RegisterConfigTest"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-api/src/test/java/org/apache/shenyu/registry/api/path/InstancePathConstantsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.api.path.InstancePathConstantsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e4177b6c0e3e592a06f980b9025b90c5d1f909e8",
+    "headCommit" : "d2705ef19d14630955e869e4f0479156a65a6e10",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/RegistryDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.RegistryDTO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/RegistryDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.RegistryDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/RegistryServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.RegistryServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/RegistryTransfer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.transfer.RegistryTransfer"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/registry-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d2705ef19d14630955e869e4f0479156a65a6e10",
+    "headCommit" : "161625cd7e4f4fba15267a0d943e6420f858031e",
+    "changedFiles" : [ {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-api/src/test/java/org/apache/shenyu/sync/data/core/AbstractNodeDataSyncServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.core.AbstractNodeDataSyncServiceTest"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-api/src/test/java/org/apache/shenyu/sync/data/core/AbstractPathDataSyncServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.core.AbstractPathDataSyncServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "161625cd7e4f4fba15267a0d943e6420f858031e",
+    "headCommit" : "7a36aab29e87f20652f2085e2ae8641b51827b67",
+    "changedFiles" : [ {
+      "path" : ".gitpod.Dockerfile",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : ".gitpod.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "changelog.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7a36aab29e87f20652f2085e2ae8641b51827b67",
+    "headCommit" : "f6a09ec9fb8c22d78eb2d3de0bec1e974f26bfaf",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/SelectorMapper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.SelectorMapper"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/SelectorDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.SelectorDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/event/selector/BatchSelectorDeletedEvent.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.event.selector.BatchSelectorDeletedEvent"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/event/selector/SelectorChangedEvent.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.event.selector.SelectorChangedEvent"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/DataPermissionPageVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.DataPermissionPageVO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/SelectorVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.SelectorVO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DiscoveryServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.DiscoveryServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DiscoveryUpstreamServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.DiscoveryUpstreamServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ProxySelectorServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.ProxySelectorServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SelectorServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SelectorServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/UpstreamCheckService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.UpstreamCheckService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.AbstractShenyuClientRegisterServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterDivideServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterGrpcServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterWebSocketServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterWebSocketServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/selector-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/SelectorMapperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.SelectorMapperTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/model/event/selector/BatchSelectorDeletedEventTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.event.selector.BatchSelectorDeletedEventTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/model/event/selector/SelectorChangedEventTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.event.selector.SelectorChangedEventTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/DiscoveryUpstreamServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.DiscoveryUpstreamServiceTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.UpstreamCheckServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f6a09ec9fb8c22d78eb2d3de0bec1e974f26bfaf",
+    "headCommit" : "fce9c8f01423eeed62f26f7ae4b1510577a95eb6",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/DiscoveryUpstreamDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.DiscoveryUpstreamDTO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/ProxySelectorAddDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.ProxySelectorAddDTO"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/discovery/DiscoveryProcessorHolderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.DiscoveryProcessorHolderTest"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/k8s/shenyu-nacos.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/compose/script/e2e-logging-kafka-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/ExponentialRetryBackoffStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.ExponentialRetryBackoffStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "fce9c8f01423eeed62f26f7ae4b1510577a95eb6",
+    "headCommit" : "cf0bbba7d6e7937a48dd9d4745bfa742f4468658",
+    "changedFiles" : [ {
+      "path" : "shenyu-registry/shenyu-registry-eureka/src/main/java/org/apache/shenyu/registry/eureka/EurekaInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.eureka.EurekaInstanceRegisterRepository"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cf0bbba7d6e7937a48dd9d4745bfa742f4468658",
+    "headCommit" : "da78f467d99d710bd2f4f529f3765e623a511b1c",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/RuleMapper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.RuleMapper"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/RuleDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.RuleDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/event/rule/BatchRuleDeletedEvent.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.event.rule.BatchRuleDeletedEvent"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/event/rule/RuleChangedEvent.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.event.rule.RuleChangedEvent"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/DataPermissionPageVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.DataPermissionPageVO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/RuleVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.RuleVO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/RuleServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.RuleServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/rule-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/RuleMapperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.RuleMapperTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "da78f467d99d710bd2f4f529f3765e623a511b1c",
+    "headCommit" : "1f913296a7a2bbbdce4f7331c6b20d8b49fe72d2",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/discovery/DiscoveryProcessorHolderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.DiscoveryProcessorHolderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1f913296a7a2bbbdce4f7331c6b20d8b49fe72d2",
+    "headCommit" : "1b9492bf266b84d320e339b41461223d7014374f",
+    "changedFiles" : [ {
+      "path" : "shenyu-registry/shenyu-registry-nacos/src/main/java/org/apache/shenyu/registry/nacos/NacosInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.nacos.NacosInstanceRegisterRepository"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1b9492bf266b84d320e339b41461223d7014374f",
+    "headCommit" : "5e90930a33ffc0644aa7d822bd1460df7a928cec",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.AbstractShenyuClientRegisterServiceImpl"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5e90930a33ffc0644aa7d822bd1460df7a928cec",
+    "headCommit" : "9234be312b213803bff9a1691ddf5afb82f41588",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/FallbackShenyuClientRegisterService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.FallbackShenyuClientRegisterService"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/FallbackShenyuClientRegisterServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.FallbackShenyuClientRegisterServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9234be312b213803bff9a1691ddf5afb82f41588",
+    "headCommit" : "89bbacd7de72f0bb4df0c032910ecab79ac6bd41",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/AppAuthMapper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.AppAuthMapper"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/TagDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.TagDTO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/TagDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.TagDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/event/role/BatchRoleDeletedEvent.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.event.role.BatchRoleDeletedEvent"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/event/role/RoleChangedEvent.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.event.role.RoleChangedEvent"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/event/role/RoleCreatedEvent.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.event.role.RoleCreatedEvent"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/query/TagQuery.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.query.TagQuery"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/TagVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.TagVO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AppAuthServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.AppAuthServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SelectorServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SelectorServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/TagServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.TagServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.AbstractShenyuClientRegisterServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/FallbackShenyuClientRegisterService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.FallbackShenyuClientRegisterService"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/tag-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/TagControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.TagControllerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/TagMapperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.TagMapperTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/TagServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.TagServiceTest"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/timer/AbstractRetryTask.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.timer.AbstractRetryTask"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "89bbacd7de72f0bb4df0c032910ecab79ac6bd41",
+    "headCommit" : "164ad635386e52f4edc1b2db398b44a9136932d7",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/model/McpServerToolParameter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.model.McpServerToolParameter"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/utils/JsonSchemaUtil.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.utils.JsonSchemaUtil"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/utils/JsonSchemaUtilTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.utils.JsonSchemaUtilTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "164ad635386e52f4edc1b2db398b44a9136932d7",
+    "headCommit" : "aed85167c2e84b9ad64db36dc74044619c30c8ca",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/resources/static/index.7d0459c3.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.88ba2307.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.html",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "aed85167c2e84b9ad64db36dc74044619c30c8ca",
+    "headCommit" : "21d66345d8061117c7d4952eb1e9df7a908c9b09",
+    "changedFiles" : [ {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/src/test/java/org/apache/shenyu/integrated/test/motan/MotanPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.motan.MotanPluginTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "21d66345d8061117c7d4952eb1e9df7a908c9b09",
+    "headCommit" : "6632d5e170d1dbb9c3a291fbb23c7a4c71e49da8",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.cache.CommonPluginDataSubscriber"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6632d5e170d1dbb9c3a291fbb23c7a4c71e49da8",
+    "headCommit" : "3e7df1cea3cff5a3e9e4f9e3262e82449e4eaf8e",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/selector/MotanUpstream.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.selector.MotanUpstream"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/MotanPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.MotanPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/cache/ApplicationConfigCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.cache.ApplicationConfigCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/handler/MotanMetaDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.handler.MotanMetaDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/handler/MotanPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.handler.MotanPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/proxy/MotanProxyService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.proxy.MotanProxyService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/test/java/org/apache/shenyu/plugin/motan/MotanPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.MotanPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/test/java/org/apache/shenyu/plugin/motan/proxy/MotanProxyServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.proxy.MotanProxyServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3e7df1cea3cff5a3e9e4f9e3262e82449e4eaf8e",
+    "headCommit" : "84060e37dfdeff978bd0861c640c527d4b0f3f35",
+    "changedFiles" : [ {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-websocket/src/test/java/org/apache/shenyue/e2e/testcase/websocket/WebSocketPluginCases.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyue.e2e.testcase.websocket.WebSocketPluginCases"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "84060e37dfdeff978bd0861c640c527d4b0f3f35",
+    "headCommit" : "67bde629907740261cf97ec2a4b1e11edfc3660f",
+    "changedFiles" : [ {
+      "path" : "shenyu-e2e/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-http/src/test/java/org/apache/shenyu/e2e/testcase/http/DividePluginCases.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.testcase.http.DividePluginCases"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/src/test/java/org/apache/shenyu/e2e/testcase/logging/kafka/DividePluginCases.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.testcase.logging.kafka.DividePluginCases"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "67bde629907740261cf97ec2a4b1e11edfc3660f",
+    "headCommit" : "b44103919b8f4a6c916e12af3e9c68dbb792c639",
+    "changedFiles" : [ {
+      "path" : ".github/filters.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "changelog.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.4.1-upgrade-2.4.2-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.4.2-upgrade-2.4.3-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.6.1-upgrade-2.7.0-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.6.1-upgrade-2.7.0-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-apollo/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-consul/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-nacos/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-polaris/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/config/HttpUtilsConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.HttpUtilsConfiguration"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/SwaggerImportController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.SwaggerImportController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/listener/DataChangedEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.listener.DataChangedEventListener"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/SwaggerImportRequest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.SwaggerImportRequest"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/scale/monitor/subject/cache/ScaleRuleCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.scale.monitor.subject.cache.ScaleRuleCache"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/scale/scaler/dynamic/TaskSchedulerManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.scale.scaler.dynamic.TaskSchedulerManager"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/SwaggerImportService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.SwaggerImportService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SwaggerImportServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/utils/UrlSecurityUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.UrlSecurityUtils"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/api-rule-relation-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/api-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/detail-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/field-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/model-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/scale-history-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/NamespacePluginRelMapperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.NamespacePluginRelMapperTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/SwaggerImportServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.SwaggerImportServiceTest"
+    }, {
+      "path" : "shenyu-alert/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/SwaggerVersion.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.SwaggerVersion"
+    }, {
+      "path" : "shenyu-common/src/test/resources/META-INF/services/org.apache.shenyu.common.utils.SpiInterface",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/src/main/resources/logback.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/resources/logback.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-h2.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-mysql.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-opengauss.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-postgres.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-nacos.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-etcd-eureka.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-etcd.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-http-eureka.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-http.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket-cluster-jdbc.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket-cluster-zookeeper.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket-eureka.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-zookeeper-eureka.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-zookeeper.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/k8s/script/init/opengauss_container_init.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/k8s/script/init/postgres_container_init.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/k8s/script/storage/storage_init_opengauss.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/k8s/script/storage/storage_init_postgres.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/k8s/shenyu-mysql.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/k8s/shenyu-opengauss.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/k8s/shenyu-postgres.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-cluster/k8s/shenyu-cluster-jdbc.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-cluster/k8s/shenyu-cluster-zookeeper.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-cluster/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-http/compose/shenyu-rocketmq-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-http/k8s/shenyu-rocketmq.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/compose/shenyu-kafka-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/k8s/shenyu-kafka.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-rocketmq/compose/shenyu-rocketmq-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-rocketmq/k8s/shenyu-kafka.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/k8s/shenyu-examples-eureka.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/compose/script/e2e-h2-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/compose/script/e2e-mysql-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/compose/script/e2e-opengauss-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/compose/script/e2e-postgres-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-app-service-h2.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-app-service-mysql.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-app-service-opengauss.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-app-service-postgres.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-deployment-h2.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-engine/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-common/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/src/main/resources/shenyu.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-grpc/src/main/resources/proto/stream.proto",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http/k8s/shenyu-deployment.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http/k8s/shenyu-service.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-https/src/main/resources/keystore.p12",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-provider/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-provider/src/main/resources/shenyu.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc-tomcat/src/main/http/http-test-api-local.http",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc-tomcat/src/main/http/http-test-api.http",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc-tomcat/src/main/resources/context/shenyu.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc-tomcat/src/main/resources/spring-mvc.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc/src/main/http/http-test-api-local.http",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc/src/main/http/http-test-api.http",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-tars/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-tars/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-annotation-websocket/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-http/config/broker.conf",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-https/script/services.list",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-https/src/main/resources/keystore.p12",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-apache-dubbo/deploy/kind-config.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-grpc/deploy/kind-config.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-http/deploy/kind-config.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/deploy/kind-config.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-sofa/deploy/kind-config.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-sofa/script/build_k8s_cluster.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-websocket/deploy/kind-config.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/script/services.list",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-http/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/resources/META-INF/shenyu/org.apache.shenyu.loadbalancer.spi.LoadBalancer",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/RoundRobinLoadBalanceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.RoundRobinLoadBalanceTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/resources/META-INF/shenyu/org.apache.shenyu.plugin.base.condition.data.ParameterData",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-memory/src/main/resources/META-INF/shenyu/org.apache.shenyu.plugin.cache.ICacheBuilder",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/resources/META-INF/scripts/concurrent_request_rate_limiter.lua",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/resources/META-INF/scripts/request_leaky_rate_limiter.lua",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/resources/META-INF/shenyu/org.apache.shenyu.plugin.ratelimiter.algorithm.RateLimiterAlgorithm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/src/main/resources/META-INF/shenyu/org.apache.shenyu.plugin.ratelimiter.resolver.RateLimiterKeyResolver",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-desensitize-api/src/main/resources/META-INF/shenyu/org.apache.shenyu.plugin.logging.desensitize.api.spi.ShenyuDataDesensitize",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/manager/ShenyuMcpServerManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.manager.ShenyuMcpServerManager"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/request/BodyWriterExchange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.BodyWriterExchange"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/request/ParameterFormatter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.ParameterFormatter"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/request/RequestConfigHelper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.RequestConfigHelper"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/response/NonCommittingMcpResponseDecorator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.response.NonCommittingMcpResponseDecorator"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/response/ShenyuMcpResponseDecorator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.response.ShenyuMcpResponseDecorator"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/session/McpSessionHelper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.session.McpSessionHelper"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/MessageHandlingResult.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.MessageHandlingResult"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/ShenyuStreamableHttpServerTransportProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.ShenyuStreamableHttpServerTransportProvider"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/SseEventFormatter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.SseEventFormatter"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/StreamableHttpProviderBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.StreamableHttpProviderBuilder"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/resources/META-INF/dubbo/org.apache.dubbo.common.threadpool.ThreadPool",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/resources/META-INF/dubbo/org.apache.dubbo.rpc.cluster.LoadBalance",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-cryptor/src/main/resources/META-INF/shenyu/org.apache.shenyu.plugin.cryptor.strategy.CryptorStrategy",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/src/main/java/org/apache/shenyu/plugin/jwt/strategy/DefaultJwtPayloadParseStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.jwt.strategy.DefaultJwtPayloadParseStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/src/main/resources/META-INF/shenyu/org.apache.shenyu.plugin.jwt.strategy.JwtConvertStrategy",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/src/main/resources/META-INF/shenyu/org.apache.shenyu.plugin.jwt.strategy.JwtPayloadParseStrategy",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/src/test/resources/META-INF/shenyu/org.apache.shenyu.plugin.jwt.strategy.JwtConvertStrategy",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/src/test/resources/org.apache.shenyu.plugin.wasm.api.AbstractWasmPluginTest$RustWasmPlugin.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/resources/org.apache.shenyu.plugin.wasm.base.AbstractShenyuWasmPluginTest$TestShenyuWasmPlugin.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/resources/org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmDiscoveryHandlerTest$TestWasmPluginDiscoveryHandler.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/resources/org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmMetaDataHandlerTest$TestWasmMetaDataHandler.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/resources/org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmPluginDataHandlerTest$TestWasmPluginDataHandler.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/rust-discovery-handler/Cargo.toml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/rust-discovery-handler/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/rust-discovery-handler/src/lib.rs",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/rust-meta-data-handler/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/rust-plugin-data-handler/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-apollo/src/main/resources/META-INF/shenyu/org.apache.shenyu.registry.api.ShenyuInstanceRegisterRepository",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-consul/src/main/resources/META-INF/shenyu/org.apache.shenyu.registry.api.ShenyuInstanceRegisterRepository",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-httpclient/src/main/resources/META-INF/shenyu/org.apache.shenyu.sdk.core.client.ShenyuSdkClient",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-okhttp/src/main/resources/META-INF/shenyu/org.apache.shenyu.sdk.core.client.ShenyuSdkClient",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spi/src/test/resources/META-INF/shenyu/org.apache.shenyu.spi.fixture.EmptySPI",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-grpc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springmvc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-k8s/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-request-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-casdoor/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-casdoor/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-huawei-lts/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-huawei-lts/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-kafka/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-pulsar/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rabbitmq/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rabbitmq/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rocketmq/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-tencent-cls/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-tencent-cls/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-redirect/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-redirect/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-redirect/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-registry/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk-feign/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-apollo/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-consul/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-etcd/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-http/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-http/src/test/resources/mock_configs_fetch_response.json",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-nacos/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-polaris/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-websocket/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/src/test/resources/logback.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-web/src/test/java/org/apache/shenyu/web/configuration/RestTemplateConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.configuration.RestTemplateConfigurationTest"
+    }, {
+      "path" : "shenyu-web/src/test/java/org/apache/shenyu/web/endpoint/ShenyuControllerEndpointTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.endpoint.ShenyuControllerEndpointTest"
+    }, {
+      "path" : "shenyu-web/src/test/java/org/apache/shenyu/web/filter/CollapseSlashesFilterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.filter.CollapseSlashesFilterTest"
+    }, {
+      "path" : "shenyu-web/src/test/java/org/apache/shenyu/web/loader/ShenyuPluginClassLoaderHolderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.loader.ShenyuPluginClassLoaderHolderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b44103919b8f4a6c916e12af3e9c68dbb792c639",
+    "headCommit" : "449832413d153159f04763c25088d3a41b5ee653",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/response/AiResponseTransformerPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.response.AiResponseTransformerPluginTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "449832413d153159f04763c25088d3a41b5ee653",
+    "headCommit" : "feadbd221548dd98ca401a72ef23b39aaee62790",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/AbstractDiscoveryProcessor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.AbstractDiscoveryProcessor"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/DiscoveryDataChangedEventSyncListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.DiscoveryDataChangedEventSyncListener"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/DiscoveryUpstreamMapper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.DiscoveryUpstreamMapper"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/DiscoveryUpstreamDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.DiscoveryUpstreamDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DiscoveryUpstreamServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.DiscoveryUpstreamServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/DiscoveryTransfer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.transfer.DiscoveryTransfer"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/discovery-upstream-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/tag-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/DiscoveryUpstreamMapperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.DiscoveryUpstreamMapperTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/DiscoveryUpstreamServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.DiscoveryUpstreamServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "feadbd221548dd98ca401a72ef23b39aaee62790",
+    "headCommit" : "812e0b9478980613cd10403981b0a8002eb4e9ed",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/DiscoveryDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.DiscoveryDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DiscoveryServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.DiscoveryServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ProxySelectorServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.ProxySelectorServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SelectorServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SelectorServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/DiscoveryTransfer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.transfer.DiscoveryTransfer"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/discovery-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "812e0b9478980613cd10403981b0a8002eb4e9ed",
+    "headCommit" : "e6e87ec1ee5e2ff5f1ead8ec3750cbd65904a371",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/config/ClusterConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.ClusterConfiguration"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/config/ShenyuAdminConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.ShenyuAdminConfiguration"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/config/StandaloneConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.StandaloneConfiguration"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/InstanceController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.InstanceController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/disruptor/subscriber/URIRegisterExecutorSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.disruptor.subscriber.URIRegisterExecutorSubscriber"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mode/cluster/service/ShenyuClusterService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mode.cluster.service.ShenyuClusterService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mode/standalone/ShenyuStandaloneService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mode.standalone.ShenyuStandaloneService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/InstanceInfoDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.InstanceInfoDTO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/InstanceInfoDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.InstanceInfoDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/event/instance/InstanceInfoReportEvent.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.event.instance.InstanceInfoReportEvent"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/InstanceDataVisualLineVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.InstanceDataVisualLineVO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/InstanceDataVisualVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.InstanceDataVisualVO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/InstanceInfoVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.InstanceInfoVO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/InstanceInfoService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.InstanceInfoService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/InstanceCheckService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.InstanceCheckService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/InstanceInfoServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.InstanceInfoServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/UpstreamCheckService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.UpstreamCheckService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/publish/InstanceInfoReportEventPublisher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.publish.InstanceInfoReportEventPublisher"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.AbstractShenyuClientRegisterServiceImpl"
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/disruptor/subcriber/ShenyuClientURIExecutorSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriber"
+    }, {
+      "path" : "shenyu-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/InstanceStatusEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.InstanceStatusEnum"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/utils/SystemInfoUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.SystemInfoUtils"
+    }, {
+      "path" : "shenyu-register-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client-beat/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client-beat/src/main/java/org/apache/shenyu/register/client/beat/HeartbeatListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.beat.HeartbeatListener"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-api/src/main/java/org/apache/shenyu/register/client/api/ShenyuClientRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.api.ShenyuClientRegisterRepository"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-http/src/main/java/org/apache/shenyu/register/client/http/HttpClientRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.http.HttpClientRegisterRepository"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/dto/InstanceBeatInfoDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.common.dto.InstanceBeatInfoDTO"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/dto/URIRegisterDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.common.dto.URIRegisterDTO"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-beat/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-beat/src/main/java/org/apache/shenyu/register/client/beat/HeartbeatListenerConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.beat.HeartbeatListenerConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-beat/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-beat/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e6e87ec1ee5e2ff5f1ead8ec3750cbd65904a371",
+    "headCommit" : "4cc679efec4947648e9214ff7c7dff44699252a1",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/ShenyuClientHttpRegistryController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.ShenyuClientHttpRegistryController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/disruptor/RegisterClientServerDisruptorPublisher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.disruptor.RegisterClientServerDisruptorPublisher"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/disruptor/subscriber/McpToolsRegisterExecutorSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.disruptor.subscriber.McpToolsRegisterExecutorSubscriber"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterMcpServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterMcpServiceImpl"
+    }, {
+      "path" : "shenyu-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/disruptor/ShenyuClientRegisterEventPublisher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.disruptor.ShenyuClientRegisterEventPublisher"
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/disruptor/subcriber/ShenyuClientMcpExecutorSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientMcpExecutorSubscriber"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/common/annotation/ShenyuMcpHeader.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.common.annotation.ShenyuMcpHeader"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/common/annotation/ShenyuMcpRequestConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.common.annotation.ShenyuMcpRequestConfig"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/common/annotation/ShenyuMcpTool.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.common.annotation.ShenyuMcpTool"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/common/annotation/ShenyuMcpToolParam.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.common.annotation.ShenyuMcpToolParam"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/common/constants/OpenApiConstants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.common.constants.OpenApiConstants"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/common/constants/RequestTemplateConstants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.common.constants.RequestTemplateConstants"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/common/constants/ShenyuToolConfigConstants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.common.constants.ShenyuToolConfigConstants"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/generator/McpOpenApiGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.generator.McpOpenApiGenerator"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/generator/McpRequestConfigGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.generator.McpRequestConfigGenerator"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/generator/McpToolsRegisterDTOGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.generator.McpToolsRegisterDTOGenerator"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/utils/OpenApiConvertorUtil.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.utils.OpenApiConvertorUtil"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-register/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-register/src/main/java/org/apache/shenyu/client/mcp/McpServiceEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.McpServiceEventListener"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/RpcTypeEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.RpcTypeEnum"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/utils/PluginNameAdapter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.PluginNameAdapter"
+    }, {
+      "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/utils/PluginNameAdapterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.PluginNameAdapterTest"
+    }, {
+      "path" : "shenyu-examples/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/src/main/java/org/apache/shenyu/ShenyuTestMcpApplication.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.ShenyuTestMcpApplication"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/src/main/java/org/apache/shenyu/controller/OrderController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.controller.OrderController"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/src/main/java/org/apache/shenyu/dto/OrderDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.dto.OrderDTO"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-api/src/main/java/org/apache/shenyu/register/client/api/FailbackRegistryRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.api.FailbackRegistryRepository"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-api/src/main/java/org/apache/shenyu/register/client/api/ShenyuClientRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.api.ShenyuClientRegisterRepository"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-http/src/main/java/org/apache/shenyu/register/client/http/HttpClientRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.http.HttpClientRegisterRepository"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/dto/McpToolsRegisterDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.common.dto.McpToolsRegisterDTO"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/type/DataType.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.common.type.DataType"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-mcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-mcp/src/main/java/org/apache/shenyu/springboot/starter/client/mcp/ShenyuMcpClientConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.client.mcp.ShenyuMcpClientConfiguration"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4cc679efec4947648e9214ff7c7dff44699252a1",
+    "headCommit" : "ab1d57a5919e89190b224d32e0b60517cf0c6dc9",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/selector/CacheUpstream.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.selector.CacheUpstream"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-handler/src/main/java/org/apache/shenyu/plugin/cache/CachePlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.CachePlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-handler/src/main/java/org/apache/shenyu/plugin/cache/cache/ApplicationConfigCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.cache.ApplicationConfigCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-handler/src/main/java/org/apache/shenyu/plugin/cache/handler/CachePluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.handler.CachePluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-handler/src/test/java/org/apache/shenyu/plugin/cache/ApplicationConfigCacheTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.ApplicationConfigCacheTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-handler/src/test/java/org/apache/shenyu/plugin/cache/CachePluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.cache.CachePluginTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ab1d57a5919e89190b224d32e0b60517cf0c6dc9",
+    "headCommit" : "16736b3e9c838cb1d5563014b7e2da346fe375a6",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/e2e-k8s.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-api/src/main/java/org/apache/shenyu/admin/listener/DataChangedListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.DataChangedListener"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/AiProxyApiKeyController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.AiProxyApiKeyController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/AbstractDataChangedListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.AbstractDataChangedListener"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/AiProxySelectorResolverInvalidator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.AiProxySelectorResolverInvalidator"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/DataChangedEventDispatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.DataChangedEventDispatcher"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/websocket/WebsocketCollector.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketCollector"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/websocket/WebsocketDataChangedListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketDataChangedListener"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/AiProxyApiKeyMapper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.AiProxyApiKeyMapper"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/BatchIdsDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.BatchIdsDTO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/ProxyApiKeyDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.ProxyApiKeyDTO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/ProxyApiKeyDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.ProxyApiKeyDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/query/ProxyApiKeyQuery.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.query.ProxyApiKeyQuery"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/ProxyApiKeyVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.ProxyApiKeyVO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/AiProxyApiKeyService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.AiProxyApiKeyService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/AiProxyConnectionService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.AiProxyConnectionService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AiProxyApiKeyServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.AiProxyApiKeyServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AiProxyConnectionServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.AiProxyConnectionServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SelectorServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SelectorServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SyncDataServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SyncDataServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/support/AiProxyRealKeyResolver.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.support.AiProxyRealKeyResolver"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/ProxyApiKeyTransfer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.transfer.ProxyApiKeyTransfer"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/ai-proxy-api-key-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/tag-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/AbstractDataChangedListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.AbstractDataChangedListenerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/http/HttpLongPollingDataChangedListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.http.HttpLongPollingDataChangedListenerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/SyncDataServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.SyncDataServiceTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/AiProxyApiKeyServiceImplTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.AiProxyApiKeyServiceImplTest"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/ProxyApiKeyData.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.ProxyApiKeyData"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/rule/AiProxyHandle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.rule.AiProxyHandle"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/ConfigGroupEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.ConfigGroupEnum"
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/config/AiCommonConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.config.AiCommonConfig"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/spring/ai/factory/OpenAiModelFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.spring.ai.factory.OpenAiModelFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/strategy/FallbackStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.FallbackStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/strategy/SimpleModelFallbackStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.SimpleModelFallbackStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.AiProxyPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/cache/AiProxyApiKeyCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.cache.AiProxyApiKeyCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/cache/ChatClientCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.cache.ChatClientCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/handler/AiProxyPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.handler.AiProxyPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyConfigService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyConfigService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyExecutorService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyExecutorService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/subscriber/CommonAiProxyApiKeyDataSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.subscriber.CommonAiProxyApiKeyDataSubscriber"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/AiProxyPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.AiProxyPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/cache/AiProxyApiKeyCacheTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.cache.AiProxyApiKeyCacheTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyConfigServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyConfigServiceTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyExecutorServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyExecutorServiceTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/subscriber/CommonAiProxyApiKeyDataSubscriberTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.subscriber.CommonAiProxyApiKeyDataSubscriberTest"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/src/main/java/org/apache/shenyu/springboot/starter/plugin/ai/proxy/AiProxyPluginConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.ai.proxy.AiProxyPluginConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-http/src/main/java/org/apache/shenyu/springboot/starter/sync/data/http/HttpSyncDataConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.sync.data.http.HttpSyncDataConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-websocket/src/main/java/org/apache/shenyu/springboot/starter/sync/data/websocket/WebsocketSyncDataConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.sync.data.websocket.WebsocketSyncDataConfiguration"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-api/src/main/java/org/apache/shenyu/sync/data/api/AiProxyApiKeyDataSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.api.AiProxyApiKeyDataSubscriber"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/HttpSyncDataService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.http.HttpSyncDataService"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/refresh/AiProxyApiKeyDataRefresh.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.http.refresh.AiProxyApiKeyDataRefresh"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/refresh/DataRefreshFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.http.refresh.DataRefreshFactory"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/src/test/java/org/apache/shenyu/sync/data/http/HttpSyncDataServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.http.HttpSyncDataServiceTest"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/WebsocketSyncDataService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sync.data.websocket.WebsocketSyncDataService"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/client/ShenyuWebsocketClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sync.data.websocket.client.ShenyuWebsocketClient"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/AiProxyApiKeyDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sync.data.websocket.handler.AiProxyApiKeyDataHandler"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/handler/WebsocketDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sync.data.websocket.handler.WebsocketDataHandler"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/src/test/java/org/apache/shenyu/plugin/sync/data/websocket/handler/WebsocketDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sync.data.websocket.handler.WebsocketDataHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "16736b3e9c838cb1d5563014b7e2da346fe375a6",
+    "headCommit" : "cdf637acbd9b4ab8d39b51605570927c4724163e",
+    "changedFiles" : [ {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cdf637acbd9b4ab8d39b51605570927c4724163e",
+    "headCommit" : "e765dbf81ff4be47bd6fd779d790a53fba6cc525",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/generator/McpToolsRegisterDTOGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.generator.McpToolsRegisterDTOGenerator"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/utils/OpenApiConvertorUtil.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.utils.OpenApiConvertorUtil"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-register/src/main/java/org/apache/shenyu/client/mcp/McpServiceEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.McpServiceEventListener"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/src/main/java/org/apache/shenyu/controller/OrderController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.controller.OrderController"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e765dbf81ff4be47bd6fd779d790a53fba6cc525",
+    "headCommit" : "44995b73bbe72172c3f259573a3a841f790b5093",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/strategy/AiModel.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.AiModel"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/strategy/AiModelFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.AiModelFactory"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/main/java/org/apache/shenyu/plugin/ai/common/strategy/openai/OpenAI.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.openai.OpenAI"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/test/java/org/apache/shenyu/plugin/ai/common/strategy/AiModelFactoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.AiModelFactoryTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/test/java/org/apache/shenyu/plugin/ai/common/strategy/openai/OpenAITest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.openai.OpenAITest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/handler/AiProxyPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/handler/AiProxyPluginHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "44995b73bbe72172c3f259573a3a841f790b5093",
+    "headCommit" : "df1389f3f098066a9949620c18b127b6fc87af15",
+    "changedFiles" : [ {
+      "path" : "shenyu-registry/shenyu-registry-nacos/src/main/java/org/apache/shenyu/registry/nacos/NacosInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.nacos.NacosInstanceRegisterRepository"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "df1389f3f098066a9949620c18b127b6fc87af15",
+    "headCommit" : "5c591f12eb61671d9bd2441ba1b6a1025429b7a4",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mode/cluster/service/ShenyuClusterService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mode.cluster.service.ShenyuClusterService"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5c591f12eb61671d9bd2441ba1b6a1025429b7a4",
+    "headCommit" : "ab3b52bc4a6ed4c2b01702c118afde16b730b119",
+    "changedFiles" : [ {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/AccessTokenManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.http.AccessTokenManager"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/src/test/java/org/apache/shenyu/sync/data/http/AccessTokenManagerFixTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.http.AccessTokenManagerFixTest"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/src/test/java/org/apache/shenyu/sync/data/http/AccessTokenManagerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.http.AccessTokenManagerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ab3b52bc4a6ed4c2b01702c118afde16b730b119",
+    "headCommit" : "51a8a95134e5590e8f01374e829d6b0fc924cceb",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/resources/static/index.88ba2307.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.a6d776d6.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.html",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "51a8a95134e5590e8f01374e829d6b0fc924cceb",
+    "headCommit" : "5543b938a827eee96d2517a5d135f8bccf982ec4",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/TagVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.TagVO"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/TagControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.TagControllerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5543b938a827eee96d2517a5d135f8bccf982ec4",
+    "headCommit" : "8d0c4e9b757bf9e0c0500f0fe22b54bb2478923c",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/discovery/AbstractDiscoveryProcessor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.AbstractDiscoveryProcessor"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/DiscoveryDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.DiscoveryDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/DiscoveryVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.DiscoveryVO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DiscoveryServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.DiscoveryServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DiscoveryUpstreamServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.DiscoveryUpstreamServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ProxySelectorServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.ProxySelectorServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SelectorServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SelectorServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/DiscoveryTransfer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.transfer.DiscoveryTransfer"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/discovery-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/discovery/DefaultDiscoveryProcessorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.discovery.DefaultDiscoveryProcessorTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/DiscoveryUpstreamServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.DiscoveryUpstreamServiceTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/SelectorServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.SelectorServiceTest"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-websocket/src/test/java/org/apache/shenyue/e2e/testcase/websocket/WebSocketPluginCases.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyue.e2e.testcase.websocket.WebSocketPluginCases"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-websocket/src/test/java/org/apache/shenyue/e2e/testcase/websocket/WebSocketPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyue.e2e.testcase.websocket.WebSocketPluginTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8d0c4e9b757bf9e0c0500f0fe22b54bb2478923c",
+    "headCommit" : "f8141dbe6ab4d2e3041cbe086e8bbfa96fafc5c8",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f8141dbe6ab4d2e3041cbe086e8bbfa96fafc5c8",
+    "headCommit" : "a09cfb270c9285b67f14ec6d878b61c2fa54a566",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/InstanceControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.InstanceControllerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/InstanceInfoMapperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.InstanceInfoMapperTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/model/event/instance/InstanceInfoReportEventTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.event.instance.InstanceInfoReportEventTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/model/query/InstanceQueryConditionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.query.InstanceQueryConditionTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/model/vo/InstanceDataVisualLineVOTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.InstanceDataVisualLineVOTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/model/vo/InstanceDataVisualVOTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.InstanceDataVisualVOTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/model/vo/InstanceInfoVOTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.InstanceInfoVOTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/InstanceInfoServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.InstanceInfoServiceTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/InstanceCheckServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.InstanceCheckServiceTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/InstanceInfoReportEventPublisherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.publish.InstanceInfoReportEventPublisherTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a09cfb270c9285b67f14ec6d878b61c2fa54a566",
+    "headCommit" : "aeba1f3cbf102b577e3ee535596331121743a825",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/AbstractLoggingPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.common.AbstractLoggingPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/collector/AbstractLogCollector.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.common.collector.AbstractLogCollector"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/collector/LogCollector.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.common.collector.LogCollector"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/main/java/org/apache/shenyu/plugin/logging/rabbitmq/cache/RabbitmqClientCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.cache.RabbitmqClientCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/main/java/org/apache/shenyu/plugin/logging/rabbitmq/config/RabbitmqLogCollectConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.config.RabbitmqLogCollectConfig"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/main/java/org/apache/shenyu/plugin/logging/rabbitmq/conllector/RabbitmqLogCollector.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.conllector.RabbitmqLogCollector"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/main/java/org/apache/shenyu/plugin/logging/rabbitmq/handler/LoggingRabbitmqPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.handler.LoggingRabbitmqPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plugin/logging/rabbitmq/cache/RabbitmqClientCacheTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.cache.RabbitmqClientCacheTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plugin/logging/rabbitmq/collector/RabbitmqLogCollectorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.collector.RabbitmqLogCollectorTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plugin/logging/rabbitmq/config/RabbitmqLogCollectConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.config.RabbitmqLogCollectConfigTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/src/test/java/org/apache/shenyu/plugin/logging/rabbitmq/handler/LoggingRabbitmqPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.rabbitmq.handler.LoggingRabbitmqPluginDataHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "aeba1f3cbf102b577e3ee535596331121743a825",
+    "headCommit" : "0af754d949c7e4851ab6c62f78750b50cfd981fe",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/selector/SofaUpstream.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.selector.SofaUpstream"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/src/main/java/org/apache/shenyu/plugin/sofa/SofaPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sofa.SofaPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/src/main/java/org/apache/shenyu/plugin/sofa/cache/ApplicationConfigCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sofa.cache.ApplicationConfigCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/src/main/java/org/apache/shenyu/plugin/sofa/handler/SofaMetaDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sofa.handler.SofaMetaDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/src/main/java/org/apache/shenyu/plugin/sofa/handler/SofaPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sofa.handler.SofaPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/src/main/java/org/apache/shenyu/plugin/sofa/proxy/SofaProxyService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sofa.proxy.SofaProxyService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/src/test/java/org/apache/shenyu/plugin/sofa/SofaPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sofa.SofaPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/src/test/java/org/apache/shenyu/plugin/sofa/cache/ApplicationConfigCacheTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sofa.cache.ApplicationConfigCacheTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/src/test/java/org/apache/shenyu/plugin/sofa/proxy/SofaProxyServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sofa.proxy.SofaProxyServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0af754d949c7e4851ab6c62f78750b50cfd981fe",
+    "headCommit" : "dd57fb78daad4e8dfcb7d8c19751cb4008f9e9ff",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/src/main/java/org/apache/shenyu/plugin/logging/kafka/cache/KafkaClientCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.kafka.cache.KafkaClientCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/src/main/java/org/apache/shenyu/plugin/logging/kafka/collector/KafkaLogCollector.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.kafka.collector.KafkaLogCollector"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/src/main/java/org/apache/shenyu/plugin/logging/kafka/config/KafkaLogCollectConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.kafka.config.KafkaLogCollectConfig"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/src/main/java/org/apache/shenyu/plugin/logging/kafka/handler/LoggingKafkaPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.kafka.handler.LoggingKafkaPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/src/test/java/org/apache/shenyu/plugin/logging/kafka/cache/KafkaClientCacheTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.kafka.cache.KafkaClientCacheTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/src/test/java/org/apache/shenyu/plugin/logging/kafka/collector/KafkaLogCollectorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.kafka.collector.KafkaLogCollectorTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/src/test/java/org/apache/shenyu/plugin/logging/kafka/handler/LoggingKafkaPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.kafka.handler.LoggingKafkaPluginDataHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "dd57fb78daad4e8dfcb7d8c19751cb4008f9e9ff",
+    "headCommit" : "2a4a7fb6213e1740b3b7bdb66cb813e61dbe1b08",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/utils/LogCollectUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.common.utils.LogCollectUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2a4a7fb6213e1740b3b7bdb66cb813e61dbe1b08",
+    "headCommit" : "555f9b456f1d90dec93d4c60bc6c4a3aa1f54ab7",
+    "changedFiles" : [ {
+      "path" : "shenyu-bootstrap/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client-beat/src/main/java/org/apache/shenyu/register/client/beat/HeartbeatListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.beat.HeartbeatListener"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client-beat/src/main/java/org/apache/shenyu/register/client/beat/ShenyuBootstrapHeartBeatConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.beat.ShenyuBootstrapHeartBeatConfig"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-beat/src/main/java/org/apache/shenyu/register/client/beat/HeartbeatListenerConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.beat.HeartbeatListenerConfiguration"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "555f9b456f1d90dec93d4c60bc6c4a3aa1f54ab7",
+    "headCommit" : "fc8c796b97e39c6cca46f0208a5bb9f3105f15b6",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/http/HttpLongPollingDataChangedListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.http.HttpLongPollingDataChangedListener"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/websocket/WebsocketCollector.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketCollector"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/websocket/WebsocketConfigurator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketConfigurator"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/websocket/WebsocketListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketListener"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-http/src/main/java/org/apache/shenyu/register/client/http/HttpClientRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.http.HttpClientRegisterRepository"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-websocket/src/main/java/org/apache/shenyu/springboot/starter/sync/data/websocket/WebsocketSyncDataConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.sync.data.websocket.WebsocketSyncDataConfiguration"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/src/main/java/org/apache/shenyu/sync/data/http/HttpSyncDataService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.http.HttpSyncDataService"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/WebsocketSyncDataService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sync.data.websocket.WebsocketSyncDataService"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/client/ShenyuWebsocketClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sync.data.websocket.client.ShenyuWebsocketClient"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "fc8c796b97e39c6cca46f0208a5bb9f3105f15b6",
+    "headCommit" : "d0994fa94d97c40e611e16d10a1f8a33651cb52b",
+    "changedFiles" : [ {
+      "path" : ".idea/vcs.xml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-api/src/test/java/org/apache/shenyu/register/client/api/FailbackRegistryRepositoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.api.FailbackRegistryRepositoryTest"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-api/src/test/java/org/apache/shenyu/register/client/api/retry/FailureRegistryTaskTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.api.retry.FailureRegistryTaskTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d0994fa94d97c40e611e16d10a1f8a33651cb52b",
+    "headCommit" : "ce9a39edf19c44612ad0c3839514d3eaa540c027",
+    "changedFiles" : [ {
+      "path" : ".github/filters.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/ci.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/e2e-k8s.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test-k8s-ingress.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/k8s-examples-http.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "actions/paths-filter/action.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "actions/paths-filter/dist/index.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/InstanceCheckServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.InstanceCheckServiceTest"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-etcd-eureka.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-etcd.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/k8s/shenyu-etcd.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/compose/script/e2e-apache-dubbo-sync-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/k8s/script/e2e-apache-dubbo-sync.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-grpc/compose/script/e2e-grpc-sync-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-grpc/k8s/script/e2e-grpc-sync.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-http/compose/script/e2e-http-sync-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-http/k8s/script/e2e-http-sync.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/compose/script/e2e-logging-kafka-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/k8s/script/e2e-http-sync.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-rocketmq/compose/script/e2e-logging-rocketmq-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-rocketmq/k8s/script/e2e-http-sync.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/compose/script/e2e-sofa-sync-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/k8s/script/e2e-sofa-sync.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/compose/script/e2e-springcloud-sync-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/k8s/script/e2e-springcloud-sync.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-websocket/compose/script/e2e-websocket-sync-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-websocket/k8s/script/e2e-websocket-sync.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/response/AiResponseTransformerPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.response.AiResponseTransformerPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/src/test/java/org/apache/shenyu/plugin/wasm/api/AbstractWasmPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.api.AbstractWasmPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/java/org/apache/shenyu/plugin/wasm/base/AbstractShenyuWasmPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.base.AbstractShenyuWasmPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/java/org/apache/shenyu/plugin/wasm/base/handler/AbstractWasmDiscoveryHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmDiscoveryHandlerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/java/org/apache/shenyu/plugin/wasm/base/handler/AbstractWasmMetaDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmMetaDataHandlerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/java/org/apache/shenyu/plugin/wasm/base/handler/AbstractWasmPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmPluginDataHandlerTest"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ce9a39edf19c44612ad0c3839514d3eaa540c027",
+    "headCommit" : "a04d9e12fb5101b97743a92ffb951631e8359e15",
+    "changedFiles" : [ {
+      "path" : ".github/activie-committers.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/auto-notify.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a04d9e12fb5101b97743a92ffb951631e8359e15",
+    "headCommit" : "a8300a4eef66d1ca5e8394c34367a9636bc17cd5",
+    "changedFiles" : [ {
+      "path" : "shenyu-register-center/shenyu-register-client-beat/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client-beat/src/test/java/org/apache/shenyu/register/client/beat/HeartbeatListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.beat.HeartbeatListenerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a8300a4eef66d1ca5e8394c34367a9636bc17cd5",
+    "headCommit" : "9f857fe613238d34a4828c8fb9483d4ded0ffb0e",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/issue-label.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".prowlabels.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9f857fe613238d34a4828c8fb9483d4ded0ffb0e",
+    "headCommit" : "f38a9c58c8aeab6f77a7820c33c7de1673a04f0f",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/ci.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/docker-publish-dockerhub.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/docker-publish.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/e2e-k8s.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test-k8s-ingress.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/k8s-examples-http.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f38a9c58c8aeab6f77a7820c33c7de1673a04f0f",
+    "headCommit" : "082e7028beb0e572d331121e09805a2bfb861ce4",
+    "changedFiles" : [ {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/cache/UpstreamCacheManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCacheManager"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/cache/UpstreamCheckTask.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCheckTask"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/entity/Upstream.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.entity.Upstream"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "082e7028beb0e572d331121e09805a2bfb861ce4",
+    "headCommit" : "24565161a50ab1250ae1a941893bbd16f71509f5",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallback"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "24565161a50ab1250ae1a941893bbd16f71509f5",
+    "headCommit" : "c94c64c703acd2b7b74e4fc5359274b4194ecea6",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/src/main/java/org/apache/shenyu/plugin/logging/elasticsearch/client/ElasticSearchLogCollectClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.logging.elasticsearch.client.ElasticSearchLogCollectClient"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c94c64c703acd2b7b74e4fc5359274b4194ecea6",
+    "headCommit" : "e0c50c3bdf78bd38476059a53e7941daad1abeec",
+    "changedFiles" : [ {
+      "path" : ".github/activie-committers.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e0c50c3bdf78bd38476059a53e7941daad1abeec",
+    "headCommit" : "3a3cc0430c7c6795aa195b8a7631925786c7db42",
+    "changedFiles" : [ {
+      "path" : "shenyu-registry/shenyu-registry-kubernetes/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-kubernetes/src/test/java/org/apache/shenyu/registry/kubernetes/KubernetesClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.kubernetes.KubernetesClientTest"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-kubernetes/src/test/java/org/apache/shenyu/registry/kubernetes/KubernetesConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.kubernetes.KubernetesConfigTest"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-kubernetes/src/test/java/org/apache/shenyu/registry/kubernetes/KubernetesInstanceRegisterRepositoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.kubernetes.KubernetesInstanceRegisterRepositoryTest"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-kubernetes/src/test/java/org/apache/shenyu/registry/kubernetes/KubernetesInstanceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.kubernetes.KubernetesInstanceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3a3cc0430c7c6795aa195b8a7631925786c7db42",
+    "headCommit" : "5cbd540d02fb759a8932d7ed45ab2227b41032ff",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/test/java/org/apache/shenyu/plugin/motan/proxy/MotanProxyServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.proxy.MotanProxyServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5cbd540d02fb759a8932d7ed45ab2227b41032ff",
+    "headCommit" : "72a89c0b05a3477f7a950f18ecf8e629ea57a12c",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/issue-label.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "actions/scripts/issue-manager.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "72a89c0b05a3477f7a950f18ecf8e629ea57a12c",
+    "headCommit" : "0484d6ab2940daa01a53914a670c96b425e87baf",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/common/constants/RequestTemplateConstants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.common.constants.RequestTemplateConstants"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/generator/McpRequestConfigGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.generator.McpRequestConfigGenerator"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/handler/McpServerPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.handler.McpServerPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/manager/ShenyuMcpServerManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.manager.ShenyuMcpServerManager"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/request/RequestConfigHelper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.RequestConfigHelper"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/request/RequestConfigHelperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.RequestConfigHelperTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0484d6ab2940daa01a53914a670c96b425e87baf",
+    "headCommit" : "abad1ada17901a715cbad55e7b28bf75210a26e0",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/utils/RequestMethodUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.utils.RequestMethodUtils"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/common/annotation/ShenyuMcpRequestConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.common.annotation.ShenyuMcpRequestConfig"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/common/dto/ShenyuMcpRequestConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.common.dto.ShenyuMcpRequestConfig"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/common/dto/ShenyuMcpTool.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.common.dto.ShenyuMcpTool"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/generator/McpOpenApiGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.generator.McpOpenApiGenerator"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/generator/McpRequestConfigGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.generator.McpRequestConfigGenerator"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/generator/McpToolsRegisterDTOGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.generator.McpToolsRegisterDTOGenerator"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/utils/OpenApiConvertorUtil.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.utils.OpenApiConvertorUtil"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-register/src/main/java/org/apache/shenyu/client/mcp/McpServiceEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.McpServiceEventListener"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/src/main/java/org/apache/shenyu/controller/OrderController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.controller.OrderController"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "abad1ada17901a715cbad55e7b28bf75210a26e0",
+    "headCommit" : "b6b1416aa32af18c11071998c4ff794553e6d97f",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/e2e-k8s.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b6b1416aa32af18c11071998c4ff794553e6d97f",
+    "headCommit" : "cf0ec09c672a5350b87075873d66f8656a8e2726",
+    "changedFiles" : [ {
+      "path" : "shenyu-registry/shenyu-registry-apollo/src/main/java/org/apache/shenyu/registry/apollo/ApolloInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.apollo.ApolloInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-consul/src/main/java/org/apache/shenyu/registry/consul/ConsulInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.consul.ConsulInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/src/main/java/org/apache/shenyu/registry/etcd/EtcdInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.etcd.EtcdInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-eureka/src/main/java/org/apache/shenyu/registry/eureka/EurekaInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.eureka.EurekaInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-kubernetes/src/main/java/org/apache/shenyu/registry/kubernetes/KubernetesInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.kubernetes.KubernetesInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-nacos/src/main/java/org/apache/shenyu/registry/nacos/NacosInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.nacos.NacosInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-polaris/src/main/java/org/apache/shenyu/registry/polaris/PolarisInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.polaris.PolarisInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/src/main/java/org/apache/shenyu/registry/zookeeper/ZookeeperInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.zookeeper.ZookeeperInstanceRegisterRepository"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cf0ec09c672a5350b87075873d66f8656a8e2726",
+    "headCommit" : "3c3a4a50bc435830a48d0eff131fd05e19ae3374",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/SwaggerImportController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.SwaggerImportController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/SwaggerImportRequest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.SwaggerImportRequest"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/SwaggerImportService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.SwaggerImportService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SwaggerImportServiceImpl"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/common/eunm/McpParameterType.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.common.eunm.McpParameterType"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/generator/McpOpenApiGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.generator.McpOpenApiGenerator"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/generator/McpToolsRegisterDTOGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.generator.McpToolsRegisterDTOGenerator"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-register/src/main/java/org/apache/shenyu/client/mcp/McpServiceEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.McpServiceEventListener"
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3c3a4a50bc435830a48d0eff131fd05e19ae3374",
+    "headCommit" : "d1d98032f6ad0da388557beeb6b984fb3c49d06f",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/websocket/WebsocketDataChangedListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketDataChangedListenerTest"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/BaseData.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.BaseData"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/PluginData.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.PluginData"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/RuleData.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.RuleData"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/SelectorData.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.SelectorData"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d1d98032f6ad0da388557beeb6b984fb3c49d06f",
+    "headCommit" : "58bbbbdbd8b526894ca2b9724b02b2fdd77e7bbd",
+    "changedFiles" : [ {
+      "path" : "shenyu-infra/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-x-module/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-x-module/src/main/java/org/apache/shenyu/infra/x/XConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.x.XConfig"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-x-module/src/test/java/org/apache/shenyu/infra/x/XTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.x.XTests"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "58bbbbdbd8b526894ca2b9724b02b2fdd77e7bbd",
+    "headCommit" : "501bec3aef9e559b4b5ba790623017088afc9b7e",
+    "changedFiles" : [ {
+      "path" : "actions/paths-filter/dist/index.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "501bec3aef9e559b4b5ba790623017088afc9b7e",
+    "headCommit" : "80596c87ab50bad1fd86e9058ffddcacc3b31f2b",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/generator/McpRequestConfigGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.generator.McpRequestConfigGenerator"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/src/main/java/org/apache/shenyu/controller/OrderController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.controller.OrderController"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallback"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "80596c87ab50bad1fd86e9058ffddcacc3b31f2b",
+    "headCommit" : "ae6ddc5abe3e88f1c0a5a9201a59bcdb74a04157",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-register/src/main/java/org/apache/shenyu/client/mcp/McpServiceEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.McpServiceEventListener"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/src/main/java/org/apache/shenyu/controller/OrderController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.controller.OrderController"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/manager/ShenyuMcpServerManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.manager.ShenyuMcpServerManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ae6ddc5abe3e88f1c0a5a9201a59bcdb74a04157",
+    "headCommit" : "b93a6870343b76e8e7d45027396006f596e9a22f",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/ci.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b93a6870343b76e8e7d45027396006f596e9a22f",
+    "headCommit" : "3c6bb7be162044e379d38b6687a2870991ae7040",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImplTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterDivideServiceImplTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDubboServiceImplTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterDubboServiceImplTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImplTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterGrpcServiceImplTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterTarsServiceImplTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterTarsServiceImplTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3c6bb7be162044e379d38b6687a2870991ae7040",
+    "headCommit" : "6b42718a6ee9027b003b76170a2cb02a269cf26b",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/websocket/WebsocketDataChangedListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketDataChangedListenerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6b42718a6ee9027b003b76170a2cb02a269cf26b",
+    "headCommit" : "13f175be50f8d25825b380b9d3e85f65065125f3",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-register/src/main/java/org/apache/shenyu/client/mcp/McpServiceEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.McpServiceEventListener"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallback"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-mcp/src/main/java/org/apache/shenyu/springboot/starter/client/mcp/ShenyuMcpClientConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.client.mcp.ShenyuMcpClientConfiguration"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "13f175be50f8d25825b380b9d3e85f65065125f3",
+    "headCommit" : "a49901f3c6a8c35ec550549bc6f7e7d31d60ff7b",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/HttpUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.HttpUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a49901f3c6a8c35ec550549bc6f7e7d31d60ff7b",
+    "headCommit" : "5d92e50f4f568fd034fcf56c659c7e210042b438",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.5.0-upgrade-2.5.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.5.0-upgrade-2.5.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.5.0-upgrade-2.5.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/FieldDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.FieldDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/ParameterDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.ParameterDO"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/field-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/parameter-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5d92e50f4f568fd034fcf56c659c7e210042b438",
+    "headCommit" : "1aba81b7cad4916888f3b0decf3777e8ef23436b",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-alert/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-api-docs-annotations/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-autoconfig/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-register/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-disruptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-docker-compose-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-src-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-annotation/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-dubbo-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-eureka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http-swagger3/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-https/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc-tomcat/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-annotation-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-native-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-reactive-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-combination/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-https/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-spring-cloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-custom-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-integrated-test-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-integrated-test-upload-plugin-case/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-kubernetes-controller/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-loadbalancer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-handler/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-memory/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-spi/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-context-path/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-hystrix/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-resilience4j/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-sentinel/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-global/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-console/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-desensitize-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-huawei-lts/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-pulsar/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rocketmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-tencent-cls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-metrics/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mock/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-modify-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-param-mapping/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-general-context/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-transform/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-redirect/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-request/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-basic-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-casdoor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-cryptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-key-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-oauth2/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-sign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-uri/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-waf/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client-beat/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-eureka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-kubernetes/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-okhttp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-spring/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spi/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-beat/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-mcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-spring-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-k8s/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-request-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-response-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-basic-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-casdoor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-context-path/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cryptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-divide/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-general-context/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-global/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-hystrix/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-jwt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-key-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-aliyun-sls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-clickhouse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-console/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-elasticsearch/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-huawei-lts/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-kafka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-pulsar/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rabbitmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rocketmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-tencent-cls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mcp-server/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-metrics/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mock/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-modify-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-oauth2/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-param-mapping/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ratelimiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-redirect/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-resilience4j/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sentinel/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-transform/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-uri/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-waf/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-registry/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-web/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1aba81b7cad4916888f3b0decf3777e8ef23436b",
+    "headCommit" : "1464229396fbec10def6827e4f082f9427931c36",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/request/RequestConfigHelper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.RequestConfigHelper"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallbackTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallbackTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/request/RequestConfigHelperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.RequestConfigHelperTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1464229396fbec10def6827e4f082f9427931c36",
+    "headCommit" : "1c7332f51883b46ac0aa74530b362debd0c00afd",
+    "changedFiles" : [ {
+      "path" : "shenyu-protocol/shenyu-protocol-grpc/src/test/java/org/apache/shenyu/protocol/grpc/message/JsonMessageTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.protocol.grpc.message.JsonMessageTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1c7332f51883b46ac0aa74530b362debd0c00afd",
+    "headCommit" : "3c615de383334a8fc574a84089297e52873108c5",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/RuleServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.RuleServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SelectorServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SelectorServiceImpl"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3c615de383334a8fc574a84089297e52873108c5",
+    "headCommit" : "bf30e31651e993ba04e52af153a9c669e0adae7c",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/src/test/java/org/apache/shenyu/plugin/ai/prompt/handler/AiPromptPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.prompt.handler.AiPromptPluginDataHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bf30e31651e993ba04e52af153a9c669e0adae7c",
+    "headCommit" : "bee956dce6af1246a6f90aec803511d7f48b0477",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/HttpUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.HttpUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bee956dce6af1246a6f90aec803511d7f48b0477",
+    "headCommit" : "ddefc04a05581b567a8cb6466248b2ab358d5172",
+    "changedFiles" : [ {
+      "path" : "script/shenyu_checkstyle.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/config/ClusterConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.ClusterConfiguration"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/IndexController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.IndexController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/ApplicationStartListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.ApplicationStartListener"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mode/cluster/service/ShenyuClusterService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mode.cluster.service.ShenyuClusterService"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/IndexControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.IndexControllerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/ApplicationStartListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.ApplicationStartListenerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ddefc04a05581b567a8cb6466248b2ab358d5172",
+    "headCommit" : "0f2f7acce28824e56472607be3804407c636b357",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/shiro/config/ShiroRealm.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.shiro.config.ShiroRealm"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/cache/UpstreamCacheManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCacheManager"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/entity/LoadBalanceData.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.entity.LoadBalanceData"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/entity/Upstream.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.entity.Upstream"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/factory/LoadBalancerFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.factory.LoadBalancerFactory"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/AbstractLoadBalancer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.AbstractLoadBalancer"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/HashLoadBalancer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.HashLoadBalancer"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalance.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.LeastActiveLoadBalance"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/LoadBalancer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.LoadBalancer"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/P2cLoadBalancer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.P2cLoadBalancer"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/RandomLoadBalancer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.RandomLoadBalancer"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/RoundRobinLoadBalancer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.RoundRobinLoadBalancer"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/ShortestResponseLoadBalancer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.ShortestResponseLoadBalancer"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/entity/UpstreamTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.entity.UpstreamTest"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/factory/LoadBalancerFactoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.factory.LoadBalancerFactoryTest"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/HashLoadBalanceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.HashLoadBalanceTest"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/HashLoadBalancerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.HashLoadBalancerTest"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalanceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.LeastActiveLoadBalanceTest"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/P2cLoadBalancerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.P2cLoadBalancerTest"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/RandomLoadBalancerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.RandomLoadBalancerTest"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/RoundRobinLoadBalanceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.RoundRobinLoadBalanceTest"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/ShortestResponseLoadBalancerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.spi.ShortestResponseLoadBalancerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/utils/LoadbalancerUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.utils.LoadbalancerUtils"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/DefaultRetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.DefaultRetryStrategy"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/src/main/java/org/apache/shenyu/plugin/divide/DividePlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.divide.DividePlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/proxy/ApacheDubboGrayLoadBalance.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.proxy.ApacheDubboGrayLoadBalance"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/proxy/ApacheDubboProxyService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.proxy.ApacheDubboProxyService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/loadbalance/picker/ShenyuPicker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.grpc.loadbalance.picker.ShenyuPicker"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-websocket/src/main/java/org/apache/shenyu/plugin/websocket/WebSocketPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.websocket.WebSocketPlugin"
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-tcp/src/main/java/org/apache/shenyu/protocol/tcp/connection/DefaultConnectionConfigProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.protocol.tcp.connection.DefaultConnectionConfigProvider"
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-core/src/main/java/org/apache/shenyu/sdk/core/client/AbstractShenyuSdkClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sdk.core.client.AbstractShenyuSdkClient"
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-feign/src/main/java/org/apache/shenyu/sdk/feign/ShenyuDiscoveryClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sdk.feign.ShenyuDiscoveryClient"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0f2f7acce28824e56472607be3804407c636b357",
+    "headCommit" : "bbdcbfebb13202273462a8fbab2502551770358c",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.AiProxyPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/cache/ChatClientCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.cache.ChatClientCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyConfigService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyConfigService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/AiProxyPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.AiProxyPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyConfigServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyConfigServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bbdcbfebb13202273462a8fbab2502551770358c",
+    "headCommit" : "46281cda468d8c72b30ef8e5c2ed9a83e7132af2",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/AiProxyApiKeyController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.AiProxyApiKeyController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/AiProxyApiKeyService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.AiProxyApiKeyService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AiProxyApiKeyServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.AiProxyApiKeyServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AiProxyConnectionServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.AiProxyConnectionServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/support/AiProxyRealKeyResolver.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.support.AiProxyRealKeyResolver"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/utils/NamespaceUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.NamespaceUtils"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/support/AiProxyRealKeyResolverTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.support.AiProxyRealKeyResolverTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyConfigService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyConfigService"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "46281cda468d8c72b30ef8e5c2ed9a83e7132af2",
+    "headCommit" : "b984ad2c6d62a269e6628da62954cc4d761beb28",
+    "changedFiles" : [ {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/main/java/org/apache/shenyu/infra/etcd/client/EtcdClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.client.EtcdClient"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/test/java/org/apache/shenyu/infra/etcd/client/EtcdClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.client.EtcdClientTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/main/java/org/apache/shenyu/infra/redis/RedisConnectionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.RedisConnectionFactory"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/src/test/java/org/apache/shenyu/infra/redis/RedisConnectionFactoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.redis.RedisConnectionFactoryTest"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/src/test/java/org/apache/shenyu/registry/etcd/EtcdClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.etcd.EtcdClientTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b984ad2c6d62a269e6628da62954cc4d761beb28",
+    "headCommit" : "47c958fa8108b75174723e50560a7b0678d1119c",
+    "changedFiles" : [ {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/utils/IpUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.IpUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "47c958fa8108b75174723e50560a7b0678d1119c",
+    "headCommit" : "0b3959ce52d8e7a6d38f8ffc6abfa238efdc447f",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/MCP_TOOL_EXAMPLES.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/MCP_TOOL_EXAMPLES_EN.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0b3959ce52d8e7a6d38f8ffc6abfa238efdc447f",
+    "headCommit" : "8df49049061f09217723a0afc3019d4cd123ee7d",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/src/main/java/org/apache/shenyu/admin/config/ZookeeperSyncConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.ZookeeperSyncConfiguration"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/src/main/java/org/apache/shenyu/admin/config/properties/ZookeeperConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.ZookeeperConfig"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/src/main/java/org/apache/shenyu/admin/config/properties/ZookeeperProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.ZookeeperProperties"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/src/main/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.zookeeper.ZookeeperClient"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/src/main/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedInit.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.zookeeper.ZookeeperDataChangedInit"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/src/main/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.zookeeper.ZookeeperDataChangedListener"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/src/test/java/org/apache/shenyu/admin/config/ZookeeperSyncConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.ZookeeperSyncConfigurationTest"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/src/test/java/org/apache/shenyu/admin/config/properties/AbstractConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.AbstractConfigurationTest"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/src/test/java/org/apache/shenyu/admin/config/properties/ZookeeperPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.ZookeeperPropertiesTest"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/src/test/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.zookeeper.ZookeeperClientTest"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/src/test/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedInitTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.zookeeper.ZookeeperDataChangedInitTest"
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/src/test/java/org/apache/shenyu/admin/listener/zookeeper/ZookeeperDataChangedListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.zookeeper.ZookeeperDataChangedListenerTest"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/config/ClusterZookeeperConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.ClusterZookeeperConfiguration"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/ClusterZookeeperProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.ClusterZookeeperProperties"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-nacos.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket-cluster-zookeeper.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-zookeeper-eureka.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-zookeeper.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-cm.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/compose/shenyu-examples-dubbo-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-sofa/compose/shenyu-examples-sofa-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/k8s/shenyu-cm.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-websocket/compose/shenyu-examples-websocket-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/k8s/shenyu-zookeeper.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http-swagger3/k8s/shenyu-examples-http-deployment.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http/k8s/shenyu-zookeeper.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/k8s/shenyu-zookeeper.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/k8s/shenyu-zookeeper.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/main/java/org/apache/shenyu/infra/etcd/autoconfig/EtcdConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.autoconfig.EtcdConfiguration"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/main/java/org/apache/shenyu/infra/etcd/autoconfig/EtcdProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.autoconfig.EtcdProperties"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/test/java/org/apache/shenyu/infra/etcd/autoconfig/EtcdPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.autoconfig.EtcdPropertiesTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/test/java/org/apache/shenyu/infra/etcd/properties/AbstractConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.properties.AbstractConfigurationTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/test/java/org/apache/shenyu/infra/etcd/properties/EtcdPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.properties.EtcdPropertiesTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/main/java/org/apache/shenyu/infra/zookeeper/ZookeeperConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.zookeeper.ZookeeperConfig"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/main/java/org/apache/shenyu/infra/zookeeper/autoconfig/ConditionOnSyncZookeeper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.zookeeper.autoconfig.ConditionOnSyncZookeeper"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/main/java/org/apache/shenyu/infra/zookeeper/autoconfig/ZookeeperConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.zookeeper.autoconfig.ZookeeperConfiguration"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/main/java/org/apache/shenyu/infra/zookeeper/autoconfig/ZookeeperProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.zookeeper.autoconfig.ZookeeperProperties"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/main/java/org/apache/shenyu/infra/zookeeper/client/ZookeeperClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.zookeeper.client.ZookeeperClient"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/main/java/org/apache/shenyu/infra/zookeeper/config/ZookeeperConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.zookeeper.config.ZookeeperConfig"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/test/java/org/apache/shenyu/infra/zookeeper/ZookeeperTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.zookeeper.ZookeeperTests"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/test/java/org/apache/shenyu/infra/zookeeper/client/ZookeeperClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.zookeeper.client.ZookeeperClientTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/test/java/org/apache/shenyu/infra/zookeeper/properties/AbstractConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.zookeeper.properties.AbstractConfigurationTest"
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/src/test/java/org/apache/shenyu/infra/zookeeper/properties/ZookeeperPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.zookeeper.properties.ZookeeperPropertiesTest"
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-combination/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-http/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sofa/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/src/main/java/org/apache/shenyu/registry/zookeeper/ZookeeperClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.zookeeper.ZookeeperClient"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/src/main/java/org/apache/shenyu/registry/zookeeper/ZookeeperConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.zookeeper.ZookeeperConfig"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/src/main/java/org/apache/shenyu/registry/zookeeper/ZookeeperInstanceRegisterRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.zookeeper.ZookeeperInstanceRegisterRepository"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/src/test/java/org/apache/shenyu/registry/zookeeper/ZookeeperClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.zookeeper.ZookeeperClientTest"
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/src/test/java/org/apache/shenyu/registry/zookeeper/ZookeeperInstanceRegisterRepositoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.registry.zookeeper.ZookeeperInstanceRegisterRepositoryTest"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/src/main/java/org/apache/shenyu/springboot/sync/data/zookeeper/ZookeeperProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.sync.data.zookeeper.ZookeeperProperties"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/src/main/java/org/apache/shenyu/springboot/sync/data/zookeeper/ZookeeperSyncDataConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.sync.data.zookeeper.ZookeeperSyncDataConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/src/test/java/org/apache/shenyu/springboot/sync/data/zookeeper/ZookeeperSyncDataConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.sync.data.zookeeper.ZookeeperSyncDataConfigurationTest"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.zookeeper.ZookeeperClient"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.zookeeper.ZookeeperConfig"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/main/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.zookeeper.ZookeeperSyncDataService"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/test/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.zookeeper.ZookeeperClientTest"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-zookeeper/src/test/java/org/apache/shenyu/sync/data/zookeeper/ZookeeperSyncDataServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.zookeeper.ZookeeperSyncDataServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8df49049061f09217723a0afc3019d4cd123ee7d",
+    "headCommit" : "cdd56c659577a12e1fd4952cfe15b40a860ba308",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.AiProxyPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/cache/AiProxyApiKeyCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.cache.AiProxyApiKeyCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/cache/ChatClientCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.cache.ChatClientCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/handler/AiProxyPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.handler.AiProxyPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyConfigService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyConfigService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyExecutorService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyExecutorService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/subscriber/CommonAiProxyApiKeyDataSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.subscriber.CommonAiProxyApiKeyDataSubscriber"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/AiProxyPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.AiProxyPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/cache/AiProxyApiKeyCacheTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.cache.AiProxyApiKeyCacheTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyConfigServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyConfigServiceTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyExecutorServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyExecutorServiceTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy-enhanced/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/subscriber/CommonAiProxyApiKeyDataSubscriberTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.subscriber.CommonAiProxyApiKeyDataSubscriberTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/AiProxyPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.AiProxyPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/cache/AiProxyApiKeyCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.cache.AiProxyApiKeyCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/cache/ChatClientCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.cache.ChatClientCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/handler/AiProxyPluginHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.handler.AiProxyPluginHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyConfigService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyConfigService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyExecutorService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyExecutorService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/enhanced/subscriber/CommonAiProxyApiKeyDataSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.subscriber.CommonAiProxyApiKeyDataSubscriber"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/AiProxyPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.AiProxyPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/cache/AiProxyApiKeyCacheTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.cache.AiProxyApiKeyCacheTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyConfigServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyConfigServiceTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/service/AiProxyExecutorServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.service.AiProxyExecutorServiceTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/enhanced/subscriber/CommonAiProxyApiKeyDataSubscriberTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.enhanced.subscriber.CommonAiProxyApiKeyDataSubscriberTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cdd56c659577a12e1fd4952cfe15b40a860ba308",
+    "headCommit" : "dcdd72788a5baa6d61ce1ae1d2351000d9d96485",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/NettyHttpClientPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.NettyHttpClientPlugin"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "dcdd72788a5baa6d61ce1ae1d2351000d9d96485",
+    "headCommit" : "d14a4238dc4710a9dc48f87804e7ac621c9bee19",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallback"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/request/RequestConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.RequestConfig"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d14a4238dc4710a9dc48f87804e7ac621c9bee19",
+    "headCommit" : "1de8abb44639b68ac93b9d7e386df671ab1ec098",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-resilience4j/src/test/java/org/apache/shenyu/plugin/resilience4j/Resilience4JPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.resilience4j.Resilience4JPluginTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1de8abb44639b68ac93b9d7e386df671ab1ec098",
+    "headCommit" : "d8fbb5257efa53540e6410bec9f5fe65ba215399",
+    "changedFiles" : [ {
+      "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/utils/VersionUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.VersionUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d8fbb5257efa53540e6410bec9f5fe65ba215399",
+    "headCommit" : "b97c7db820e68cd052a9d9938eef33551d2a4ab6",
+    "changedFiles" : [ {
+      "path" : "shenyu-disruptor/src/main/java/org/apache/shenyu/disruptor/DisruptorProviderManage.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.disruptor.DisruptorProviderManage"
+    }, {
+      "path" : "shenyu-disruptor/src/main/java/org/apache/shenyu/disruptor/provider/DisruptorProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.disruptor.provider.DisruptorProvider"
+    }, {
+      "path" : "shenyu-disruptor/src/test/java/org/apache/shenyu/disruptor/provider/DisruptorProviderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.disruptor.provider.DisruptorProviderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b97c7db820e68cd052a9d9938eef33551d2a4ab6",
+    "headCommit" : "385f2b8a0f21dbd472d056f3c8f7244fedfec219",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/ShenyuSseServerTransportProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.ShenyuSseServerTransportProvider"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "385f2b8a0f21dbd472d056f3c8f7244fedfec219",
+    "headCommit" : "3c29cc36c7f3948ec97b98a43fe00b094056c268",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallback"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3c29cc36c7f3948ec97b98a43fe00b094056c268",
+    "headCommit" : "71ff9d26e01e233fc571eac02e55f5ee86a65bb0",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/UpstreamCheckService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.UpstreamCheckService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/DiscoveryTransfer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.transfer.DiscoveryTransfer"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/utils/CommonUpstreamUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.CommonUpstreamUtils"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.UpstreamCheckServiceTest"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/selector/CommonUpstream.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.selector.CommonUpstream"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/selector/DivideUpstream.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.selector.DivideUpstream"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/selector/GrpcUpstream.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.selector.GrpcUpstream"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/cache/UpstreamCacheManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCacheManager"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/cache/UpstreamCheckTask.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCheckTask"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/entity/Upstream.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.entity.Upstream"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/cache/UpstreamCacheManagerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCacheManagerTest"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/cache/UpstreamCheckTaskTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCheckTaskTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/src/main/java/org/apache/shenyu/plugin/divide/handler/DivideUpstreamDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.divide.handler.DivideUpstreamDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/proxy/ApacheDubboProxyService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.proxy.ApacheDubboProxyService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/src/main/java/org/apache/shenyu/plugin/dubbo/common/handler/AbstractDubboPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.dubbo.common.handler.AbstractDubboPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/handler/GrpcDiscoveryUpstreamDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.grpc.handler.GrpcDiscoveryUpstreamDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/loadbalance/picker/ShenyuPicker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.grpc.loadbalance.picker.ShenyuPicker"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-websocket/src/main/java/org/apache/shenyu/plugin/websocket/handler/WebSocketUpstreamDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.websocket.handler.WebSocketUpstreamDataHandler"
+    }, {
+      "path" : "shenyu-web/src/main/java/org/apache/shenyu/web/controller/LocalPluginController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.controller.LocalPluginController"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "71ff9d26e01e233fc571eac02e55f5ee86a65bb0",
+    "headCommit" : "fbc3c4bf4975055da422b2d8ae9d0df52321925d",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallback"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "fbc3c4bf4975055da422b2d8ae9d0df52321925d",
+    "headCommit" : "74954fa2b9e5a8d0426929ad754a78048be32c9f",
+    "changedFiles" : [ {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/src/test/java/org/apache/shenyu/infra/etcd/client/EtcdClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.infra.etcd.client.EtcdClientTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "74954fa2b9e5a8d0426929ad754a78048be32c9f",
+    "headCommit" : "a6b8de170008aab26879952a797b5d8a85ae18d6",
+    "changedFiles" : [ {
+      "path" : "shenyu-e2e/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a6b8de170008aab26879952a797b5d8a85ae18d6",
+    "headCommit" : "cb3c582f4cf0457ddb8cbbc1d465083c237ed787",
+    "changedFiles" : [ {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/cache/UpstreamCacheManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCacheManager"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/cache/UpstreamCheckTask.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCheckTask"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/cache/UpstreamCacheManagerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCacheManagerTest"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/cache/UpstreamCheckTaskTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCheckTaskTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cb3c582f4cf0457ddb8cbbc1d465083c237ed787",
+    "headCommit" : "64ad46fa44d6295d284660afbd12fe0080d4b963",
+    "changedFiles" : [ {
+      "path" : "shenyu-dist/shenyu-admin-dist/docker/Dockerfile",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/docker/Dockerfile",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "64ad46fa44d6295d284660afbd12fe0080d4b963",
+    "headCommit" : "1d8879a4a8b99ec667fe19fa3c8a8db20fd0d9a3",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/PluginController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.PluginController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/query/PluginQuery.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.query.PluginQuery"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/plugin-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/PluginControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.PluginControllerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1d8879a4a8b99ec667fe19fa3c8a8db20fd0d9a3",
+    "headCommit" : "dff154a7dc8349ab51649c9155261113e81facfd",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/resources/static/index.814edc73.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.a6d776d6.js",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/index.html",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/static/asf_logo.1bf96e15.svg",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/static/support-apache.da556428.png",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/resources/static/static/support-apache.f17e77a6.png",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "dff154a7dc8349ab51649c9155261113e81facfd",
+    "headCommit" : "75ade3625f5483a5848ccabe287235aea49e33a1",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/manager/ShenyuMcpServerManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.manager.ShenyuMcpServerManager"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/model/ShenyuMcpServerTool.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.model.ShenyuMcpServerTool"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "75ade3625f5483a5848ccabe287235aea49e33a1",
+    "headCommit" : "556e840f373daa7b8ca5979c76b14270b9bd0989",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AppAuthServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.AppAuthServiceImpl"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "556e840f373daa7b8ca5979c76b14270b9bd0989",
+    "headCommit" : "b94f2a242504306bca8574c4321efa7cb51337c7",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/InstanceInfoServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.InstanceInfoServiceImpl"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b94f2a242504306bca8574c4321efa7cb51337c7",
+    "headCommit" : "1a92cca9a43196ba8dc32d5a8cc4f12a1f361451",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ApiServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.ApiServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/TagServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.TagServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.shiro.config.ShiroConfigurationTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1a92cca9a43196ba8dc32d5a8cc4f12a1f361451",
+    "headCommit" : "e5c1db9f826a535969a41777ee8fc111af687544",
+    "changedFiles" : [ {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/utils/GsonUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.GsonUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e5c1db9f826a535969a41777ee8fc111af687544",
+    "headCommit" : "29f9d5ff75b42a316ce7968845fab467ab62748c",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/AbstractHttpClientPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.AbstractHttpClientPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/NettyHttpClientPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.NettyHttpClientPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallback"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/response/NonCommittingMcpResponseDecorator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.response.NonCommittingMcpResponseDecorator"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "29f9d5ff75b42a316ce7968845fab467ab62748c",
+    "headCommit" : "c224816207e5f71cc5e9f8e0041d0cc0218f4c95",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/McpServerPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.McpServerPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/handler/McpServerPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.handler.McpServerPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/ShenyuSseServerTransportProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.ShenyuSseServerTransportProvider"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/ShenyuStreamableHttpServerTransportProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.ShenyuStreamableHttpServerTransportProvider"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/McpServerPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.McpServerPluginTest"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mcp-server/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c224816207e5f71cc5e9f8e0041d0cc0218f4c95",
+    "headCommit" : "205fe32a3c06b654dcd03529c39c980b105a4492",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/AiRequestTransformerPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.AiRequestTransformerPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/template/AiRequestTransformerTemplate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.template.AiRequestTransformerTemplate"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/request/AiRequestTransformerPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.AiRequestTransformerPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/response/AiResponseTransformerPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.response.AiResponseTransformerPlugin"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "205fe32a3c06b654dcd03529c39c980b105a4492",
+    "headCommit" : "6f828183710981cd5635b4bb38bc6229df9cfa5e",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/McpServerPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.McpServerPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/manager/ShenyuMcpServerManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.manager.ShenyuMcpServerManager"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/ShenyuStreamableHttpServerTransportProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.ShenyuStreamableHttpServerTransportProvider"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/StreamableHttpProviderBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.StreamableHttpProviderBuilder"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/McpServerPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.McpServerPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/transport/ShenyuStreamableHttpServerTransportProviderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.ShenyuStreamableHttpServerTransportProviderTest"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mcp-server/src/main/java/org/apache/shenyu/springboot/starter/plugin/mcp/server/McpServerPluginConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.mcp.server.McpServerPluginConfiguration"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6f828183710981cd5635b4bb38bc6229df9cfa5e",
+    "headCommit" : "7ff5ba3164da052b22ebbb1ae21c8c1975a5a8a8",
+    "changedFiles" : [ {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/cache/UpstreamCacheManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCacheManager"
+    }, {
+      "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/entity/Upstream.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.entity.Upstream"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/cache/UpstreamCacheManagerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCacheManagerTest"
+    }, {
+      "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/entity/UpstreamTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.loadbalancer.entity.UpstreamTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7ff5ba3164da052b22ebbb1ae21c8c1975a5a8a8",
+    "headCommit" : "c2efae14e795655f3ec37a9e9e78d33bfeedf5dc",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/src/main/java/org/apache/shenyu/client/mcp/generator/McpRequestConfigGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.generator.McpRequestConfigGenerator"
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-register/src/main/java/org/apache/shenyu/client/mcp/McpServiceEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.mcp.McpServiceEventListener"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/handler/McpServerPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.handler.McpServerPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/manager/ShenyuMcpServerManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.manager.ShenyuMcpServerManager"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/request/RequestConfigHelper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.RequestConfigHelper"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/ShenyuSseServerTransportProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.ShenyuSseServerTransportProvider"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/transport/ShenyuStreamableHttpServerTransportProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.transport.ShenyuStreamableHttpServerTransportProvider"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/McpServerPluginIntegrationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.McpServerPluginIntegrationTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/handler/McpServerPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.handler.McpServerPluginDataHandlerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/manager/ShenyuMcpServerManagerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.manager.ShenyuMcpServerManagerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/request/RequestConfigHelperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.RequestConfigHelperTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c2efae14e795655f3ec37a9e9e78d33bfeedf5dc",
+    "headCommit" : "c39506e97ceef9490a97c736fd5098ce97d6f3a0",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/RuleServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.RuleServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/mappers/rule-sqlmap.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/RuleServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.RuleServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c39506e97ceef9490a97c736fd5098ce97d6f3a0",
+    "headCommit" : "5c2c3ed612e5bc7b6c87f45c8ceef65321f7948c",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/ci.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5c2c3ed612e5bc7b6c87f45c8ceef65321f7948c",
+    "headCommit" : "295a12bb56539465ba3d979c0e8bbf13b2696fce",
+    "changedFiles" : [ {
+      "path" : "shenyu-bootstrap/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/config/ShenyuConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.config.ShenyuConfig"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/TrieCacheTypeEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.TrieCacheTypeEnum"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/TrieEventEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.TrieEventEnum"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/TrieMatchModeEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.TrieMatchModeEnum"
+    }, {
+      "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/enums/TrieEventEnumTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.TrieEventEnumTest"
+    }, {
+      "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/enums/TrieMatchModeEnumTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.TrieMatchModeEnumTest"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-cm.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/k8s/shenyu-cm.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-apache-dubbo/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-http/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-websocket/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/AbstractShenyuPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.AbstractShenyuPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.cache.CommonPluginDataSubscriber"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/event/TrieEvent.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.event.TrieEvent"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/trie/ShenyuTrie.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.trie.ShenyuTrie"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/trie/ShenyuTrieListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.trie.ShenyuTrieListener"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/trie/ShenyuTrieNode.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.trie.ShenyuTrieNode"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/AbstractShenyuPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.AbstractShenyuPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/cache/CommonPluginDataSubscriberTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.cache.CommonPluginDataSubscriberTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/trie/ShenyuRuleTrieTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.trie.ShenyuRuleTrieTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/test/java/org/apache/shenyu/plugin/base/trie/ShenyuSelectorTrieTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.trie.ShenyuSelectorTrieTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/java/org/apache/shenyu/plugin/wasm/base/AbstractShenyuWasmPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.base.AbstractShenyuWasmPluginTest"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/main/java/org/apache/shenyu/springboot/starter/gateway/ShenyuConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.gateway.ShenyuConfiguration"
+    }, {
+      "path" : "shenyu-web/src/main/java/org/apache/shenyu/web/controller/LocalPluginController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.controller.LocalPluginController"
+    }, {
+      "path" : "shenyu-web/src/main/java/org/apache/shenyu/web/endpoint/ShenyuControllerEndpoint.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.endpoint.ShenyuControllerEndpoint"
+    }, {
+      "path" : "shenyu-web/src/test/java/org/apache/shenyu/web/controller/LocalPluginControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.controller.LocalPluginControllerTest"
+    }, {
+      "path" : "shenyu-web/src/test/java/org/apache/shenyu/web/endpoint/ShenyuControllerEndpointTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.endpoint.ShenyuControllerEndpointTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "295a12bb56539465ba3d979c0e8bbf13b2696fce",
+    "headCommit" : "7248388da1796866be10af9cb68b5ebe1b70fe8b",
+    "changedFiles" : [ {
+      "path" : "shenyu-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7248388da1796866be10af9cb68b5ebe1b70fe8b",
+    "headCommit" : "8e437489c9b90b9549c4ad2ae1a8ed6843abec53",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8e437489c9b90b9549c4ad2ae1a8ed6843abec53",
+    "headCommit" : "87e0fe8604ec07eb0bb0ca243d92844eb4e8a51c",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/manager/impl/PullSwaggerDocServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.manager.impl.PullSwaggerDocServiceImpl"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "87e0fe8604ec07eb0bb0ca243d92844eb4e8a51c",
+    "headCommit" : "0a927fdd1663291185363dc37defbd231392037d",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/RuleServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.RuleServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/RuleServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.RuleServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0a927fdd1663291185363dc37defbd231392037d",
+    "headCommit" : "2870eab95ed69700abd918f46a0cbc387b94dd74",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.PluginEnum"
+    }, {
+      "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/enums/PluginEnumTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.PluginEnumTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2870eab95ed69700abd918f46a0cbc387b94dd74",
+    "headCommit" : "d45cd7012b7ef708d767ce7ada346a3fadc72b81",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/ci.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d45cd7012b7ef708d767ce7ada346a3fadc72b81",
+    "headCommit" : "2c44e7ef7e7bf1b5cb0a3adee68106547c810ee2",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/MCP_TOOL_EXAMPLES.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/MCP_TOOL_EXAMPLES_EN.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallback"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/session/McpSessionHelper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.session.McpSessionHelper"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallbackTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallbackTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2c44e7ef7e7bf1b5cb0a3adee68106547c810ee2",
+    "headCommit" : "bec32f355972e095ef57289e84a30578b71b60ee",
+    "changedFiles" : [ {
+      "path" : ".gitignore",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/utils/UrlSecurityUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.UrlSecurityUtils"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/SwaggerImportServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.SwaggerImportServiceTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/UrlSecurityUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.UrlSecurityUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bec32f355972e095ef57289e84a30578b71b60ee",
+    "headCommit" : "aceaf5b2aa1aff229f557c387e6aefbf46666380",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/RegistryVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.RegistryVO"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/transfer/RegistryTransferTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.transfer.RegistryTransferTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "aceaf5b2aa1aff229f557c387e6aefbf46666380",
+    "headCommit" : "0e1cc3cb28b1996594b3a0ea27ce0452209bc58c",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SwaggerImportServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/utils/HttpUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.HttpUtils"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/HttpUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.HttpUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0e1cc3cb28b1996594b3a0ea27ce0452209bc58c",
+    "headCommit" : "f258aecad7328d7e0328f0c0d0f0a4254fcf66c6",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DataPermissionController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.DataPermissionController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/RuleController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.RuleController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/SelectorController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.SelectorController"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/DataPermissionControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.DataPermissionControllerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/RuleControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.RuleControllerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/SelectorControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.SelectorControllerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f258aecad7328d7e0328f0c0d0f0a4254fcf66c6",
+    "headCommit" : "33c79d19a2613fe1b64998c593f117d3cede3cbb",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-mock/src/test/java/org/apache/shenyu/plugin/mock/generator/ExpressionGeneratorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.mock.generator.ExpressionGeneratorTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "33c79d19a2613fe1b64998c593f117d3cede3cbb",
+    "headCommit" : "e6298fab1054c4ddff79ed61c5ffed13956a924c",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e6298fab1054c4ddff79ed61c5ffed13956a924c",
+    "headCommit" : "31f0a4d8a7e2ae99beafcb2523e67419ac11b81a",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DashboardUserServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.DashboardUserServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SecretServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SecretServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/PlatformControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.PlatformControllerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/DashboardUserServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.DashboardUserServiceTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/SecretServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.SecretServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "31f0a4d8a7e2ae99beafcb2523e67419ac11b81a",
+    "headCommit" : "a19cb16ff67afaa58ed078390cd621be1c682229",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a19cb16ff67afaa58ed078390cd621be1c682229",
+    "headCommit" : "4f346c577f79cf2391f14b46c7384250df9c2056",
+    "changedFiles" : [ {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-apollo/src/test/java/org/apache/shenyu/sync/data/apollo/ApolloDataServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.apollo.ApolloDataServiceTest"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-polaris/src/test/java/org/apache/shenyu/sync/data/polaris/PolarisSyncDataServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.sync.data.polaris.PolarisSyncDataServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4f346c577f79cf2391f14b46c7384250df9c2056",
+    "headCommit" : "e2c21ed11433e774fa341dd4a52ec369f9cdf98d",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/aspect/controller/SuperAdminPasswordSafeAdviceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.aspect.controller.SuperAdminPasswordSafeAdviceTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/config/properties/DashboardPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.DashboardPropertiesTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/disruptor/RegisterClientServerDisruptorPublisherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.disruptor.RegisterClientServerDisruptorPublisherTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/disruptor/executor/RegisterServerConsumerExecutorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.disruptor.executor.RegisterServerConsumerExecutorTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/disruptor/subscriber/ApiDocExecutorSubscriberTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.disruptor.subscriber.ApiDocExecutorSubscriberTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/disruptor/subscriber/DiscoveryConfigRegisterExecutorSubscriberTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.disruptor.subscriber.DiscoveryConfigRegisterExecutorSubscriberTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/exception/I18nExceptionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.exception.I18nExceptionTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/exception/ResourceNotFoundExceptionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.exception.ResourceNotFoundExceptionTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/exception/ShenyuAdminExceptionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.exception.ShenyuAdminExceptionTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/exception/ValidFailExceptionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.exception.ValidFailExceptionTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/exception/WebI18nExceptionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.exception.WebI18nExceptionTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/ApplicationStartListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.ApplicationStartListenerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/DataChangedEventDispatcherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.DataChangedEventDispatcherTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/http/HttpLongPollingDataChangedListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.http.HttpLongPollingDataChangedListenerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/websocket/WebsocketCollectorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketCollectorTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/websocket/WebsocketConfiguratorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketConfiguratorTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/websocket/WebsocketDataChangedListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketDataChangedListenerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/websocket/WebsocketListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketListenerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/converter/DivideSelectorHandleConverterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.converter.DivideSelectorHandleConverterTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/converter/DubboSelectorHandleConverterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.converter.DubboSelectorHandleConverterTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/converter/GrpcSelectorHandleConverterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.converter.GrpcSelectorHandleConverterTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/converter/SelectorHandleConverterFactorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.converter.SelectorHandleConverterFactorTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/converter/TarsSelectorHandleConverterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.converter.TarsSelectorHandleConverterTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/DictEventPublisherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.publish.DictEventPublisherTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/MetaDataEventPublisherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.publish.MetaDataEventPublisherTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/NamespaceEventPublisherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.publish.NamespaceEventPublisherTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/NamespacePluginEventPublisherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.publish.NamespacePluginEventPublisherTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/PluginEventPublisherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.publish.PluginEventPublisherTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/PluginHandleEventPublisherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.publish.PluginHandleEventPublisherTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/ResourceEventPublisherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.publish.ResourceEventPublisherTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/RoleEventPublisherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.publish.RoleEventPublisherTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/RuleEventPublisherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.publish.RuleEventPublisherTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/SelectorEventPublisherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.publish.SelectorEventPublisherTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/publish/UserEventPublisherTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.publish.UserEventPublisherTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/BaseTriggerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.BaseTriggerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/CommonUpstreamUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.CommonUpstreamUtilsTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/HttpUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.HttpUtilsTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/JwtUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.JwtUtilsTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/ResourceUtilTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.ResourceUtilTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/SelectorUtilTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.SelectorUtilTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/utils/WebI18nAssertTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.WebI18nAssertTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e2c21ed11433e774fa341dd4a52ec369f9cdf98d",
+    "headCommit" : "fb454de3cb21d5dae7a281a7aae492d5bbb26ebc",
+    "changedFiles" : [ {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-websocket/src/main/java/org/apache/shenyu/springboot/plugin/websocket/WebSocketPluginConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.plugin.websocket.WebSocketPluginConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-websocket/src/test/java/org/apache/shenyu/springboot/plugin/websocket/WebSocketPluginConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.plugin.websocket.WebSocketPluginConfigurationTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "fb454de3cb21d5dae7a281a7aae492d5bbb26ebc",
+    "headCommit" : "73b580d3c07c74904d2d72ce3dc2b3a3aee44d2a",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "73b580d3c07c74904d2d72ce3dc2b3a3aee44d2a",
+    "headCommit" : "c8961528b72a2a7f81f0d1cd7525af1659a670bc",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/client/AbstractContextRefreshedEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.client.AbstractContextRefreshedEventListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springmvc/src/main/java/org/apache/shenyu/client/springmvc/init/SpringMvcClientEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springmvc.init.SpringMvcClientEventListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springmvc/src/test/java/org/apache/shenyu/client/springmvc/init/SpringMvcClientEventListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springmvc.init.SpringMvcClientEventListenerTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket/src/main/java/org/apache/shenyu/client/spring/websocket/init/SpringWebSocketClientEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.spring.websocket.init.SpringWebSocketClientEventListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket/src/test/java/org/apache/shenyu/client/spring/websocket/init/SpringWebSocketClientEventListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.spring.websocket.init.SpringWebSocketClientEventListenerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c8961528b72a2a7f81f0d1cd7525af1659a670bc",
+    "headCommit" : "338ea9adaff36140c478cc6e2ef01dea8c3c46d8",
+    "changedFiles" : [ {
+      "path" : ".asf.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test-k8s-ingress.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/ApiDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.ApiDTO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/ApiDO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.entity.ApiDO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/ApiVO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.vo.ApiVO"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterMotanServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterMotanServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterMotanServiceImplTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterMotanServiceImplTest"
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-motan/src/main/java/org/apache/shenyu/client/motan/MotanServiceEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.motan.MotanServiceEventListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-motan/src/main/java/org/apache/shenyu/client/motan/common/annotation/ShenyuMotanClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.motan.common.annotation.ShenyuMotanClient"
+    }, {
+      "path" : "shenyu-client/shenyu-client-motan/src/main/java/org/apache/shenyu/client/motan/common/annotation/ShenyuMotanService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.motan.common.annotation.ShenyuMotanService"
+    }, {
+      "path" : "shenyu-client/shenyu-client-motan/src/main/java/org/apache/shenyu/client/motan/common/dto/MotanRpcExt.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.motan.common.dto.MotanRpcExt"
+    }, {
+      "path" : "shenyu-client/shenyu-client-motan/src/test/java/org/apache/shenyu/client/motan/MotanServiceEventListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.motan.MotanServiceEventListenerTest"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/plugin/MotanRegisterConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.plugin.MotanRegisterConfig"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/dto/convert/selector/MotanUpstream.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.selector.MotanUpstream"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/PluginEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.PluginEnum"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/enums/RpcTypeEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.RpcTypeEnum"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/utils/PluginNameAdapter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.utils.PluginNameAdapter"
+    }, {
+      "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/dto/convert/plugin/MotanRegisterConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.dto.convert.plugin.MotanRegisterConfigTest"
+    }, {
+      "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/enums/PluginEnumTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.PluginEnumTest"
+    }, {
+      "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/enums/RpcTypeEnumTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.enums.RpcTypeEnumTest"
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/src/main/release-docs/README.txt",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/README.txt",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-motan/src/test/java/org/apache/shenyu/e2e/testcase/motan/MotanPluginCases.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.testcase.motan.MotanPluginCases"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-motan/src/test/java/org/apache/shenyu/e2e/testcase/motan/MotanPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.testcase.motan.MotanPluginTest"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-common/src/main/java/org/apache/shenyu/e2e/model/Plugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.e2e.model.Plugin"
+    }, {
+      "path" : "shenyu-examples/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-api/src/main/java/org/apache/shenyu/examples/motan/service/MotanClassDemoService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.motan.service.MotanClassDemoService"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-api/src/main/java/org/apache/shenyu/examples/motan/service/MotanDemoService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.motan.service.MotanDemoService"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-api/src/main/java/org/apache/shenyu/examples/motan/service/MotanTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.motan.service.MotanTest"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/Dockerfile",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/k8s/ingress.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/k8s/shenyu-examples-motan.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/k8s/shenyu-zookeeper.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/src/main/http/motan-class-test-api.http",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/src/main/http/motan-test-api.http",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/src/main/java/org/apache/shenyu/examples/motan/service/TestMotanApplication.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.motan.service.TestMotanApplication"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/src/main/java/org/apache/shenyu/examples/motan/service/impl/MotanClassDemoServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.motan.service.impl.MotanClassDemoServiceImpl"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/src/main/java/org/apache/shenyu/examples/motan/service/impl/MotanDemoServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.motan.service.impl.MotanDemoServiceImpl"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-motan/shenyu-examples-motan-service/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-combination/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-combination/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-combination/src/main/java/org/apache/shenyu/integrated/test/combination/controller/SharedThreadPoolController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.combination.controller.SharedThreadPoolController"
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-combination/src/test/java/org/apache/shenyu/integrated/test/combination/SharedThreadPoolTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.combination.SharedThreadPoolTest"
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-common/src/main/java/org/apache/shenyu/integratedtest/common/dto/MotanDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integratedtest.common.dto.MotanDTO"
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/Dockerfile",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/deploy/deploy-shenyu.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/deploy/kind-config.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/script/build_k8s_cluster.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/script/healthcheck.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/script/services.list",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/src/main/java/org/apache/shenyu/integrated/test/k8s/ingress/motan/MotanIngressControllerIntegratedBootstrap.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.k8s.ingress.motan.MotanIngressControllerIntegratedBootstrap"
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-motan/src/test/java/org/apache/shenyu/integrated/test/k8s/ingress/motan/MotanPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.k8s.ingress.motan.MotanPluginTest"
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/Dockerfile",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/script/healthcheck.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/script/services.list",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/src/main/java/org/apache/shenyu/integrated/test/motan/MotanIntegratedBootstrap.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.motan.MotanIntegratedBootstrap"
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/src/main/resources/application-local.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/src/test/java/org/apache/shenyu/integrated/test/motan/MotanPluginShareThreadPoolTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.motan.MotanPluginShareThreadPoolTest"
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-motan/src/test/java/org/apache/shenyu/integrated/test/motan/MotanPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.motan.MotanPluginTest"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/main/java/org/apache/shenyu/k8s/common/IngressConstants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.common.IngressConstants"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/main/java/org/apache/shenyu/k8s/parser/IngressParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.parser.IngressParser"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/main/java/org/apache/shenyu/k8s/parser/MotanIngressParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.parser.MotanIngressParser"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/main/java/org/apache/shenyu/k8s/reconciler/IngressReconciler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.reconciler.IngressReconciler"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/test/java/org/apache/shenyu/k8s/MotanReconcilerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.MotanReconcilerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/result/ShenyuResultEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.api.result.ShenyuResultEnum"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/src/test/java/org/apache/shenyu/plugin/api/result/ShenyuResultEnumTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.api.result.ShenyuResultEnumTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-general-context/src/main/java/org/apache/shenyu/plugin/general/context/GeneralContextPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.general.context.GeneralContextPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/MotanPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.MotanPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/cache/ApplicationConfigCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.cache.ApplicationConfigCache"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/context/MotanShenyuContextDecorator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.context.MotanShenyuContextDecorator"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/handler/MotanMetaDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.handler.MotanMetaDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/handler/MotanPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.handler.MotanPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/proxy/MotanProxyService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.proxy.MotanProxyService"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/util/PrxInfoUtil.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.util.PrxInfoUtil"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/test/java/org/apache/shenyu/plugin/motan/MotanPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.MotanPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/test/java/org/apache/shenyu/plugin/motan/cache/ApplicationConfigCacheTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.cache.ApplicationConfigCacheTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/test/java/org/apache/shenyu/plugin/motan/context/MotanShenyuContextDecoratorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.context.MotanShenyuContextDecoratorTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/test/java/org/apache/shenyu/plugin/motan/handler/MotanPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.handler.MotanPluginDataHandlerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/test/java/org/apache/shenyu/plugin/motan/proxy/MotanProxyServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.proxy.MotanProxyServiceTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/test/java/org/apache/shenyu/plugin/motan/util/PrxInfoUtilTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.motan.util.PrxInfoUtilTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-transform/src/main/java/org/apache/shenyu/plugin/transform/RpcParamTransformPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.transform.RpcParamTransformPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-response/src/main/java/org/apache/shenyu/plugin/response/strategy/RPCMessageWriter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.response.strategy.RPCMessageWriter"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-response/src/test/java/org/apache/shenyu/plugin/response/ResponsePluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.response.ResponsePluginTest"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/dto/ApiDocRegisterDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.common.dto.ApiDocRegisterDTO"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/src/main/java/org/apache/shenyu/register/common/enums/RegisterTypeEnum.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.common.enums.RegisterTypeEnum"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/src/main/java/org/apache/shenyu/springboot/starter/client/motan/ShenyuMotanClientConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.client.motan.ShenyuMotanClientConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/src/main/java/org/apache/shenyu/springboot/starter/client/motan/property/RegistryConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.client.motan.property.RegistryConfig"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/src/main/java/org/apache/shenyu/springboot/starter/client/motan/property/ShenyuMotanConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.client.motan.property.ShenyuMotanConfig"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-motan/src/test/java/org/apache/shenyu/springboot/starter/client/motan/ShenyuMotanClientConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.client.motan.ShenyuMotanClientConfigurationTest"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-motan/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-motan/src/main/java/org/apache/shenyu/springboot/starter/plugin/motan/MotanPluginConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.motan.MotanPluginConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-motan/src/main/resources/META-INF/spring.factories",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-motan/src/main/resources/META-INF/spring.provides",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-motan/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-motan/src/test/java/org/apache/shenyu/springboot/starter/plugin/motan/MotanPluginConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.plugin.motan.MotanPluginConfigurationTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "338ea9adaff36140c478cc6e2ef01dea8c3c46d8",
+    "headCommit" : "73a4a06811e3ed1325a7e1af91a2247b12ee2b8b",
+    "changedFiles" : [ {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-api/src/main/java/org/apache/shenyu/register/client/api/FailbackRegistryRepository.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.api.FailbackRegistryRepository"
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-api/src/test/java/org/apache/shenyu/register/client/api/FailbackRegistryRepositoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.register.client.api.FailbackRegistryRepositoryTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "73a4a06811e3ed1325a7e1af91a2247b12ee2b8b",
+    "headCommit" : "e3cf5ce54a4448ce246fba3d2bdfdb4a5e651cbd",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/src/main/java/org/apache/shenyu/plugin/ai/prompt/AiPromptPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.prompt.AiPromptPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/src/test/java/org/apache/shenyu/plugin/ai/prompt/AiPromptPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.ai.prompt.AiPromptPluginTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e3cf5ce54a4448ce246fba3d2bdfdb4a5e651cbd",
+    "headCommit" : "7dc8ecc59d33b33f0ecaf0ac05976756a42d3f93",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/disruptor/subcriber/ShenyuClientURIExecutorSubscriber.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriber"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7dc8ecc59d33b33f0ecaf0ac05976756a42d3f93",
+    "headCommit" : "7c8a67ddfc26ab6091c8112746592ebb11db7916",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.UpstreamCheckServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7c8a67ddfc26ab6091c8112746592ebb11db7916",
+    "headCommit" : "48e48df4ddde91938f4be3d11c91a8f21be8c0cc",
+    "changedFiles" : [ {
+      "path" : "README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "48e48df4ddde91938f4be3d11c91a8f21be8c0cc",
+    "headCommit" : "0e41bcc4e46a561c3a942613b25409a5aa7b2a8d",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SandboxServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SandboxServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SandboxServiceImplTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SandboxServiceImplTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0e41bcc4e46a561c3a942613b25409a5aa7b2a8d",
+    "headCommit" : "48120c13668150b9e9b4c9f0786f671451d58ecc",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/ci.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/docker-publish-dockerhub.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/docker-publish.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/e2e-k8s.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test-k8s-ingress.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/k8s-examples-http.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "actions/setup-java-with-retry/action.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/k8s/shenyu-examples-dubbo.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-grpc/k8s/shenyu-examples-grpc.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http/src/main/java/org/apache/shenyu/examples/http/controller/HttpTestController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.http.controller.HttpTestController"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/k8s/shenyu-examples-sofa.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-annotation-websocket/k8s/shenyu-example-spring-annotation-websocket.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-annotation-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/k8s-ingress-healthcheck.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/SentinelPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.http.combination.SentinelPluginTest"
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-apache-dubbo/deploy/kind-config.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-apache-dubbo/script/healthcheck.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-grpc/deploy/kind-config.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-grpc/script/healthcheck.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-grpc/script/services.list",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-http/deploy/kind-config.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-http/script/healthcheck.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-sofa/deploy/kind-config.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-sofa/script/services.list",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-websocket/script/healthcheck.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-websocket/script/services.list",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/main/java/org/apache/shenyu/k8s/reconciler/EndpointsReconciler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.reconciler.EndpointsReconciler"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/test/java/org/apache/shenyu/k8s/EndpointsReconcilerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.EndpointsReconcilerTest"
+    }, {
+      "path" : "shenyu-web/src/main/java/org/apache/shenyu/web/fallback/DefaultFallbackController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.fallback.DefaultFallbackController"
+    }, {
+      "path" : "shenyu-web/src/test/java/org/apache/shenyu/web/fallback/DefaultFallbackControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.web.fallback.DefaultFallbackControllerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "48120c13668150b9e9b4c9f0786f671451d58ecc",
+    "headCommit" : "86e544b074b010eb787e1e062a4d7048461b10f3",
+    "changedFiles" : [ {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/SentinelPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.http.combination.SentinelPluginTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "86e544b074b010eb787e1e062a4d7048461b10f3",
+    "headCommit" : "0b16b58eb4bb1bbfd5e1182468f3fc87538d1c98",
+    "changedFiles" : [ {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-http.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-zookeeper.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-http/compose/script/e2e-http-sync-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0b16b58eb4bb1bbfd5e1182468f3fc87538d1c98",
+    "headCommit" : "d17b29d42da729e1e5a8691c3fa19739b30811fb",
+    "changedFiles" : [ {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/combination/SentinelPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.http.combination.SentinelPluginTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d17b29d42da729e1e5a8691c3fa19739b30811fb",
+    "headCommit" : "1ecc77c5117987d7bf775802e9dfb4586374fd6b",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/RuleService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.RuleService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/validation/validator/UriConditionValidator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.validation.validator.UriConditionValidator"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/validation/validator/UriConditionValidatorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.validation.validator.UriConditionValidatorTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1ecc77c5117987d7bf775802e9dfb4586374fd6b",
+    "headCommit" : "75a23bbd31c2af02102cdd9d85f685244c22dad5",
+    "changedFiles" : [ {
+      "path" : "shenyu-bootstrap/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/config/NettyHttpProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.config.NettyHttpProperties"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/main/java/org/apache/shenyu/springboot/starter/netty/ShenyuNettyWebServerConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.netty.ShenyuNettyWebServerConfiguration"
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/src/test/java/org/apache/shenyu/springboot/starter/netty/ShenyuNettyWebServerConfigurationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.springboot.starter.netty.ShenyuNettyWebServerConfigurationTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "75a23bbd31c2af02102cdd9d85f685244c22dad5",
+    "headCommit" : "ca83c6974d69e96c63f5a1d42272e9dcc738fd2b",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ApiServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.ApiServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/ApiServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.ApiServiceTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/client/AbstractContextRefreshedEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.client.AbstractContextRefreshedEventListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/register/registrar/AbstractApiDocRegistrar.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.register.registrar.AbstractApiDocRegistrar"
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/register/registrar/ApiDocRegistrarImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.register.registrar.ApiDocRegistrarImpl"
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/utils/OpenApiUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.utils.OpenApiUtils"
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/test/java/org/apache/shenyu/client/core/register/registrar/ApiDocRegistrarImplTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.register.registrar.ApiDocRegistrarImplTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/test/java/org/apache/shenyu/client/core/register/registrar/NoHttpApiDocRegistrarTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.register.registrar.NoHttpApiDocRegistrarTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/test/java/org/apache/shenyu/client/core/utils/OpenApiUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.utils.OpenApiUtilsTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/src/test/proto/test.proto",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-sofa/src/main/java/org/apache/shenyu/client/sofa/SofaServiceEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.sofa.SofaServiceEventListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-sofa/src/test/java/org/apache/shenyu/client/sofa/SofaServiceEventListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.sofa.SofaServiceEventListenerTest"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-rocketmq/compose/script/e2e-logging-rocketmq-compose.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-annotation/src/main/java/org/apache/shenyu/examples/apache/dubbo/service/annotation/impl/DubboProtobufServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.apache.dubbo.service.annotation.impl.DubboProtobufServiceImpl"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/src/main/java/org/apache/shenyu/examples/apache/dubbo/service/xml/impl/DubboProtobufServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.apache.dubbo.service.xml.impl.DubboProtobufServiceImpl"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/src/main/java/org/apache/shenyu/examples/apache/dubbo/service/impl/DubboProtobufServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.apache.dubbo.service.impl.DubboProtobufServiceImpl"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ca83c6974d69e96c63f5a1d42272e9dcc738fd2b",
+    "headCommit" : "3be50376da5904f6c9195cf7670285a4bb019065",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-request/src/main/java/org/apache/shenyu/plugin/request/RequestPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.request.RequestPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-request/src/test/java/org/apache/shenyu/plugin/request/RequestPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.request.RequestPluginTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3be50376da5904f6c9195cf7670285a4bb019065",
+    "headCommit" : "e1530777cd108d809a638e9ae9c6e0d8683d14f6",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/AbstractHttpClientPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.AbstractHttpClientPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/NettyHttpClientPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.NettyHttpClientPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/WebClientPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.httpclient.WebClientPlugin"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e1530777cd108d809a638e9ae9c6e0d8683d14f6",
+    "headCommit" : "6d3605af9c3f8805f7ae08b048fe812b84fab5ea",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/ci.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-websocket/deploy/kind-config.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-websocket/script/services.list",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6d3605af9c3f8805f7ae08b048fe812b84fab5ea",
+    "headCommit" : "470aefed12379970bcca16cf9c5571d0a3c8bc9b",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/licenses/LICENSE-chicory.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/licenses/LICENSE-jni-rs.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/licenses/LICENSE-wasi-cap-std-sync.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/licenses/LICENSE-wasi-common.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/licenses/LICENSE-wasmtime-wasi.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/licenses/LICENSE-wasmtime.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/src/main/java/org/apache/shenyu/plugin/wasm/api/AbstractWasmPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.api.AbstractWasmPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/src/main/java/org/apache/shenyu/plugin/wasm/api/loader/WasmLoader.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.api.loader.WasmLoader"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/src/test/go-wasm-plugin/Makefile",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/src/test/go-wasm-plugin/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/src/test/go-wasm-plugin/go.mod",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/src/test/go-wasm-plugin/main.go",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/src/test/java/org/apache/shenyu/plugin/wasm/api/AbstractWasmPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.api.AbstractWasmPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/src/test/resources/org.apache.shenyu.plugin.wasm.api.AbstractWasmPluginTest$GoWasmPlugin.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/src/test/resources/org.apache.shenyu.plugin.wasm.api.AbstractWasmPluginTest$RustWasmPlugin.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/main/java/org/apache/shenyu/plugin/wasm/base/AbstractShenyuWasmPlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.base.AbstractShenyuWasmPlugin"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/main/java/org/apache/shenyu/plugin/wasm/base/handler/AbstractWasmDiscoveryHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmDiscoveryHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/main/java/org/apache/shenyu/plugin/wasm/base/handler/AbstractWasmMetaDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmMetaDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/main/java/org/apache/shenyu/plugin/wasm/base/handler/AbstractWasmPluginDataHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmPluginDataHandler"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-discovery-handler/Makefile",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-discovery-handler/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-discovery-handler/go.mod",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-discovery-handler/main.go",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-meta-data-handler/Makefile",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-meta-data-handler/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-meta-data-handler/go.mod",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-meta-data-handler/main.go",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-plugin-data-handler/Makefile",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-plugin-data-handler/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-plugin-data-handler/go.mod",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-plugin-data-handler/main.go",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-shenyu-wasm-plugin/Makefile",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-shenyu-wasm-plugin/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-shenyu-wasm-plugin/go.mod",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/go-shenyu-wasm-plugin/main.go",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/java/org/apache/shenyu/plugin/wasm/base/AbstractShenyuWasmPluginTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.base.AbstractShenyuWasmPluginTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/java/org/apache/shenyu/plugin/wasm/base/handler/AbstractWasmDiscoveryHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmDiscoveryHandlerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/java/org/apache/shenyu/plugin/wasm/base/handler/AbstractWasmMetaDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmMetaDataHandlerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/java/org/apache/shenyu/plugin/wasm/base/handler/AbstractWasmPluginDataHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmPluginDataHandlerTest"
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/pkg/wasmabi/abi.go",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/pkg/wasmabi/go.mod",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/resources/org.apache.shenyu.plugin.wasm.base.AbstractShenyuWasmPluginTest$TestGoShenyuWasmPlugin.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/resources/org.apache.shenyu.plugin.wasm.base.AbstractShenyuWasmPluginTest$TestShenyuWasmPlugin.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/resources/org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmDiscoveryHandlerTest$TestGoWasmPluginDiscoveryHandler.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/resources/org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmDiscoveryHandlerTest$TestWasmPluginDiscoveryHandler.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/resources/org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmMetaDataHandlerTest$TestGoWasmMetaDataHandler.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/resources/org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmMetaDataHandlerTest$TestWasmMetaDataHandler.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/resources/org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmPluginDataHandlerTest$TestGoWasmPluginDataHandler.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/src/test/resources/org.apache.shenyu.plugin.wasm.base.handler.AbstractWasmPluginDataHandlerTest$TestWasmPluginDataHandler.wasm",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "470aefed12379970bcca16cf9c5571d0a3c8bc9b",
+    "headCommit" : "6c3110fd1741c641703af388403cec9fdb3fb820",
+    "changedFiles" : [ {
+      "path" : "shenyu-dist/shenyu-admin-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6c3110fd1741c641703af388403cec9fdb3fb820",
+    "headCommit" : "6e79c7b7c3f62163d82a7775593de49f95dae754",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/client/AbstractContextRefreshedEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.client.AbstractContextRefreshedEventListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springmvc/src/test/java/org/apache/shenyu/client/springmvc/init/SpringMvcClientEventListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springmvc.init.SpringMvcClientEventListenerTest"
+    }, {
+      "path" : "shenyu-client/shenyu-client-tars/src/test/java/org/apache/shenyu/client/tars/TarsServiceBeanPostProcessorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.tars.TarsServiceBeanPostProcessorTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6e79c7b7c3f62163d82a7775593de49f95dae754",
+    "headCommit" : "d4db5e60d27c7ba35d583e10068e0f77deac2ed4",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/src/main/java/org/apache/shenyu/plugin/divide/DividePlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.divide.DividePlugin"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d4db5e60d27c7ba35d583e10068e0f77deac2ed4",
+    "headCommit" : "9e7d5ffcf8357d1dce94f302e21cc007615c756e",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/shiro/config/ShiroRealm.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.shiro.config.ShiroRealm"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/shiro/config/ShiroRealmTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.shiro.config.ShiroRealmTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9e7d5ffcf8357d1dce94f302e21cc007615c756e",
+    "headCommit" : "d409a0429a9657b55474dd91014af7e989d04858",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/SwaggerImportController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.SwaggerImportController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SwaggerImportServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/SwaggerImportControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.SwaggerImportControllerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImplTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SwaggerImportServiceImplTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d409a0429a9657b55474dd91014af7e989d04858",
+    "headCommit" : "74644fbf1a5873810fd5e4377f7690ca8a520c76",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ConfigsServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.ConfigsServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/utils/ZipUtil.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.utils.ZipUtil"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/ConfigsServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.ConfigsServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "74644fbf1a5873810fd5e4377f7690ca8a520c76",
+    "headCommit" : "4e539dda59d7388d972f9309544fe4ddd8cef750",
+    "changedFiles" : [ {
+      "path" : "shenyu-dist/shenyu-docker-compose-dist/src/main/resources/docker-compose.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4e539dda59d7388d972f9309544fe4ddd8cef750",
+    "headCommit" : "9181fb155ebd721b875b77f9840b5ad281d42a99",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/http/http-debug-app-auth-controller-api.http",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/AppAuthController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.AppAuthController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/SandboxController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.SandboxController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/UpdateSkDTO.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.model.dto.UpdateSkDTO"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/AppAuthControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.AppAuthControllerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9181fb155ebd721b875b77f9840b5ad281d42a99",
+    "headCommit" : "f158c08c09992554b2912f9978cb35c3096caf89",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/NamespacePluginController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.NamespacePluginController"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/NamespacePluginControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.NamespacePluginControllerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f158c08c09992554b2912f9978cb35c3096caf89",
+    "headCommit" : "33e30336b4f03e27958289b1a417d4e8d413345b",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/SelectorService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.SelectorService"
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/src/main/release-docs/licenses/LICENSE-re2j.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/licenses/LICENSE-re2j.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/condition/judge/RegexPredicateJudge.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.base.condition.judge.RegexPredicateJudge"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "33e30336b4f03e27958289b1a417d4e8d413345b",
+    "headCommit" : "281bc61d80aeb73e32e16e84681314af2204646d",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SandboxServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SandboxServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SandboxServiceImplTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SandboxServiceImplTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "281bc61d80aeb73e32e16e84681314af2204646d",
+    "headCommit" : "bc4f20dcbda70c0589e4121b4019d1d3bd848570",
+    "changedFiles" : [ {
+      "path" : "shenyu-dist/shenyu-admin-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/src/main/release-docs/LICENSE",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bc4f20dcbda70c0589e4121b4019d1d3bd848570",
+    "headCommit" : "492bf473854b21f846c65b34719ecd31a1369f78",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin-listener/shenyu-admin-listener-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-alert/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-bootstrap/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-api-docs-annotations/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-autoconfig/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-dubbo/shenyu-client-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-mcp/shenyu-client-mcp-register/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-client/shenyu-client-websocket/shenyu-client-spring-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-disruptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-admin-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-bootstrap-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-docker-compose-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-dist/shenyu-src-dist/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-annotation/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-dubbo-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-eureka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http-swagger3/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-https/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-grpc/shenyu-examples-sdk-grpc-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-consumer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-springcloud/shenyu-examples-sdk-springcloud-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc-tomcat/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-annotation-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-native-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-reactive-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-redis/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-infra/shenyu-infra-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-combination/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-https/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-k8s-ingress-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-spring-cloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-custom-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-integrated-test-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-integrated-test-upload-plugin-case/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-kubernetes-controller/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-loadbalancer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-response-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-base/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-handler/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-memory/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-spi/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-context-path/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-hystrix/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-ratelimiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-resilience4j/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-sentinel/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-global/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-aliyun-sls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-console/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-desensitize-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-elasticsearch/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-huawei-lts/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-kafka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-pulsar/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rabbitmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-rocketmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-tencent-cls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mcp-server/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-metrics/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-mock/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-modify-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-param-mapping/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-general-context/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-transform/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-redirect/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-request/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-basic-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-casdoor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-cryptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-jwt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-key-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-oauth2/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-sign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-uri/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-waf/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-plugin/shenyu-plugin-wasm-base/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client-beat/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-client/shenyu-register-client-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-register-center/shenyu-register-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-eureka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-kubernetes/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-registry/shenyu-registry-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-core/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-okhttp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sdk/shenyu-sdk-spring/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spi/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-beat/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-mcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-spring-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-client/shenyu-spring-boot-starter-client-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-gateway/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-k8s/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-prompt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-proxy/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-request-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-response-transformer/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ai-token-limiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-basic-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-casdoor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-context-path/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-cryptor/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-divide/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-apache-dubbo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-dubbo/shenyu-spring-boot-starter-plugin-dubbo-common/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-general-context/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-global/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-httpclient/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-hystrix/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-jwt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-key-auth/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-aliyun-sls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-clickhouse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-console/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-elasticsearch/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-huawei-lts/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-kafka/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-pulsar/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rabbitmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-rocketmq/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-logging-tencent-cls/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mcp-server/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-metrics/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mock/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-modify-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-mqtt/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-oauth2/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-param-mapping/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-ratelimiter/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-redirect/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-request/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-resilience4j/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-response/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-rewrite/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sentinel/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-sofa/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-transform/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-uri/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-waf/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-plugin/shenyu-spring-boot-starter-plugin-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-registry/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sdk/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-api/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-apollo/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-consul/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-etcd/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-nacos/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-polaris/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-zookeeper/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-web/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "492bf473854b21f846c65b34719ecd31a1369f78",
+    "headCommit" : "d39e623b57677160d3b38a144a566a2ad798162b",
+    "changedFiles" : [ {
+      "path" : "shenyu-client/shenyu-client-core/src/main/java/org/apache/shenyu/client/core/client/AbstractContextRefreshedEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.core.client.AbstractContextRefreshedEventListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springmvc/src/main/java/org/apache/shenyu/client/springmvc/init/SpringMvcClientEventListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springmvc.init.SpringMvcClientEventListener"
+    }, {
+      "path" : "shenyu-client/shenyu-client-http/shenyu-client-springmvc/src/test/java/org/apache/shenyu/client/springmvc/init/SpringMvcClientEventListenerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.client.springmvc.init.SpringMvcClientEventListenerTest"
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http/src/main/java/org/apache/shenyu/examples/http/controller/SpringMvcMultiPathController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.examples.http.controller.SpringMvcMultiPathController"
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-http/src/test/java/org/apache/shenyu/integrated/test/http/SpringMvcMappingPathControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.integrated.test.http.SpringMvcMappingPathControllerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d39e623b57677160d3b38a144a566a2ad798162b",
+    "headCommit" : "b94a6997b697f7272fdf18cf7c9b080195e3fc75",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/docker-publish-dockerhub.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/docker-publish.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b94a6997b697f7272fdf18cf7c9b080195e3fc75",
+    "headCommit" : "79885c1bbbd8a0625e0fcffe251f7675d1cd2e0b",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/e2e-k8s.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test-k8s-ingress.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "79885c1bbbd8a0625e0fcffe251f7675d1cd2e0b",
+    "headCommit" : "2974ec34a5a1e89883eeb5212ce48bea667ffe80",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/ci.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/e2e-k8s.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test-k8s-ingress.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/k8s-examples-http.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2974ec34a5a1e89883eeb5212ce48bea667ffe80",
+    "headCommit" : "bf909a878334fc0242e77d8580859b3817f54efb",
+    "changedFiles" : [ {
+      "path" : "SECURITY.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "SECURITY_MODEL.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bf909a878334fc0242e77d8580859b3817f54efb",
+    "headCommit" : "5926970c22ccf72e96d37c9196dd76141ffaf9ff",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/InstanceCheckService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.InstanceCheckService"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5926970c22ccf72e96d37c9196dd76141ffaf9ff",
+    "headCommit" : "8a18ecab49ba7b733706108288e815f8436ad68e",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/ci.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test-k8s-ingress.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/integrated-test.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8a18ecab49ba7b733706108288e815f8436ad68e",
+    "headCommit" : "292b73b251ebc8c8afaa3c9474c0eb4e7be6e6db",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/ci.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "292b73b251ebc8c8afaa3c9474c0eb4e7be6e6db",
+    "headCommit" : "96a4c946e64eb1df320d4e96b41481966c56e9c3",
+    "changedFiles" : [ {
+      "path" : "shenyu-examples/README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-annotation/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service-xml/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-dubbo/shenyu-examples-apache-dubbo-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-grpc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http-swagger3/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-https/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-mcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-dubbo/shenyu-examples-sdk-apache-dubbo-provider/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-feign/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sdk/shenyu-examples-sdk-http/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-sofa/shenyu-examples-sofa-service/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springcloud/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc-tomcat/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-springmvc/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-tars/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-annotation-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-native-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-examples/shenyu-examples-websocket/shenyu-example-spring-reactive-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "96a4c946e64eb1df320d4e96b41481966c56e9c3",
+    "headCommit" : "a1b6ae3290cec2b30a0c2c1accbbe4f1073bc8fb",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/AppAuthServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.AppAuthServiceImpl"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a1b6ae3290cec2b30a0c2c1accbbe4f1073bc8fb",
+    "headCommit" : "5f9f4b307f534d5defcf5a535f1333a02647a450",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5f9f4b307f534d5defcf5a535f1333a02647a450",
+    "headCommit" : "924f06169cab7bb9c151d68e3079552886b6f78d",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/e2e-k8s.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/k8s-examples-http.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "924f06169cab7bb9c151d68e3079552886b6f78d",
+    "headCommit" : "659da659efd93a8aeead627f3efc6d9668d3a396",
+    "changedFiles" : [ {
+      "path" : "db/init/mysql/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/ob/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/og/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/oracle/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "db/init/pg/create-table.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DashboardUserController.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.DashboardUserController"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/DashboardUserMapper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.mapper.DashboardUserMapper"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/DashboardUserService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.DashboardUserService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/PasswordHashService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.PasswordHashService"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DashboardUserServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.DashboardUserServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/controller/DashboardUserControllerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.controller.DashboardUserControllerTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/DashboardUserServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.DashboardUserServiceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "659da659efd93a8aeead627f3efc6d9668d3a396",
+    "headCommit" : "ea4f1770676522e0f36ffd14b3c35ae9af0c212f",
+    "changedFiles" : [ {
+      "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/src/main/java/org/apache/shenyu/plugin/divide/DividePlugin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.divide.DividePlugin"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ea4f1770676522e0f36ffd14b3c35ae9af0c212f",
+    "headCommit" : "92c2197b1ab9451e0f0cf9a96e7534d908c7ba75",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/config/properties/WebsocketSyncProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.WebsocketSyncProperties"
+    }, {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/listener/websocket/WebsocketConfigurator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketConfigurator"
+    }, {
+      "path" : "shenyu-admin/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/config/properties/WebsocketSyncPropertiesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.config.properties.WebsocketSyncPropertiesTest"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/websocket/WebsocketConfiguratorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketConfiguratorTest"
+    }, {
+      "path" : "shenyu-bootstrap/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/constant/Constants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.constant.Constants"
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-h2.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-mysql.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-opengauss.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/storage/shenyu-storage-postgres.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket-cluster-jdbc.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket-cluster-zookeeper.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket-eureka.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/compose/sync/shenyu-sync-websocket.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/k8s/sync/shenyu-cm.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-apache-dubbo/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-cluster/k8s/shenyu-cluster-jdbc.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-cluster/k8s/shenyu-cluster-zookeeper.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-spring-cloud/k8s/shenyu-cm.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-deployment-h2.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-deployment-mysql.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-deployment-opengauss.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-storage/k8s/shenyu-deployment-postgres.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-apache-dubbo/src/main/resources/application-local.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-combination/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-combination/src/main/resources/application-local.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-grpc/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-grpc/src/main/resources/application-local.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-http/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-http/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-https/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-https/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-rewrite/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-rewrite/src/main/resources/application-local.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-apache-dubbo/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-apache-dubbo/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-http/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sdk-http/src/main/resources/application.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sofa/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-sofa/src/main/resources/application-local.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-spring-cloud/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-spring-cloud/src/main/resources/application-local.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-upload-plugin/shenyu-integrated-test-upload-plugin-case/src/main/resources/application.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-websocket/docker-compose.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-integrated-test/shenyu-integrated-test-websocket/src/main/resources/application-local.yml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/WebsocketSyncDataService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sync.data.websocket.WebsocketSyncDataService"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/src/main/java/org/apache/shenyu/plugin/sync/data/websocket/config/WebsocketConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sync.data.websocket.config.WebsocketConfig"
+    }, {
+      "path" : "shenyu-sync-data-center/shenyu-sync-data-websocket/src/test/java/org/apache/shenyu/plugin/sync/data/websocket/config/WebsocketConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.plugin.sync.data.websocket.config.WebsocketConfigTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "92c2197b1ab9451e0f0cf9a96e7534d908c7ba75",
+    "headCommit" : "84921f4ffc3284eb48b8bdd31e752fdbc5a8e927",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ConfigsServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.ConfigsServiceImpl"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "84921f4ffc3284eb48b8bdd31e752fdbc5a8e927",
+    "headCommit" : "7b96daa13521b6ecfa85e045ce25d68d7c63e597",
+    "changedFiles" : [ {
+      "path" : "shenyu-protocol/shenyu-protocol-tcp/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-tcp/src/main/java/org/apache/shenyu/protocol/tcp/TcpBootstrapServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.protocol.tcp.TcpBootstrapServer"
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-tcp/src/main/java/org/apache/shenyu/protocol/tcp/connection/ActivityConnectionObserver.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.protocol.tcp.connection.ActivityConnectionObserver"
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-tcp/src/test/java/org/apache/shenyu/protocol/tcp/TcpBootstrapServerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.protocol.tcp.TcpBootstrapServerTest"
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-tcp/src/test/java/org/apache/shenyu/protocol/tcp/connection/ActivityConnectionObserverTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.protocol.tcp.connection.ActivityConnectionObserverTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7b96daa13521b6ecfa85e045ce25d68d7c63e597",
+    "headCommit" : "43e05e91fe2149a2695a0f3e048b71f82945783d",
+    "changedFiles" : [ {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/concurrent/MemorySafeLinkedBlockingQueue.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.concurrent.MemorySafeLinkedBlockingQueue"
+    }, {
+      "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/concurrent/Rejector.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.common.concurrent.Rejector"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "43e05e91fe2149a2695a0f3e048b71f82945783d",
+    "headCommit" : "0df09caa4e6973da5a412193109eac2b30332470",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/ci.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-e2e/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/main/java/org/apache/shenyu/k8s/parser/DivideIngressParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.parser.DivideIngressParser"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/main/java/org/apache/shenyu/k8s/parser/WebSocketParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.parser.WebSocketParser"
+    }, {
+      "path" : "shenyu-kubernetes-controller/src/main/java/org/apache/shenyu/k8s/reconciler/IngressReconciler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.k8s.reconciler.IngressReconciler"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0df09caa4e6973da5a412193109eac2b30332470",
+    "headCommit" : "838973296aee94a855e98657ad6fc6462061f47a",
+    "changedFiles" : [ {
+      "path" : "shenyu-protocol/shenyu-protocol-tcp/src/main/java/org/apache/shenyu/protocol/tcp/TcpBootstrapServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.protocol.tcp.TcpBootstrapServer"
+    }, {
+      "path" : "shenyu-protocol/shenyu-protocol-tcp/src/test/java/org/apache/shenyu/protocol/tcp/TcpBootstrapServerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.protocol.tcp.TcpBootstrapServerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "838973296aee94a855e98657ad6fc6462061f47a",
+    "headCommit" : "3a411e017acfc47636e2bbfeb2958108d1f15a05",
+    "changedFiles" : [ {
+      "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImpl.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SwaggerImportServiceImpl"
+    }, {
+      "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/impl/SwaggerImportServiceImplTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.shenyu.admin.service.impl.SwaggerImportServiceImplTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  } ],
+  "excludedCommitPairs" : [ ],
+  "wouldMissCases" : [ ],
+  "flakyFailures" : [ {
+    "commitPair" : {
+      "baseCommit" : "c37b4854633efdf019c01805dd9a7e050a7a4e55",
+      "headCommit" : "3854267989135ed7941e0d38df221c953cde3c07",
+      "changedFiles" : [ {
+        "path" : "shenyu-admin/src/main/resources/application-mysql.yml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest",
+      "methodName" : "testExecutorValidData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "4a75fec871c57c6f4411af49afbb24db65888448",
+      "headCommit" : "b9444302397e04e24124e74f6258f98f5908c34e",
+      "changedFiles" : [ {
+        "path" : "shenyu-alert/src/main/java/org/apache/shenyu/alert/strategy/DingTalkRobotAlertNotifyStrategy.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.alert.strategy.DingTalkRobotAlertNotifyStrategy"
+      }, {
+        "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/utils/GsonUtils.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.common.utils.GsonUtils"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai-token-limiter/src/main/java/org/apache/shenyu/plugin/ai/token/limiter/redis/RedisConnectionFactory.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.token.limiter.redis.RedisConnectionFactory"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/ShenyuPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.api.ShenyuPlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/utils/RequestUrlUtils.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.api.utils.RequestUrlUtils"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-api/src/main/java/org/apache/shenyu/plugin/api/utils/WebFluxResultUtils.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.api.utils.WebFluxResultUtils"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-cache/shenyu-plugin-cache-redis/src/main/java/org/apache/shenyu/plugin/cache/redis/RedisConnectionFactory.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.cache.redis.RedisConnectionFactory"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-context-path/src/main/java/org/apache/shenyu/plugin/context/path/ContextPathPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.context.path.ContextPathPlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-hystrix/src/main/java/org/apache/shenyu/plugin/hystrix/HystrixPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.hystrix.HystrixPlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-fault-tolerance/shenyu-plugin-sentinel/src/main/java/org/apache/shenyu/plugin/sentinel/SentinelPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.sentinel.SentinelPlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/AbstractHttpClientPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.httpclient.AbstractHttpClientPlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-common/src/main/java/org/apache/shenyu/plugin/logging/common/body/LoggingServerHttpResponse.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.logging.common.body.LoggingServerHttpResponse"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-metrics/src/main/java/org/apache/shenyu/plugin/metrics/MetricsPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.metrics.MetricsPlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-modify-response/src/main/java/org/apache/shenyu/plugin/modify/response/ModifyResponsePlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.modify.response.ModifyResponsePlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/src/main/java/org/apache/shenyu/plugin/divide/DividePlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.divide.DividePlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/src/test/java/org/apache/shenyu/plugin/divide/DividePluginTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.divide.DividePluginTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-dubbo-common/src/main/java/org/apache/shenyu/plugin/dubbo/common/AbstractDubboPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.dubbo.common.AbstractDubboPlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/GrpcPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.grpc.GrpcPlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-motan/src/main/java/org/apache/shenyu/plugin/motan/MotanPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.motan.MotanPlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/src/main/java/org/apache/shenyu/plugin/sofa/SofaPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.sofa.SofaPlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-sofa/src/main/java/org/apache/shenyu/plugin/sofa/param/SofaParamResolveServiceImpl.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.sofa.param.SofaParamResolveServiceImpl"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-tars/src/main/java/org/apache/shenyu/plugin/tars/TarsPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.tars.TarsPlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-tars/src/main/java/org/apache/shenyu/plugin/tars/cache/ApplicationConfigCache.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.tars.cache.ApplicationConfigCache"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-response/src/main/java/org/apache/shenyu/plugin/response/ResponsePlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.response.ResponsePlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-rewrite/src/main/java/org/apache/shenyu/plugin/rewrite/RewritePlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.rewrite.RewritePlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-security/shenyu-plugin-sign/src/main/java/org/apache/shenyu/plugin/sign/service/ComposableSignService.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.sign.service.ComposableSignService"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest",
+      "methodName" : "testExecutorValidData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "f3fd88d6fc44ada465598efeca0a48943f078201",
+      "headCommit" : "5be0bf6d7422bfc478ce122800f5c21960681352",
+      "changedFiles" : [ {
+        "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/src/main/java/org/apache/shenyu/plugin/logging/clickhouse/config/ClickHouseLogCollectConfig.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.logging.clickhouse.config.ClickHouseLogCollectConfig"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-logging/shenyu-plugin-logging-clickhouse/src/test/java/org/apache/shenyu/plugin/logging/clickhouse/handler/LoggingClickHousePluginDataHandlerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.logging.clickhouse.handler.LoggingClickHousePluginDataHandlerTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest",
+      "methodName" : "testExecutorValidData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "9ac8659040e83a4b7c85d3c3aab632b3a380e275",
+      "headCommit" : "cf7915992b6939523ede8a51f10ce7b79d4b1c55",
+      "changedFiles" : [ {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/main/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPlugin"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest",
+      "methodName" : "testExecutorValidData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "8f65ce09475dd41315b95428febc3baf4e927fad",
+      "headCommit" : "0eaec1e63adef81d0bd5d8797f0e907778abcfea",
+      "changedFiles" : [ {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/AiProxyPluginTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.AiProxyPluginTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-proxy/src/test/java/org/apache/shenyu/plugin/ai/proxy/handler/AiProxyPluginHandlerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "0eaec1e63adef81d0bd5d8797f0e907778abcfea",
+      "headCommit" : "9c8b78f782f95efb646bf3ad231d745b112fd7cd",
+      "changedFiles" : [ {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/ApiController.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.controller.ApiController"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DashboardUserController.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.controller.DashboardUserController"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DiscoveryController.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.controller.DiscoveryController"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/DiscoveryUpstreamController.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.controller.DiscoveryUpstreamController"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/PluginController.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.controller.PluginController"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/PluginHandleController.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.controller.PluginHandleController"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/ProxySelectorController.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.controller.ProxySelectorController"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/ResourceController.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.controller.ResourceController"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/RoleController.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.controller.RoleController"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/RuleController.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.controller.RuleController"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/SelectorController.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.controller.SelectorController"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/ShenyuDictController.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.controller.ShenyuDictController"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/controller/TagController.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.controller.TagController"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "9c8b78f782f95efb646bf3ad231d745b112fd7cd",
+      "headCommit" : "d782a64e874d2ac1737d4509db4bffdc91844f28",
+      "changedFiles" : [ {
+        "path" : ".github/workflows/e2e-k8s.yml",
+        "kind" : "INERT",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "d782a64e874d2ac1737d4509db4bffdc91844f28",
+      "headCommit" : "319ca4fd9f824625ec609284d390f0236cdb3722",
+      "changedFiles" : [ {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/test/java/org/apache/shenyu/plugin/ai/common/spring/ai/factory/DeepSeekModelFactoryTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.common.spring.ai.factory.DeepSeekModelFactoryTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/test/java/org/apache/shenyu/plugin/ai/common/spring/ai/factory/OpenAiModelFactoryTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.common.spring.ai.factory.OpenAiModelFactoryTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/test/java/org/apache/shenyu/plugin/ai/common/spring/ai/registry/AiModelFactoryRegistryTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.common.spring.ai.registry.AiModelFactoryRegistryTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/test/java/org/apache/shenyu/plugin/ai/common/strategy/AiModelFactoryTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.AiModelFactoryTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-common/src/test/java/org/apache/shenyu/plugin/ai/common/strategy/openai/OpenAITest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.common.strategy.openai.OpenAITest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "319ca4fd9f824625ec609284d390f0236cdb3722",
+      "headCommit" : "d0745961538abbcad9e60547f5aed181e00f29bb",
+      "changedFiles" : [ {
+        "path" : "shenyu-examples/shenyu-examples-http/src/main/resources/application.yml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest",
+      "methodName" : "testExecutorValidData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "d0745961538abbcad9e60547f5aed181e00f29bb",
+      "headCommit" : "4f9e69c54f1f2abf67bb87d4abd8f612dad342b8",
+      "changedFiles" : [ {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/src/test/java/org/apache/shenyu/plugin/ai/prompt/AiPromptPluginTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.prompt.AiPromptPluginTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-prompt/src/test/java/org/apache/shenyu/plugin/ai/prompt/handler/AiPromptPluginDataHandlerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.prompt.handler.AiPromptPluginDataHandlerTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "4f9e69c54f1f2abf67bb87d4abd8f612dad342b8",
+      "headCommit" : "7c1e43bf6fb8477352e7fb7f236255545f33e362",
+      "changedFiles" : [ {
+        "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/utils/AesUtilsTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.common.utils.AesUtilsTest"
+      }, {
+        "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/utils/NamespaceIDUtilsTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.common.utils.NamespaceIDUtilsTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "7c1e43bf6fb8477352e7fb7f236255545f33e362",
+      "headCommit" : "85307386b9f3412a5afc6c504fc10bf64c859892",
+      "changedFiles" : [ {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/AiRequestTransformerPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.AiRequestTransformerPlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/cache/ChatClientCache.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.cache.ChatClientCache"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/handler/AiRequestTransformerPluginHandler.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.handler.AiRequestTransformerPluginHandler"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/request/AiRequestTransformerPluginTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.AiRequestTransformerPluginTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/request/cache/ChatClientCacheTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.cache.ChatClientCacheTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/request/handler/AiRequestTransformerPluginHandlerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.handler.AiRequestTransformerPluginHandlerTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/test/java/org/apache/shenyu/plugin/ai/transformer/request/template/AiRequestTransformerTemplateTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.template.AiRequestTransformerTemplateTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "85307386b9f3412a5afc6c504fc10bf64c859892",
+      "headCommit" : "15278cf6e66ec2b42023af21ba85538dbdeb64d0",
+      "changedFiles" : [ {
+        "path" : "db/init/mysql/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/ob/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/og/create-table.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/oracle/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/pg/create-table.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-ai/shenyu-plugin-ai-request-transformer/src/main/java/org/apache/shenyu/plugin/ai/transformer/request/AiRequestTransformerPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.ai.transformer.request.AiRequestTransformerPlugin"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "15278cf6e66ec2b42023af21ba85538dbdeb64d0",
+      "headCommit" : "0933a2c450b4ad3c5d17284417ac026d8f0d6c27",
+      "changedFiles" : [ {
+        "path" : "shenyu-disruptor/src/test/java/org/apache/shenyu/disruptor/DisruptorProviderManagerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.disruptor.DisruptorProviderManagerTest"
+      }, {
+        "path" : "shenyu-disruptor/src/test/java/org/apache/shenyu/disruptor/consumer/QueueConsumerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.disruptor.consumer.QueueConsumerTest"
+      }, {
+        "path" : "shenyu-disruptor/src/test/java/org/apache/shenyu/disruptor/provider/DisruptorProviderTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.disruptor.provider.DisruptorProviderTest"
+      }, {
+        "path" : "shenyu-disruptor/src/test/java/org/apache/shenyu/disruptor/thread/DisruptorThreadFactoryTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.disruptor.thread.DisruptorThreadFactoryTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "0933a2c450b4ad3c5d17284417ac026d8f0d6c27",
+      "headCommit" : "1b245d325d3edb20bad33c3ae901eb46947b7183",
+      "changedFiles" : [ {
+        "path" : "shenyu-disruptor/src/main/java/org/apache/shenyu/disruptor/common/Data.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.disruptor.common.Data"
+      }, {
+        "path" : "shenyu-disruptor/src/main/java/org/apache/shenyu/disruptor/consumer/QueueConsumerExecutor.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.disruptor.consumer.QueueConsumerExecutor"
+      }, {
+        "path" : "shenyu-disruptor/src/main/java/org/apache/shenyu/disruptor/event/DataEvent.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.disruptor.event.DataEvent"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "9e8576a2aec00317076a18bb04933b4bfe42a366",
+      "headCommit" : "eaa2f9503d4f213402f0ca8e1c3b9e9aef015a5d",
+      "changedFiles" : [ {
+        "path" : "shenyu-registry/shenyu-registry-etcd/src/test/java/org/apache/shenyu/registry/etcd/EtcdInstanceRegisterRepositoryTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.registry.etcd.EtcdInstanceRegisterRepositoryTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "eaa2f9503d4f213402f0ca8e1c3b9e9aef015a5d",
+      "headCommit" : "0184d4b658729ac5e57fe74217461635f4295e41",
+      "changedFiles" : [ {
+        "path" : "shenyu-admin/pom.xml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "0184d4b658729ac5e57fe74217461635f4295e41",
+      "headCommit" : "cde3f548f7284fafd23ac8bb3c91ed716d4d9c51",
+      "changedFiles" : [ {
+        "path" : "shenyu-infra/shenyu-infra-nacos/src/main/java/org/apache/shenyu/infra/nacos/autoconfig/ConditionOnSyncNacos.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.infra.nacos.autoconfig.ConditionOnSyncNacos"
+      }, {
+        "path" : "shenyu-spring-boot-starter/shenyu-spring-boot-starter-sync-data-center/shenyu-spring-boot-starter-sync-data-nacos/src/main/java/org/apache/shenyu/springboot/starter/sync/data/nacos/NacosSyncDataConfiguration.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.springboot.starter.sync.data.nacos.NacosSyncDataConfiguration"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "cde3f548f7284fafd23ac8bb3c91ed716d4d9c51",
+      "headCommit" : "1f595adefabc529623c58565acafd7d7e9cbe74f",
+      "changedFiles" : [ {
+        "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallback.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallback"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/manager/ShenyuMcpServerManager.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.mcp.server.manager.ShenyuMcpServerManager"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/main/java/org/apache/shenyu/plugin/mcp/server/response/ShenyuMcpResponseDecorator.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.mcp.server.response.ShenyuMcpResponseDecorator"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/McpServerPluginIntegrationTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.mcp.server.McpServerPluginIntegrationTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/McpServerPluginTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.mcp.server.McpServerPluginTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/callback/ShenyuToolCallbackTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.mcp.server.callback.ShenyuToolCallbackTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/handler/McpServerPluginDataHandlerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.mcp.server.handler.McpServerPluginDataHandlerTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/manager/ShenyuMcpServerManagerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.mcp.server.manager.ShenyuMcpServerManagerTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/request/RequestConfigHelperTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.mcp.server.request.RequestConfigHelperTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/java/org/apache/shenyu/plugin/mcp/server/utils/JsonSchemaUtilTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.mcp.server.utils.JsonSchemaUtilTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-mcp-server/src/test/resources/application-test.yml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "1f595adefabc529623c58565acafd7d7e9cbe74f",
+      "headCommit" : "c25dc204c33f229ccc82cd23f4232f834ba0ba68",
+      "changedFiles" : [ {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/PluginServiceImpl.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.impl.PluginServiceImpl"
+      }, {
+        "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/PluginServiceTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.PluginServiceTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "c25dc204c33f229ccc82cd23f4232f834ba0ba68",
+      "headCommit" : "07453a26d20cd12a8997a331de2ffba5fe78d850",
+      "changedFiles" : [ {
+        "path" : "shenyu-admin/src/main/resources/static/index.7d0459c3.js",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-admin/src/main/resources/static/index.b93e0e23.js",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-admin/src/main/resources/static/index.html",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "07453a26d20cd12a8997a331de2ffba5fe78d850",
+      "headCommit" : "e624a19aae027361f309cb3e236d6345962ac811",
+      "changedFiles" : [ {
+        "path" : "shenyu-sync-data-center/shenyu-sync-data-api/src/main/java/org/apache/shenyu/sync/data/core/AbstractNodeDataSyncService.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.sync.data.core.AbstractNodeDataSyncService"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "e624a19aae027361f309cb3e236d6345962ac811",
+      "headCommit" : "e4177b6c0e3e592a06f980b9025b90c5d1f909e8",
+      "changedFiles" : [ {
+        "path" : "shenyu-registry/shenyu-registry-api/pom.xml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-registry/shenyu-registry-api/src/test/java/org/apache/shenyu/registry/api/config/RegisterConfigTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.registry.api.config.RegisterConfigTest"
+      }, {
+        "path" : "shenyu-registry/shenyu-registry-api/src/test/java/org/apache/shenyu/registry/api/path/InstancePathConstantsTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.registry.api.path.InstancePathConstantsTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "e4177b6c0e3e592a06f980b9025b90c5d1f909e8",
+      "headCommit" : "d2705ef19d14630955e869e4f0479156a65a6e10",
+      "changedFiles" : [ {
+        "path" : "db/init/mysql/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/ob/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/og/create-table.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/oracle/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/pg/create-table.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/RegistryDTO.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.dto.RegistryDTO"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/RegistryDO.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.entity.RegistryDO"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/RegistryServiceImpl.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.impl.RegistryServiceImpl"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/transfer/RegistryTransfer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.transfer.RegistryTransfer"
+      }, {
+        "path" : "shenyu-admin/src/main/resources/mappers/registry-sqlmap.xml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "d2705ef19d14630955e869e4f0479156a65a6e10",
+      "headCommit" : "161625cd7e4f4fba15267a0d943e6420f858031e",
+      "changedFiles" : [ {
+        "path" : "shenyu-sync-data-center/shenyu-sync-data-api/src/test/java/org/apache/shenyu/sync/data/core/AbstractNodeDataSyncServiceTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.sync.data.core.AbstractNodeDataSyncServiceTest"
+      }, {
+        "path" : "shenyu-sync-data-center/shenyu-sync-data-api/src/test/java/org/apache/shenyu/sync/data/core/AbstractPathDataSyncServiceTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.sync.data.core.AbstractPathDataSyncServiceTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "161625cd7e4f4fba15267a0d943e6420f858031e",
+      "headCommit" : "7a36aab29e87f20652f2085e2ae8641b51827b67",
+      "changedFiles" : [ {
+        "path" : ".gitpod.Dockerfile",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : ".gitpod.yml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "changelog.sh",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "7a36aab29e87f20652f2085e2ae8641b51827b67",
+      "headCommit" : "f6a09ec9fb8c22d78eb2d3de0bec1e974f26bfaf",
+      "changedFiles" : [ {
+        "path" : "db/init/mysql/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/ob/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/og/create-table.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/oracle/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/pg/create-table.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/SelectorMapper.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.mapper.SelectorMapper"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/SelectorDO.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.entity.SelectorDO"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/event/selector/BatchSelectorDeletedEvent.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.event.selector.BatchSelectorDeletedEvent"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/event/selector/SelectorChangedEvent.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.event.selector.SelectorChangedEvent"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/DataPermissionPageVO.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.vo.DataPermissionPageVO"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/SelectorVO.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.vo.SelectorVO"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DiscoveryServiceImpl.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.impl.DiscoveryServiceImpl"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/DiscoveryUpstreamServiceImpl.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.impl.DiscoveryUpstreamServiceImpl"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/ProxySelectorServiceImpl.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.impl.ProxySelectorServiceImpl"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/SelectorServiceImpl.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.impl.SelectorServiceImpl"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/UpstreamCheckService.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.impl.UpstreamCheckService"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.register.AbstractShenyuClientRegisterServiceImpl"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterDivideServiceImpl.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterDivideServiceImpl"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterGrpcServiceImpl.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterGrpcServiceImpl"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/ShenyuClientRegisterWebSocketServiceImpl.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.register.ShenyuClientRegisterWebSocketServiceImpl"
+      }, {
+        "path" : "shenyu-admin/src/main/resources/mappers/selector-sqlmap.xml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/SelectorMapperTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.mapper.SelectorMapperTest"
+      }, {
+        "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/model/event/selector/BatchSelectorDeletedEventTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.event.selector.BatchSelectorDeletedEventTest"
+      }, {
+        "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/model/event/selector/SelectorChangedEventTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.event.selector.SelectorChangedEventTest"
+      }, {
+        "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/DiscoveryUpstreamServiceTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.DiscoveryUpstreamServiceTest"
+      }, {
+        "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/UpstreamCheckServiceTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.UpstreamCheckServiceTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "f6a09ec9fb8c22d78eb2d3de0bec1e974f26bfaf",
+      "headCommit" : "fce9c8f01423eeed62f26f7ae4b1510577a95eb6",
+      "changedFiles" : [ {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/DiscoveryUpstreamDTO.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.dto.DiscoveryUpstreamDTO"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/dto/ProxySelectorAddDTO.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.dto.ProxySelectorAddDTO"
+      }, {
+        "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/discovery/DiscoveryProcessorHolderTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.discovery.DiscoveryProcessorHolderTest"
+      }, {
+        "path" : "shenyu-e2e/shenyu-e2e-case/k8s/shenyu-nacos.yml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-e2e/shenyu-e2e-case/shenyu-e2e-case-logging-kafka/compose/script/e2e-logging-kafka-compose.sh",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/ExponentialRetryBackoffStrategy.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.httpclient.ExponentialRetryBackoffStrategy"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "fce9c8f01423eeed62f26f7ae4b1510577a95eb6",
+      "headCommit" : "cf0bbba7d6e7937a48dd9d4745bfa742f4468658",
+      "changedFiles" : [ {
+        "path" : "shenyu-registry/shenyu-registry-eureka/src/main/java/org/apache/shenyu/registry/eureka/EurekaInstanceRegisterRepository.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.registry.eureka.EurekaInstanceRegisterRepository"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "cf0bbba7d6e7937a48dd9d4745bfa742f4468658",
+      "headCommit" : "da78f467d99d710bd2f4f529f3765e623a511b1c",
+      "changedFiles" : [ {
+        "path" : "db/init/mysql/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/ob/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/og/create-table.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/oracle/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/init/pg/create-table.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-mysql.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-ob.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-og.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-oracle.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "db/upgrade/2.7.0-upgrade-2.7.1-pg.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/mapper/RuleMapper.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.mapper.RuleMapper"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/entity/RuleDO.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.entity.RuleDO"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/event/rule/BatchRuleDeletedEvent.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.event.rule.BatchRuleDeletedEvent"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/event/rule/RuleChangedEvent.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.event.rule.RuleChangedEvent"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/DataPermissionPageVO.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.vo.DataPermissionPageVO"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/model/vo/RuleVO.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.model.vo.RuleVO"
+      }, {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/impl/RuleServiceImpl.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.impl.RuleServiceImpl"
+      }, {
+        "path" : "shenyu-admin/src/main/resources/mappers/rule-sqlmap.xml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-admin/src/main/resources/sql-script/h2/schema.sql",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/mapper/RuleMapperTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.mapper.RuleMapperTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "da78f467d99d710bd2f4f529f3765e623a511b1c",
+      "headCommit" : "1f913296a7a2bbbdce4f7331c6b20d8b49fe72d2",
+      "changedFiles" : [ {
+        "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/discovery/DiscoveryProcessorHolderTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.discovery.DiscoveryProcessorHolderTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "1f913296a7a2bbbdce4f7331c6b20d8b49fe72d2",
+      "headCommit" : "1b9492bf266b84d320e339b41461223d7014374f",
+      "changedFiles" : [ {
+        "path" : "shenyu-registry/shenyu-registry-nacos/src/main/java/org/apache/shenyu/registry/nacos/NacosInstanceRegisterRepository.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.registry.nacos.NacosInstanceRegisterRepository"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "1b9492bf266b84d320e339b41461223d7014374f",
+      "headCommit" : "5e90930a33ffc0644aa7d822bd1460df7a928cec",
+      "changedFiles" : [ {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/AbstractShenyuClientRegisterServiceImpl.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.register.AbstractShenyuClientRegisterServiceImpl"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "5e90930a33ffc0644aa7d822bd1460df7a928cec",
+      "headCommit" : "9234be312b213803bff9a1691ddf5afb82f41588",
+      "changedFiles" : [ {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/service/register/FallbackShenyuClientRegisterService.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.register.FallbackShenyuClientRegisterService"
+      }, {
+        "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/service/register/FallbackShenyuClientRegisterServiceTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.service.register.FallbackShenyuClientRegisterServiceTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest",
+      "methodName" : "testHandlerPluginWithNullData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "3c6bb7be162044e379d38b6687a2870991ae7040",
+      "headCommit" : "6b42718a6ee9027b003b76170a2cb02a269cf26b",
+      "changedFiles" : [ {
+        "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/websocket/WebsocketDataChangedListenerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketDataChangedListenerTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.springboot.starter.sync.data.http.HttpClientPluginConfigurationTest",
+      "methodName" : "testHttpConfig"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "3c6bb7be162044e379d38b6687a2870991ae7040",
+      "headCommit" : "6b42718a6ee9027b003b76170a2cb02a269cf26b",
+      "changedFiles" : [ {
+        "path" : "shenyu-admin/src/test/java/org/apache/shenyu/admin/listener/websocket/WebsocketDataChangedListenerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.listener.websocket.WebsocketDataChangedListenerTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.springboot.starter.sync.data.http.HttpClientPluginConfigurationTest",
+      "methodName" : "testHttpSyncDataService"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "ddefc04a05581b567a8cb6466248b2ab358d5172",
+      "headCommit" : "0f2f7acce28824e56472607be3804407c636b357",
+      "changedFiles" : [ {
+        "path" : "shenyu-admin/src/main/java/org/apache/shenyu/admin/shiro/config/ShiroRealm.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.admin.shiro.config.ShiroRealm"
+      }, {
+        "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/cache/UpstreamCacheManager.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.cache.UpstreamCacheManager"
+      }, {
+        "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/entity/LoadBalanceData.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.entity.LoadBalanceData"
+      }, {
+        "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/entity/Upstream.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.entity.Upstream"
+      }, {
+        "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/factory/LoadBalancerFactory.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.factory.LoadBalancerFactory"
+      }, {
+        "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/AbstractLoadBalancer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.AbstractLoadBalancer"
+      }, {
+        "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/HashLoadBalancer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.HashLoadBalancer"
+      }, {
+        "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalance.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.LeastActiveLoadBalance"
+      }, {
+        "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/LoadBalancer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.LoadBalancer"
+      }, {
+        "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/P2cLoadBalancer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.P2cLoadBalancer"
+      }, {
+        "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/RandomLoadBalancer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.RandomLoadBalancer"
+      }, {
+        "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/RoundRobinLoadBalancer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.RoundRobinLoadBalancer"
+      }, {
+        "path" : "shenyu-loadbalancer/src/main/java/org/apache/shenyu/loadbalancer/spi/ShortestResponseLoadBalancer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.ShortestResponseLoadBalancer"
+      }, {
+        "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/entity/UpstreamTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.entity.UpstreamTest"
+      }, {
+        "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/factory/LoadBalancerFactoryTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.factory.LoadBalancerFactoryTest"
+      }, {
+        "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/HashLoadBalanceTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.HashLoadBalanceTest"
+      }, {
+        "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/HashLoadBalancerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.HashLoadBalancerTest"
+      }, {
+        "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/LeastActiveLoadBalanceTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.LeastActiveLoadBalanceTest"
+      }, {
+        "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/P2cLoadBalancerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.P2cLoadBalancerTest"
+      }, {
+        "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/RandomLoadBalancerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.RandomLoadBalancerTest"
+      }, {
+        "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/RoundRobinLoadBalanceTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.RoundRobinLoadBalanceTest"
+      }, {
+        "path" : "shenyu-loadbalancer/src/test/java/org/apache/shenyu/loadbalancer/spi/ShortestResponseLoadBalancerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.loadbalancer.spi.ShortestResponseLoadBalancerTest"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-base/pom.xml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-base/src/main/java/org/apache/shenyu/plugin/base/utils/LoadbalancerUtils.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.base.utils.LoadbalancerUtils"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-httpclient/src/main/java/org/apache/shenyu/plugin/httpclient/DefaultRetryStrategy.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.httpclient.DefaultRetryStrategy"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-divide/src/main/java/org/apache/shenyu/plugin/divide/DividePlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.divide.DividePlugin"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/proxy/ApacheDubboGrayLoadBalance.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.proxy.ApacheDubboGrayLoadBalance"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-dubbo/shenyu-plugin-apache-dubbo/src/main/java/org/apache/shenyu/plugin/apache/dubbo/proxy/ApacheDubboProxyService.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.apache.dubbo.proxy.ApacheDubboProxyService"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-rpc/shenyu-plugin-grpc/src/main/java/org/apache/shenyu/plugin/grpc/loadbalance/picker/ShenyuPicker.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.grpc.loadbalance.picker.ShenyuPicker"
+      }, {
+        "path" : "shenyu-plugin/shenyu-plugin-proxy/shenyu-plugin-websocket/src/main/java/org/apache/shenyu/plugin/websocket/WebSocketPlugin.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.plugin.websocket.WebSocketPlugin"
+      }, {
+        "path" : "shenyu-protocol/shenyu-protocol-tcp/src/main/java/org/apache/shenyu/protocol/tcp/connection/DefaultConnectionConfigProvider.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.protocol.tcp.connection.DefaultConnectionConfigProvider"
+      }, {
+        "path" : "shenyu-sdk/shenyu-sdk-core/src/main/java/org/apache/shenyu/sdk/core/client/AbstractShenyuSdkClient.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.sdk.core.client.AbstractShenyuSdkClient"
+      }, {
+        "path" : "shenyu-sdk/shenyu-sdk-feign/src/main/java/org/apache/shenyu/sdk/feign/ShenyuDiscoveryClient.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.sdk.feign.ShenyuDiscoveryClient"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.admin.config.PolarisSyncConfigurationTest",
+      "methodName" : "polarisConfigServiceTest"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "b984ad2c6d62a269e6628da62954cc4d761beb28",
+      "headCommit" : "47c958fa8108b75174723e50560a7b0678d1119c",
+      "changedFiles" : [ {
+        "path" : "shenyu-common/src/main/java/org/apache/shenyu/common/utils/IpUtils.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.common.utils.IpUtils"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest",
+      "methodName" : "testExecutorValidData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "1de8abb44639b68ac93b9d7e386df671ab1ec098",
+      "headCommit" : "d8fbb5257efa53540e6410bec9f5fe65ba215399",
+      "changedFiles" : [ {
+        "path" : "shenyu-common/src/test/java/org/apache/shenyu/common/utils/VersionUtilsTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.shenyu.common.utils.VersionUtilsTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest",
+      "methodName" : "testExecutorValidData"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "c39506e97ceef9490a97c736fd5098ce97d6f3a0",
+      "headCommit" : "5c2c3ed612e5bc7b6c87f45c8ceef65321f7948c",
+      "changedFiles" : [ {
+        "path" : ".github/workflows/ci.yml",
+        "kind" : "INERT",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.springboot.starter.sync.data.http.HttpClientPluginConfigurationTest",
+      "methodName" : "testHttpConfig"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "c39506e97ceef9490a97c736fd5098ce97d6f3a0",
+      "headCommit" : "5c2c3ed612e5bc7b6c87f45c8ceef65321f7948c",
+      "changedFiles" : [ {
+        "path" : ".github/workflows/ci.yml",
+        "kind" : "INERT",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.springboot.starter.sync.data.http.HttpClientPluginConfigurationTest",
+      "methodName" : "testHttpSyncDataService"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "b94a6997b697f7272fdf18cf7c9b080195e3fc75",
+      "headCommit" : "79885c1bbbd8a0625e0fcffe251f7675d1cd2e0b",
+      "changedFiles" : [ {
+        "path" : ".github/workflows/e2e-k8s.yml",
+        "kind" : "INERT",
+        "changedClassName" : null
+      }, {
+        "path" : ".github/workflows/integrated-test-k8s-ingress.yml",
+        "kind" : "INERT",
+        "changedClassName" : null
+      }, {
+        "path" : ".github/workflows/integrated-test.yml",
+        "kind" : "INERT",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.shenyu.admin.listener.http.HttpLongPollingDataChangedListenerTest",
+      "methodName" : "testDataChangeTaskBatchNotify"
+    }
+  } ],
+  "savingsSummary" : {
+    "totalTestExecutions" : 747680,
+    "totalSelected" : 233603,
+    "proportionSkipped" : 0.6875628611170554,
+    "fallbackDrivenSelections" : 158976,
+    "moduleScopedFallbackSelections" : 27811,
+    "dependencyMatchedSelections" : 7043,
+    "newOrModifiedTestSelections" : 33341
+  }
+}

--- a/analyses/summary_shenyu_300.txt
+++ b/analyses/summary_shenyu_300.txt
@@ -1,0 +1,52 @@
+Verdict: PASS
+Analyzed: 300 commit pair(s)
+Would-miss cases: 0
+
+Savings: 233603 / 747680 test executions selected (68.8% skipped)
+  - dependency-matched: 7043
+  - fallback-driven: 158976
+  - module-scoped fallback: 27811
+  - new-or-modified: 33341
+Flaky failures observed: 42 (excluded from verdict)
+  - commit c37b4854633efdf019c01805dd9a7e050a7a4e55..3854267989135ed7941e0d38df221c953cde3c07: org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest#testExecutorValidData
+  - commit 4a75fec871c57c6f4411af49afbb24db65888448..b9444302397e04e24124e74f6258f98f5908c34e: org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest#testExecutorValidData
+  - commit f3fd88d6fc44ada465598efeca0a48943f078201..5be0bf6d7422bfc478ce122800f5c21960681352: org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest#testExecutorValidData
+  - commit 9ac8659040e83a4b7c85d3c3aab632b3a380e275..cf7915992b6939523ede8a51f10ce7b79d4b1c55: org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest#testExecutorValidData
+  - commit 8f65ce09475dd41315b95428febc3baf4e927fad..0eaec1e63adef81d0bd5d8797f0e907778abcfea: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 0eaec1e63adef81d0bd5d8797f0e907778abcfea..9c8b78f782f95efb646bf3ad231d745b112fd7cd: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 9c8b78f782f95efb646bf3ad231d745b112fd7cd..d782a64e874d2ac1737d4509db4bffdc91844f28: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit d782a64e874d2ac1737d4509db4bffdc91844f28..319ca4fd9f824625ec609284d390f0236cdb3722: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 319ca4fd9f824625ec609284d390f0236cdb3722..d0745961538abbcad9e60547f5aed181e00f29bb: org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest#testExecutorValidData
+  - commit d0745961538abbcad9e60547f5aed181e00f29bb..4f9e69c54f1f2abf67bb87d4abd8f612dad342b8: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 4f9e69c54f1f2abf67bb87d4abd8f612dad342b8..7c1e43bf6fb8477352e7fb7f236255545f33e362: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 7c1e43bf6fb8477352e7fb7f236255545f33e362..85307386b9f3412a5afc6c504fc10bf64c859892: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 85307386b9f3412a5afc6c504fc10bf64c859892..15278cf6e66ec2b42023af21ba85538dbdeb64d0: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 15278cf6e66ec2b42023af21ba85538dbdeb64d0..0933a2c450b4ad3c5d17284417ac026d8f0d6c27: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 0933a2c450b4ad3c5d17284417ac026d8f0d6c27..1b245d325d3edb20bad33c3ae901eb46947b7183: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 9e8576a2aec00317076a18bb04933b4bfe42a366..eaa2f9503d4f213402f0ca8e1c3b9e9aef015a5d: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit eaa2f9503d4f213402f0ca8e1c3b9e9aef015a5d..0184d4b658729ac5e57fe74217461635f4295e41: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 0184d4b658729ac5e57fe74217461635f4295e41..cde3f548f7284fafd23ac8bb3c91ed716d4d9c51: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit cde3f548f7284fafd23ac8bb3c91ed716d4d9c51..1f595adefabc529623c58565acafd7d7e9cbe74f: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 1f595adefabc529623c58565acafd7d7e9cbe74f..c25dc204c33f229ccc82cd23f4232f834ba0ba68: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit c25dc204c33f229ccc82cd23f4232f834ba0ba68..07453a26d20cd12a8997a331de2ffba5fe78d850: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 07453a26d20cd12a8997a331de2ffba5fe78d850..e624a19aae027361f309cb3e236d6345962ac811: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit e624a19aae027361f309cb3e236d6345962ac811..e4177b6c0e3e592a06f980b9025b90c5d1f909e8: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit e4177b6c0e3e592a06f980b9025b90c5d1f909e8..d2705ef19d14630955e869e4f0479156a65a6e10: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit d2705ef19d14630955e869e4f0479156a65a6e10..161625cd7e4f4fba15267a0d943e6420f858031e: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 161625cd7e4f4fba15267a0d943e6420f858031e..7a36aab29e87f20652f2085e2ae8641b51827b67: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 7a36aab29e87f20652f2085e2ae8641b51827b67..f6a09ec9fb8c22d78eb2d3de0bec1e974f26bfaf: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit f6a09ec9fb8c22d78eb2d3de0bec1e974f26bfaf..fce9c8f01423eeed62f26f7ae4b1510577a95eb6: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit fce9c8f01423eeed62f26f7ae4b1510577a95eb6..cf0bbba7d6e7937a48dd9d4745bfa742f4468658: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit cf0bbba7d6e7937a48dd9d4745bfa742f4468658..da78f467d99d710bd2f4f529f3765e623a511b1c: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit da78f467d99d710bd2f4f529f3765e623a511b1c..1f913296a7a2bbbdce4f7331c6b20d8b49fe72d2: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 1f913296a7a2bbbdce4f7331c6b20d8b49fe72d2..1b9492bf266b84d320e339b41461223d7014374f: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 1b9492bf266b84d320e339b41461223d7014374f..5e90930a33ffc0644aa7d822bd1460df7a928cec: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 5e90930a33ffc0644aa7d822bd1460df7a928cec..9234be312b213803bff9a1691ddf5afb82f41588: org.apache.shenyu.plugin.ai.proxy.handler.AiProxyPluginHandlerTest#testHandlerPluginWithNullData
+  - commit 3c6bb7be162044e379d38b6687a2870991ae7040..6b42718a6ee9027b003b76170a2cb02a269cf26b: org.apache.shenyu.springboot.starter.sync.data.http.HttpClientPluginConfigurationTest#testHttpConfig
+  - commit 3c6bb7be162044e379d38b6687a2870991ae7040..6b42718a6ee9027b003b76170a2cb02a269cf26b: org.apache.shenyu.springboot.starter.sync.data.http.HttpClientPluginConfigurationTest#testHttpSyncDataService
+  - commit ddefc04a05581b567a8cb6466248b2ab358d5172..0f2f7acce28824e56472607be3804407c636b357: org.apache.shenyu.admin.config.PolarisSyncConfigurationTest#polarisConfigServiceTest
+  - commit b984ad2c6d62a269e6628da62954cc4d761beb28..47c958fa8108b75174723e50560a7b0678d1119c: org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest#testExecutorValidData
+  - commit 1de8abb44639b68ac93b9d7e386df671ab1ec098..d8fbb5257efa53540e6410bec9f5fe65ba215399: org.apache.shenyu.client.core.disruptor.subcriber.ShenyuClientURIExecutorSubscriberTest#testExecutorValidData
+  - commit c39506e97ceef9490a97c736fd5098ce97d6f3a0..5c2c3ed612e5bc7b6c87f45c8ceef65321f7948c: org.apache.shenyu.springboot.starter.sync.data.http.HttpClientPluginConfigurationTest#testHttpConfig
+  - commit c39506e97ceef9490a97c736fd5098ce97d6f3a0..5c2c3ed612e5bc7b6c87f45c8ceef65321f7948c: org.apache.shenyu.springboot.starter.sync.data.http.HttpClientPluginConfigurationTest#testHttpSyncDataService
+  - commit b94a6997b697f7272fdf18cf7c9b080195e3fc75..79885c1bbbd8a0625e0fcffe251f7675d1cd2e0b: org.apache.shenyu.admin.listener.http.HttpLongPollingDataChangedListenerTest#testDataChangeTaskBatchNotify


### PR DESCRIPTION
## Summary

- document the 300-pair sequential Apache ShenYu shadow-mode validation
- record the exact commit range, outcome metrics, report, and summary
- state the flake caveat and conservative selection behavior

## Validation

- `jq empty analyses/report_shenyu_300.json`
- `git diff --check`