### PR TITLE
docs: add Commons Lang validator evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ train something probabilistic on historical flakiness. Blastradius does neither:
 uses that real, per-test dependency map to decide what to run next time. No training data,
 no heuristics, no opaque score.
 
-## Early validation: Apache ShenYu
+## Early validation
 
-The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode, from [`ce3719d4d68cb51df0704a154fb1da8b2a1778ed`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) to [`3a411e017acfc47636e2bbfeb2958108d1f15a05`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases. 
+### Apache ShenYu
+
+The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode, from [`ce3719d4d68cb51df0704a154fb1da8b2a1778ed`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) to [`3a411e017acfc47636e2bbfeb2958108d1f15a05`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases. The full [machine-readable report](analyses/report_shenyu_300.json) and [human-readable summary](analyses/summary_shenyu_300.txt) are included in this repository.
 
 | Metric | Result |
 | --- | --- |
@@ -29,7 +31,20 @@ The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode,
 | Tests selected | 233,603 |
 | Flaky test observations | 42 (excluded from the verdict) |
 
-This is early evidence from one Maven project and one 300-pair history window, not a universal guarantee. The run stayed conservative: most selected tests came from fallback and module-scoped fallback rules rather than direct dependency matches. It also exposed recurring test flakiness, which the validator excludes from its soundness verdict. Full suites still remain the recommended daily safety net.
+### Apache Commons Lang
+
+The validator replayed 300 sequential Apache Commons Lang commit pairs in shadow mode, from [`13c99492bf695b8ca378d0976919fcea10010c7f`](https://github.com/apache/commons-lang/commit/13c99492bf695b8ca378d0976919fcea10010c7f) to [`8f8f3b26e8cb81e0879fc676068db1212652dcaf`](https://github.com/apache/commons-lang/commit/8f8f3b26e8cb81e0879fc676068db1212652dcaf). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases. The full [machine-readable report](analyses/common-lang-report.json) and [human-readable summary](analyses/common-lang-summary.txt) are included in this repository.
+
+| Metric | Result |
+| --- | --- |
+| Commit pairs analyzed | 300 / 300 |
+| Build exclusions | 0 |
+| Would-miss cases | 0 |
+| Test executions skipped | 14,313,702 / 23,610,943 **(60.6%)** |
+| Tests selected | 9,297,241 |
+| Flaky test observations | 0 |
+
+These are early results from two Maven projects and two 300-pair history windows, not a universal guarantee. Both runs stayed conservative: most selected tests came from fallback rules rather than direct dependency matches. Full suites still remain the recommended daily safety net.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -18,31 +18,12 @@ no heuristics, no opaque score.
 
 ## Early validation
 
-### Apache ShenYu
+The validator replayed sequential commit pairs in shadow mode and compared the selected-test outcomes with each corresponding full-test outcome.
 
-The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode, from [`ce3719d`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) to [`3a411e0`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases.
-
-| Metric | Result |
-| --- | --- |
-| Commit pairs analyzed | 300 / 300 |
-| Build exclusions | 0 |
-| Would-miss cases | 0 |
-| Test executions skipped | 514,077 / 747,680 **(68.8%)** |
-| Tests selected | 233,603 |
-| Flaky test observations | 42 (excluded from the verdict) |
-
-### Apache Commons Lang
-
-The validator replayed 300 sequential Apache Commons Lang commit pairs in shadow mode, from [`13c9949`](https://github.com/apache/commons-lang/commit/13c99492bf695b8ca378d0976919fcea10010c7f) to [`8f8f3b2`](https://github.com/apache/commons-lang/commit/8f8f3b26e8cb81e0879fc676068db1212652dcaf). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases.
-
-| Metric | Result |
-| --- | --- |
-| Commit pairs analyzed | 300 / 300 |
-| Build exclusions | 0 |
-| Would-miss cases | 0 |
-| Test executions skipped | 14,313,702 / 23,610,943 **(60.6%)** |
-| Tests selected | 9,297,241 |
-| Flaky test observations | 0 |
+| Project | Commit range | Pairs analyzed (excluded) | Would-miss cases | Test executions selected | Skipped | Flaky observations |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| Apache ShenYu | [`ce3719d`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) → [`3a411e0`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05) | 300 (0) | 0 | 233,603 / 747,680 | **68.8%** | 42 (excluded from verdict) |
+| Apache Commons Lang | [`13c9949`](https://github.com/apache/commons-lang/commit/13c99492bf695b8ca378d0976919fcea10010c7f) → [`8f8f3b2`](https://github.com/apache/commons-lang/commit/8f8f3b26e8cb81e0879fc676068db1212652dcaf) | 300 (0) | 0 | 9,297,241 / 23,610,943 | **60.6%** | 0 |
 
 These are early results from two Maven projects and two 300-pair history windows, not a universal guarantee. Both runs stayed conservative: most selected tests came from fallback rules rather than direct dependency matches. Full suites still remain the recommended daily safety net.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ no heuristics, no opaque score.
 
 ### Apache ShenYu
 
-The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode, from [`ce3719d4d68cb51df0704a154fb1da8b2a1778ed`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) to [`3a411e017acfc47636e2bbfeb2958108d1f15a05`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases. See the [machine-readable report](analyses/report_shenyu_300.json) and [human-readable summary](analyses/summary_shenyu_300.txt).
+The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode, from [`ce3719d4d68cb51df0704a154fb1da8b2a1778ed`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) to [`3a411e017acfc47636e2bbfeb2958108d1f15a05`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases.
 
 | Metric | Result |
 | --- | --- |
@@ -33,7 +33,7 @@ The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode,
 
 ### Apache Commons Lang
 
-The validator replayed 300 sequential Apache Commons Lang commit pairs in shadow mode, from [`13c99492bf695b8ca378d0976919fcea10010c7f`](https://github.com/apache/commons-lang/commit/13c99492bf695b8ca378d0976919fcea10010c7f) to [`8f8f3b26e8cb81e0879fc676068db1212652dcaf`](https://github.com/apache/commons-lang/commit/8f8f3b26e8cb81e0879fc676068db1212652dcaf). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases. See the [machine-readable report](analyses/common-lang-report.json) and [human-readable summary](analyses/common-lang-summary.txt).
+The validator replayed 300 sequential Apache Commons Lang commit pairs in shadow mode, from [`13c99492bf695b8ca378d0976919fcea10010c7f`](https://github.com/apache/commons-lang/commit/13c99492bf695b8ca378d0976919fcea10010c7f) to [`8f8f3b26e8cb81e0879fc676068db1212652dcaf`](https://github.com/apache/commons-lang/commit/8f8f3b26e8cb81e0879fc676068db1212652dcaf). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases.
 
 | Metric | Result |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ no heuristics, no opaque score.
 
 ### Apache ShenYu
 
-The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode, from [`ce3719d4d68cb51df0704a154fb1da8b2a1778ed`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) to [`3a411e017acfc47636e2bbfeb2958108d1f15a05`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases. The full [machine-readable report](analyses/report_shenyu_300.json) and [human-readable summary](analyses/summary_shenyu_300.txt) are included in this repository.
+The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode, from [`ce3719d4d68cb51df0704a154fb1da8b2a1778ed`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) to [`3a411e017acfc47636e2bbfeb2958108d1f15a05`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases. See the [machine-readable report](analyses/report_shenyu_300.json) and [human-readable summary](analyses/summary_shenyu_300.txt).
 
 | Metric | Result |
 | --- | --- |
@@ -33,7 +33,7 @@ The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode,
 
 ### Apache Commons Lang
 
-The validator replayed 300 sequential Apache Commons Lang commit pairs in shadow mode, from [`13c99492bf695b8ca378d0976919fcea10010c7f`](https://github.com/apache/commons-lang/commit/13c99492bf695b8ca378d0976919fcea10010c7f) to [`8f8f3b26e8cb81e0879fc676068db1212652dcaf`](https://github.com/apache/commons-lang/commit/8f8f3b26e8cb81e0879fc676068db1212652dcaf). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases. The full [machine-readable report](analyses/common-lang-report.json) and [human-readable summary](analyses/common-lang-summary.txt) are included in this repository.
+The validator replayed 300 sequential Apache Commons Lang commit pairs in shadow mode, from [`13c99492bf695b8ca378d0976919fcea10010c7f`](https://github.com/apache/commons-lang/commit/13c99492bf695b8ca378d0976919fcea10010c7f) to [`8f8f3b26e8cb81e0879fc676068db1212652dcaf`](https://github.com/apache/commons-lang/commit/8f8f3b26e8cb81e0879fc676068db1212652dcaf). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases. See the [machine-readable report](analyses/common-lang-report.json) and [human-readable summary](analyses/common-lang-summary.txt).
 
 | Metric | Result |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ no heuristics, no opaque score.
 
 ### Apache ShenYu
 
-The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode, from [`ce3719d4d68cb51df0704a154fb1da8b2a1778ed`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) to [`3a411e017acfc47636e2bbfeb2958108d1f15a05`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases.
+The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode, from [`ce3719d`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) to [`3a411e0`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases.
 
 | Metric | Result |
 | --- | --- |
@@ -33,7 +33,7 @@ The validator replayed 300 sequential Apache ShenYu commit pairs in shadow mode,
 
 ### Apache Commons Lang
 
-The validator replayed 300 sequential Apache Commons Lang commit pairs in shadow mode, from [`13c99492bf695b8ca378d0976919fcea10010c7f`](https://github.com/apache/commons-lang/commit/13c99492bf695b8ca378d0976919fcea10010c7f) to [`8f8f3b26e8cb81e0879fc676068db1212652dcaf`](https://github.com/apache/commons-lang/commit/8f8f3b26e8cb81e0879fc676068db1212652dcaf). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases.
+The validator replayed 300 sequential Apache Commons Lang commit pairs in shadow mode, from [`13c9949`](https://github.com/apache/commons-lang/commit/13c99492bf695b8ca378d0976919fcea10010c7f) to [`8f8f3b2`](https://github.com/apache/commons-lang/commit/8f8f3b26e8cb81e0879fc676068db1212652dcaf). All 300 pairs built and were analyzed; comparison with the corresponding full-test outcomes found no would-miss cases.
 
 | Metric | Result |
 | --- | --- |

--- a/analyses/common-lang-report.json
+++ b/analyses/common-lang-report.json
@@ -1,0 +1,6212 @@
+{
+  "verdict" : "PASS",
+  "analyzedCommitPairs" : [ {
+    "baseCommit" : "13c99492bf695b8ca378d0976919fcea10010c7f",
+    "headCommit" : "18979f30e963081e5e0f018448dd3aadc429f51e",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/StrBuilderClearTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilderClearTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "18979f30e963081e5e0f018448dd3aadc429f51e",
+    "headCommit" : "5d55a80df85119d8e3035ee7c533d6cf874a7cc9",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5d55a80df85119d8e3035ee7c533d6cf874a7cc9",
+    "headCommit" : "b6d284b49de8460381a1752d25f4d4f387db28e2",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayFill.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayFill"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b6d284b49de8460381a1752d25f4d4f387db28e2",
+    "headCommit" : "0b4a9d95df610bfcc83c375110ac100d08662ba1",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/LocaleUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.LocaleUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.LocaleUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0b4a9d95df610bfcc83c375110ac100d08662ba1",
+    "headCommit" : "cf855a838ac4bb4a9c919d01cc5254c89db6d8e1",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cf855a838ac4bb4a9c919d01cc5254c89db6d8e1",
+    "headCommit" : "79380dba919716065f5e16465671782119449a36",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DurationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/StopWatch.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.StopWatch"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/DurationUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "79380dba919716065f5e16465671782119449a36",
+    "headCommit" : "108aa571c1d6a79773d9c92bd1ee0eb10b165528",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "108aa571c1d6a79773d9c92bd1ee0eb10b165528",
+    "headCommit" : "68c33330820f94f1f335e16eeb201988ad8c1edd",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDatePrinter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDatePrinter"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateFormatTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "68c33330820f94f1f335e16eeb201988ad8c1edd",
+    "headCommit" : "cc54667ce1ee7d4cbddd836d14467d1569b4057f",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cc54667ce1ee7d4cbddd836d14467d1569b4057f",
+    "headCommit" : "526a03a8701f85e422786f0a4d1fadd3f0c249c1",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DateUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "526a03a8701f85e422786f0a4d1fadd3f0c249c1",
+    "headCommit" : "d962b3c924f132b83d6db99ca126ac75a1469d90",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d962b3c924f132b83d6db99ca126ac75a1469d90",
+    "headCommit" : "b11591895eed00e9f6e0bcb19178dedbaab4a971",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/FormattableUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.FormattableUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/FormattableUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.FormattableUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b11591895eed00e9f6e0bcb19178dedbaab4a971",
+    "headCommit" : "17fa81a348ffabfe4a8347beac2e199512b2ff10",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "17fa81a348ffabfe4a8347beac2e199512b2ff10",
+    "headCommit" : "c79a10240bd7ddcb956c3f6853f956e0251fb745",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ClassUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/ClassUtilsGetShortClassNameTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassUtilsGetShortClassNameTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c79a10240bd7ddcb956c3f6853f956e0251fb745",
+    "headCommit" : "b7a1c5ea301e9aaf5fc062697274b2be377b6294",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/scorecards-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ClassUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/ClassUtilsGetShortClassNameTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassUtilsGetShortClassNameTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b7a1c5ea301e9aaf5fc062697274b2be377b6294",
+    "headCommit" : "bd8fa876cfd1f448c1981fc26c37bb6fcea7447f",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bd8fa876cfd1f448c1981fc26c37bb6fcea7447f",
+    "headCommit" : "f51d0615d034ae997611ac01fd4c79823122372b",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ClassUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/ClassUtilsGetShortClassNameTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassUtilsGetShortClassNameTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f51d0615d034ae997611ac01fd4c79823122372b",
+    "headCommit" : "344df301589744f0a4dc0f4eea91e078b2f97443",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/ImmutableTimeZone.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.ImmutableTimeZone"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/TimeZones.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.TimeZones"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/ImmutableTimeZoneTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.ImmutableTimeZoneTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/TimeZonesGmtTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.TimeZonesGmtTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/TimeZonesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.TimeZonesTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "344df301589744f0a4dc0f4eea91e078b2f97443",
+    "headCommit" : "8c4deb83471987bd4e8a489e4c423ed911610d5a",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/ImmutableTimeZone.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.ImmutableTimeZone"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/TimeZones.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.TimeZones"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/ImmutableTimeZoneTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.ImmutableTimeZoneTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/TimeZonesGmtTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.TimeZonesGmtTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/TimeZonesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.TimeZonesTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8c4deb83471987bd4e8a489e4c423ed911610d5a",
+    "headCommit" : "38f7109f4214300ae6eaf4bd76f5a7f1b2a10dc1",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/ImmutableTimeZone.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.ImmutableTimeZone"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/TimeZones.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.TimeZones"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/ImmutableTimeZoneTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.ImmutableTimeZoneTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/TimeZonesGmtTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.TimeZonesGmtTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/TimeZonesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.TimeZonesTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "38f7109f4214300ae6eaf4bd76f5a7f1b2a10dc1",
+    "headCommit" : "4d5ac2df889aa6f18389e0be0fc74b08271bc11f",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.EqualsBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.HashCodeBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/ToStringBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ToStringBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4d5ac2df889aa6f18389e0be0fc74b08271bc11f",
+    "headCommit" : "b9bc027df25a60188d3400669cd8edad78c737a1",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.EqualsBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b9bc027df25a60188d3400669cd8edad78c737a1",
+    "headCommit" : "8e2d1bed8623e0f5b281504d151476689f21690a",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/AbstractReflection.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.AbstractReflection"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.CompareToBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.EqualsBuilder"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/CompareToBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.CompareToBuilderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8e2d1bed8623e0f5b281504d151476689f21690a",
+    "headCommit" : "593af7639553540f7d1c68e5305756ffc2b4e944",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "593af7639553540f7d1c68e5305756ffc2b4e944",
+    "headCommit" : "7db3e126dd480698eb523e72e8dc4e5ed7e7a5c7",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayFill.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayFill"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/ArrayFillTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayFillTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7db3e126dd480698eb523e72e8dc4e5ed7e7a5c7",
+    "headCommit" : "465c6a980aa783bd0fa82ab2742568c3f34c0d55",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "465c6a980aa783bd0fa82ab2742568c3f34c0d55",
+    "headCommit" : "28f46460d63b4c7806a2b9cce382b2b79ba6fd50",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ClassUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/ClassUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "28f46460d63b4c7806a2b9cce382b2b79ba6fd50",
+    "headCommit" : "172cbbd778e7e5ec4206ec96bf61b740e3800fce",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "172cbbd778e7e5ec4206ec96bf61b740e3800fce",
+    "headCommit" : "667b67a1c4e2521a28deee0b673ec4a79a4d993d",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "667b67a1c4e2521a28deee0b673ec4a79a4d993d",
+    "headCommit" : "f3e64b3b0e67d7faa0f10b698e08207f972a15b1",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayFill.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayFill"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/ArrayFillTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayFillTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/StrBuilderClearTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilderClearTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f3e64b3b0e67d7faa0f10b698e08207f972a15b1",
+    "headCommit" : "60e07f154ecaa0a30d4d0ce30fe27da9f43528ad",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "60e07f154ecaa0a30d4d0ce30fe27da9f43528ad",
+    "headCommit" : "ef39bc92712d47c100af3b243a8bfcd84a45f116",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/StrBuilderClearTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilderClearTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ef39bc92712d47c100af3b243a8bfcd84a45f116",
+    "headCommit" : "60b63f627c274b3310bbdc9c4d0b08378f7f7f8d",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "60b63f627c274b3310bbdc9c4d0b08378f7f7f8d",
+    "headCommit" : "1aa5352287f581b628c48c6f61e38866d4a2f64a",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1aa5352287f581b628c48c6f61e38866d4a2f64a",
+    "headCommit" : "14deed1bff705a46c485733451f462f549ac528d",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.NumericEntityUnescaper"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/translate/NumericEntityEscaperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.NumericEntityEscaperTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "14deed1bff705a46c485733451f462f549ac528d",
+    "headCommit" : "5a62dd00b16179fcba4566728c8b39d8461af4fa",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5a62dd00b16179fcba4566728c8b39d8461af4fa",
+    "headCommit" : "2c0b8483606efbfbaccf600e3bc31fe10533e004",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastTimeZone.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastTimeZone"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/GmtTimeZone.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.GmtTimeZone"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastTimeZoneTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastTimeZoneTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2c0b8483606efbfbaccf600e3bc31fe10533e004",
+    "headCommit" : "dd2028bd6c583b8c6aab4e1b43d8b4b72fbdec65",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "dd2028bd6c583b8c6aab4e1b43d8b4b72fbdec65",
+    "headCommit" : "28c2fcbb73e2247ec1a3846e4e55f0ed4986b9c9",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/Range.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Range"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/RangeReadObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RangeReadObjectTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "28c2fcbb73e2247ec1a3846e4e55f0ed4986b9c9",
+    "headCommit" : "186f6bcbab753cdd8b5a58191cc20e91fabe70ed",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/time/StopWatchTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.StopWatchTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "186f6bcbab753cdd8b5a58191cc20e91fabe70ed",
+    "headCommit" : "9dada254003cfb118397c14a8f4b5cba2549b11f",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9dada254003cfb118397c14a8f4b5cba2549b11f",
+    "headCommit" : "8aed583a797d977d199b62e85d67a1fbbf7ca060",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8aed583a797d977d199b62e85d67a1fbbf7ca060",
+    "headCommit" : "4f1a343ea40ceade111a5ba2e29215f83a91c26c",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParser_TimeZoneStrategyTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser_TimeZoneStrategyTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4f1a343ea40ceade111a5ba2e29215f83a91c26c",
+    "headCommit" : "9bcc0d0bf84f6278a000eaf39af0e9780be9046c",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/RandomStringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomStringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomStringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9bcc0d0bf84f6278a000eaf39af0e9780be9046c",
+    "headCommit" : "093cf417bfc2a295c62fd541d39a994fa1d37804",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationFormatUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "093cf417bfc2a295c62fd541d39a994fa1d37804",
+    "headCommit" : "52343c5bec231bc2ae47f89375c6b98c0c04de98",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "52343c5bec231bc2ae47f89375c6b98c0c04de98",
+    "headCommit" : "cefdd9c6e2c70f947436bbb67574ddc8ff107e8d",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomStringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cefdd9c6e2c70f947436bbb67574ddc8ff107e8d",
+    "headCommit" : "eb9c5bf0cd8f86da37392f2a6f1c91454f55ce7c",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/scorecards-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "eb9c5bf0cd8f86da37392f2a6f1c91454f55ce7c",
+    "headCommit" : "d95e17f1c173a6259886e577cf5acc914ec44c2d",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DurationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/DurationUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d95e17f1c173a6259886e577cf5acc914ec44c2d",
+    "headCommit" : "531e2a2cf1c1e56708859ad2579a5e5760140714",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/Instants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.Instants"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/InstantsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.InstantsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "531e2a2cf1c1e56708859ad2579a5e5760140714",
+    "headCommit" : "bd7ffdf5b27004908f10345f3048d4790291fbe0",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsTrimTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsTrimTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bd7ffdf5b27004908f10345f3048d4790291fbe0",
+    "headCommit" : "b84e429f6ab7ac095d875356a0b447856ffc4049",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b84e429f6ab7ac095d875356a0b447856ffc4049",
+    "headCommit" : "e77aa119745bf7a6aeda13a92a266ebdce6c8e18",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e77aa119745bf7a6aeda13a92a266ebdce6c8e18",
+    "headCommit" : "e96157d6d50288d69e8ac57097d58c6035ec8697",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e96157d6d50288d69e8ac57097d58c6035ec8697",
+    "headCommit" : "62ea4b620be45462ace4247df34ca938aa29a4da",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "62ea4b620be45462ace4247df34ca938aa29a4da",
+    "headCommit" : "c2a7e5b005d19932df37486efd598f0a99331b7e",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.NumericEntityUnescaperTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c2a7e5b005d19932df37486efd598f0a99331b7e",
+    "headCommit" : "2d2e68560fb001c7fa8f8d6f7475f3b800acd995",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.NumericEntityUnescaperTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2d2e68560fb001c7fa8f8d6f7475f3b800acd995",
+    "headCommit" : "bdd674f7c64dbc2c8ff043ee995fcd9f6f59a13b",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/CharSequenceUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharSequenceUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsEqualsIndexOfTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bdd674f7c64dbc2c8ff043ee995fcd9f6f59a13b",
+    "headCommit" : "bda0680763ad90264b9cca8233bb3369c03f4e13",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/Instants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.Instants"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/InstantsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.InstantsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bda0680763ad90264b9cca8233bb3369c03f4e13",
+    "headCommit" : "9abd79314b19676c54eab02d441cfb3051bb2d8c",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/CharUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/CharUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9abd79314b19676c54eab02d441cfb3051bb2d8c",
+    "headCommit" : "70403b95ec98eca76f14543e3d04d22078af3956",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "70403b95ec98eca76f14543e3d04d22078af3956",
+    "headCommit" : "fc67697ebe7d8c4a6ad5b9344e3216522ec83113",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/conf/spotbugs-exclude-filter-java8-sb-4.8.6.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Range.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Range"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/RangeReadObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RangeReadObjectTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "fc67697ebe7d8c4a6ad5b9344e3216522ec83113",
+    "headCommit" : "cfd1065afb0168983b7f1e18c663336f349fba36",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cfd1065afb0168983b7f1e18c663336f349fba36",
+    "headCommit" : "a9ae10e31066a183050b356ecf667b23ace21a61",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/math/Fraction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.Fraction"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/math/FractionReadObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.FractionReadObjectTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a9ae10e31066a183050b356ecf667b23ace21a61",
+    "headCommit" : "62841003b601f443ac5b67eddc823916b99e9089",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "62841003b601f443ac5b67eddc823916b99e9089",
+    "headCommit" : "0cd12b10588b09895a370198d87303c8774205af",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsTrimTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsTrimTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0cd12b10588b09895a370198d87303c8774205af",
+    "headCommit" : "2478e56f677db974fa196761cf704202cb2cd3c0",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2478e56f677db974fa196761cf704202cb2cd3c0",
+    "headCommit" : "9073a1e87c259f273a3ecf2ca7f3549530395909",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/scorecards-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9073a1e87c259f273a3ecf2ca7f3549530395909",
+    "headCommit" : "6e02b0a4d22f376a9414ff0a73f00ad9ef265241",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/Instants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.Instants"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/InstantsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.InstantsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6e02b0a4d22f376a9414ff0a73f00ad9ef265241",
+    "headCommit" : "1e4e8376a3d516ea0990906e5275aa095892a420",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1e4e8376a3d516ea0990906e5275aa095892a420",
+    "headCommit" : "7cab315eba320ec56bce1c225da90ecc8a74e286",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7cab315eba320ec56bce1c225da90ecc8a74e286",
+    "headCommit" : "31cf693fa7fed3ee1a14dc804f89fa2ea5586f67",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "31cf693fa7fed3ee1a14dc804f89fa2ea5586f67",
+    "headCommit" : "0924f91d57d8932084c44fa7a957318a57b7aa40",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/Range.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Range"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/SerializationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.SerializationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDateParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserReadObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserReadObjectTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0924f91d57d8932084c44fa7a957318a57b7aa40",
+    "headCommit" : "451c0691a64912458541ce5f84f85943597433bb",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Range.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Range"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/SerializationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.SerializationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDateParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserReadObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserReadObjectTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "451c0691a64912458541ce5f84f85943597433bb",
+    "headCommit" : "2a2dc544ed31bc8257bef596d012d91b23444f9b",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.ExtendedMessageFormatTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2a2dc544ed31bc8257bef596d012d91b23444f9b",
+    "headCommit" : "b9bce16817a58756b287ae2b4403a961307b95f8",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/Range.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Range"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/SerializationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.SerializationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDateParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserReadObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserReadObjectTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b9bce16817a58756b287ae2b4403a961307b95f8",
+    "headCommit" : "5b87be5e67f393cf62a11dbc8ffcbec56cdde12b",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsEqualsIndexOfTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsEqualsIndexOfTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5b87be5e67f393cf62a11dbc8ffcbec56cdde12b",
+    "headCommit" : "1e071b3dd5a16cd74b3dd991b7d0b03e581c8d7a",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1e071b3dd5a16cd74b3dd991b7d0b03e581c8d7a",
+    "headCommit" : "80bf07c61721520ef12679fc394ac5584c1e9536",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/translate/LookupTranslator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.LookupTranslator"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/translate/LookupTranslatorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.LookupTranslatorTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "80bf07c61721520ef12679fc394ac5584c1e9536",
+    "headCommit" : "a35fdd51c6c9894ac1e7fbe7b0e4f9744ec45898",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a35fdd51c6c9894ac1e7fbe7b0e4f9744ec45898",
+    "headCommit" : "e36ad64c2f08ad6efecf1bd00727930ca9557d37",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e36ad64c2f08ad6efecf1bd00727930ca9557d37",
+    "headCommit" : "07fe35dae2c1dbeb943ab6a95fc015925e3500c1",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/CompareToBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.CompareToBuilderTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/EqualsBuilderReflectionEqualsCycleTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.EqualsBuilderReflectionEqualsCycleTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderCycleTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.HashCodeBuilderCycleTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializerInitTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AtomicSafeInitializerInitTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/translate/NumericEntityEscaperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.NumericEntityEscaperTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateUtilsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateFormatTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/TimeZonesGmtTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.TimeZonesGmtTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "07fe35dae2c1dbeb943ab6a95fc015925e3500c1",
+    "headCommit" : "d1159fcafb6e37a6ac98bf2e2ff09c78187c7656",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d1159fcafb6e37a6ac98bf2e2ff09c78187c7656",
+    "headCommit" : "b10be28d248ee40442bb718bb64d26be1ac82454",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParser_TimeZoneStrategyTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser_TimeZoneStrategyTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDatePrinterTimeZonesTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDatePrinterTimeZonesTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b10be28d248ee40442bb718bb64d26be1ac82454",
+    "headCommit" : "39922155e537992157b261738fab157da2146dcd",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/dependency-review.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "39922155e537992157b261738fab157da2146dcd",
+    "headCommit" : "ca135032f0a73c4a41353960781b45968e081e8d",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/dependency-review.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ca135032f0a73c4a41353960781b45968e081e8d",
+    "headCommit" : "764b42f876be88b595e8e7deb5dce37566df9efa",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/CharRange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharRange"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/CharRangeReadObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharRangeReadObjectTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "764b42f876be88b595e8e7deb5dce37566df9efa",
+    "headCommit" : "ac8e5b5e30c0db79d1a399ae706300805cf2de47",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ac8e5b5e30c0db79d1a399ae706300805cf2de47",
+    "headCommit" : "bcf09d227765e788e09344ef5173b6c2e8fb4870",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/util/FluentBitSet.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.util.FluentBitSet"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/util/FluentBitSetReadObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.util.FluentBitSetReadObjectTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bcf09d227765e788e09344ef5173b6c2e8fb4870",
+    "headCommit" : "2a6a10437d8d479af4bf7d180f0974238ab831b9",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2a6a10437d8d479af4bf7d180f0974238ab831b9",
+    "headCommit" : "81804c19c0f67d2cd1abef3220da0a741872679a",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.event.EventListenerSupport"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/event/EventListenerSupportReadObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.event.EventListenerSupportReadObjectTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "81804c19c0f67d2cd1abef3220da0a741872679a",
+    "headCommit" : "6c7b28b4aee6f7b55148430087f370be0fbece31",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6c7b28b4aee6f7b55148430087f370be0fbece31",
+    "headCommit" : "1409264e20994abc8ff6a0ffc4109318114333e4",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/Strings.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Strings"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1409264e20994abc8ff6a0ffc4109318114333e4",
+    "headCommit" : "e79347fd471671da37bd8cf5623d3b310bf88162",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Strings.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Strings"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e79347fd471671da37bd8cf5623d3b310bf88162",
+    "headCommit" : "b33448dd18cf76ac03d82e0da0c27fc521470312",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/Strings.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Strings"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b33448dd18cf76ac03d82e0da0c27fc521470312",
+    "headCommit" : "2c3748412e5a4f4f167ac4f15c8fe0a093ea5e2b",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/Strings.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Strings"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2c3748412e5a4f4f167ac4f15c8fe0a093ea5e2b",
+    "headCommit" : "d420ed9fed960a0ad4150b74742e1cb939f3a042",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d420ed9fed960a0ad4150b74742e1cb939f3a042",
+    "headCommit" : "e6b8bbd39505694012d869fa2107ef068b88d800",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.LocaleUtilsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsContainsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsContainsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateFormatTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateFormatTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParser_MoreOrLessTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser_MoreOrLessTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParser_TimeZoneStrategyTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser_TimeZoneStrategyTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/WeekYearTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.WeekYearTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e6b8bbd39505694012d869fa2107ef068b88d800",
+    "headCommit" : "2240c1f93e5f96b12a83ec8615c29dfac46258e9",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsSubstringTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsSubstringTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2240c1f93e5f96b12a83ec8615c29dfac46258e9",
+    "headCommit" : "cba3a601052629002618e102f310690d27361014",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/StringsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cba3a601052629002618e102f310690d27361014",
+    "headCommit" : "51c84dfb6cfd3321aff4bdbec1566d0bd93bbe54",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "51c84dfb6cfd3321aff4bdbec1566d0bd93bbe54",
+    "headCommit" : "67ab00abf3f0a8378326d2af91c359746863af19",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "67ab00abf3f0a8378326d2af91c359746863af19",
+    "headCommit" : "57f39420fef8413ea42f045f1bdba4864ff75a0c",
+    "changedFiles" : [ {
+      "path" : "CONTRIBUTING.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "57f39420fef8413ea42f045f1bdba4864ff75a0c",
+    "headCommit" : "d927bfc848c409af2050d1c32b3e7cf1daed304e",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.ExtendedMessageFormat"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.ExtendedMessageFormatTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d927bfc848c409af2050d1c32b3e7cf1daed304e",
+    "headCommit" : "44298fe0c0df0688827bcbf07677c3706de00f88",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "44298fe0c0df0688827bcbf07677c3706de00f88",
+    "headCommit" : "060ab31e517d856292e97428345821b5b289249a",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/math/NumberUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "060ab31e517d856292e97428345821b5b289249a",
+    "headCommit" : "99c22e51ca610a1c7c35c705a906e911b156451f",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "99c22e51ca610a1c7c35c705a906e911b156451f",
+    "headCommit" : "1dd567ea0c8aeb7ecca2c7dedeef6f511e366760",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1dd567ea0c8aeb7ecca2c7dedeef6f511e366760",
+    "headCommit" : "294aac0f00c54792654124b44fa145c677368176",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "294aac0f00c54792654124b44fa145c677368176",
+    "headCommit" : "7cd272ed863e2220be20829f84efd06ef8bf4211",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7cd272ed863e2220be20829f84efd06ef8bf4211",
+    "headCommit" : "947e1d61888e097e3356c32ba474248b6dd57327",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "947e1d61888e097e3356c32ba474248b6dd57327",
+    "headCommit" : "35376e48374e65382f37a1c4b7d9d169908d2e70",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "35376e48374e65382f37a1c4b7d9d169908d2e70",
+    "headCommit" : "85caf864f6b15c8505f12c3a342e91a0469a023f",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "85caf864f6b15c8505f12c3a342e91a0469a023f",
+    "headCommit" : "c0168c3fdd3c7a23b9e4ddceb0aad262b6b5613f",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c0168c3fdd3c7a23b9e4ddceb0aad262b6b5613f",
+    "headCommit" : "6674bb3c3eb32bcb2f79eae2f26495e422a7b492",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6674bb3c3eb32bcb2f79eae2f26495e422a7b492",
+    "headCommit" : "7ce93bc4a7f6a9b482dbad814c1badd13aa09eea",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7ce93bc4a7f6a9b482dbad814c1badd13aa09eea",
+    "headCommit" : "3e111f128a1f5a2f1e7df78c5cd6e8206eada959",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3e111f128a1f5a2f1e7df78c5cd6e8206eada959",
+    "headCommit" : "60d4c9843891f07596d2caf52fb8689d80179344",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/compare/ObjectToStringComparator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.compare.ObjectToStringComparator"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/compare/ObjectToStringComparatorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.compare.ObjectToStringComparatorTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "60d4c9843891f07596d2caf52fb8689d80179344",
+    "headCommit" : "8ee0477816221dbb67139db7e0dff6f997f9be9e",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/compare/ObjectToStringComparator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.compare.ObjectToStringComparator"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/compare/ObjectToStringComparatorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.compare.ObjectToStringComparatorTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8ee0477816221dbb67139db7e0dff6f997f9be9e",
+    "headCommit" : "86ed42da5c1ac09888dfe2481aaa06df13fb1a68",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/RandomStringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomStringUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/compare/ObjectToStringComparator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.compare.ObjectToStringComparator"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomStringUtilsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/compare/ObjectToStringComparatorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.compare.ObjectToStringComparatorTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "86ed42da5c1ac09888dfe2481aaa06df13fb1a68",
+    "headCommit" : "5fceb927149723bc6199d46f3a5f27675e65d9db",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5fceb927149723bc6199d46f3a5f27675e65d9db",
+    "headCommit" : "2780ad699014d6ce9c7141b15c45bb2c806ef173",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomStringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2780ad699014d6ce9c7141b15c45bb2c806ef173",
+    "headCommit" : "8e0dd9df142dd25fdb0de1d7b34937980c08c03f",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsSubstringTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsSubstringTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8e0dd9df142dd25fdb0de1d7b34937980c08c03f",
+    "headCommit" : "9aafb61e8af50eb3d9aaa139ddb129afac7eadd9",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9aafb61e8af50eb3d9aaa139ddb129afac7eadd9",
+    "headCommit" : "f2294f76476bc3d64eb2c2b8091ca80b03293962",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomStringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f2294f76476bc3d64eb2c2b8091ca80b03293962",
+    "headCommit" : "5eccadae66249bd06c5dec28bd8c99e8161941fa",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomStringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5eccadae66249bd06c5dec28bd8c99e8161941fa",
+    "headCommit" : "e10003978ba6bacb7b32c27816b68b858404e967",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomStringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e10003978ba6bacb7b32c27816b68b858404e967",
+    "headCommit" : "18063c1f6d935d60d0e7341d68434ab4c88a34ee",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/math/NumberUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "18063c1f6d935d60d0e7341d68434ab4c88a34ee",
+    "headCommit" : "08425d17f0adf454d6cd4c8c30efa08a7aed3978",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "08425d17f0adf454d6cd4c8c30efa08a7aed3978",
+    "headCommit" : "46d9a80e548f792c5ee1a9e63f82a84256bf18a4",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/math/Fraction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.Fraction"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/math/FractionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.FractionTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "46d9a80e548f792c5ee1a9e63f82a84256bf18a4",
+    "headCommit" : "9ceaf34297f2b6e05f5477d5c70eb38e65eb8be9",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9ceaf34297f2b6e05f5477d5c70eb38e65eb8be9",
+    "headCommit" : "fbae26f0819b795b38b4a251021c3086751f69f4",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "fbae26f0819b795b38b4a251021c3086751f69f4",
+    "headCommit" : "78de8a9aa9ecb40c02888467a6514f6536f3669d",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "78de8a9aa9ecb40c02888467a6514f6536f3669d",
+    "headCommit" : "53172785c29bb450479c5ba2c198102a5aa9a753",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "53172785c29bb450479c5ba2c198102a5aa9a753",
+    "headCommit" : "738b8800a7a07c98898974d9761dd487ad3f17db",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "738b8800a7a07c98898974d9761dd487ad3f17db",
+    "headCommit" : "ddf5625d50a4c2fbe9346f12a26fc60e68af894e",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/BitField.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BitField"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/BitFieldTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BitFieldTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ddf5625d50a4c2fbe9346f12a26fc60e68af894e",
+    "headCommit" : "cac9ec71ee4cd3082f5b53548299a4c95752bf25",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cac9ec71ee4cd3082f5b53548299a4c95752bf25",
+    "headCommit" : "eedd91729833cedcb31b0fd8116869c71e57ac74",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ObjectUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ObjectUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ObjectUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "eedd91729833cedcb31b0fd8116869c71e57ac74",
+    "headCommit" : "82252aa9c2634b319302129f4b367439b2dd4f13",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "82252aa9c2634b319302129f4b367439b2dd4f13",
+    "headCommit" : "61e87aa1e5a74d4b39140d656967b0bd4b126b93",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/BitFieldTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BitFieldTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "61e87aa1e5a74d4b39140d656967b0bd4b126b93",
+    "headCommit" : "9217777220d6ff3dae6f35c6312eb972c3e20d49",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/BitFieldTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BitFieldTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9217777220d6ff3dae6f35c6312eb972c3e20d49",
+    "headCommit" : "04df64b765d5817c04454e343007cb4c091c5c20",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/BitFieldTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BitFieldTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "04df64b765d5817c04454e343007cb4c091c5c20",
+    "headCommit" : "153ef3f3db2dccdbfd6896ac847a38083e14f0de",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/dependency-review.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "153ef3f3db2dccdbfd6896ac847a38083e14f0de",
+    "headCommit" : "a0ffef035d6a0e7803da8405ebceacb011efbaa0",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/math/Fraction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.Fraction"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/math/FractionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.FractionTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a0ffef035d6a0e7803da8405ebceacb011efbaa0",
+    "headCommit" : "034fea0a8d8b87cd3bacdf52334186d3ec74aa97",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "034fea0a8d8b87cd3bacdf52334186d3ec74aa97",
+    "headCommit" : "3e50a7f9cf103357d781483d41ec9c9386e69e9d",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3e50a7f9cf103357d781483d41ec9c9386e69e9d",
+    "headCommit" : "04365e544f536fd67e6f6dcb2ca8e18c70fcf00b",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "04365e544f536fd67e6f6dcb2ca8e18c70fcf00b",
+    "headCommit" : "4e1f3eef1f16de28c83d67040b7a5e554b81fcdf",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/translate/UnicodeUnescaper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.UnicodeUnescaper"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnescaperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.UnicodeUnescaperTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4e1f3eef1f16de28c83d67040b7a5e554b81fcdf",
+    "headCommit" : "66faf46919ce196886953993697f3a1b3efd6a20",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/translate/UnicodeUnescaper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.UnicodeUnescaper"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnescaperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.UnicodeUnescaperTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "66faf46919ce196886953993697f3a1b3efd6a20",
+    "headCommit" : "2c2ed9d80dac4b46e9426041c091ddcaadb4df2b",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.NumericEntityUnescaperTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/translate/UnicodeEscaperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.UnicodeEscaperTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/translate/UnicodeUnpairedSurrogateRemoverTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.UnicodeUnpairedSurrogateRemoverTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2c2ed9d80dac4b46e9426041c091ddcaadb4df2b",
+    "headCommit" : "75d85a807d7b66da432a822de6fc75c48134decf",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsAbbreviateTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsAbbreviateTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "75d85a807d7b66da432a822de6fc75c48134decf",
+    "headCommit" : "226bf3975afd430b6b74c23a0c9cbae9f9b90de5",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "226bf3975afd430b6b74c23a0c9cbae9f9b90de5",
+    "headCommit" : "6bef246b2f10699a56a3010bbc6fa11d241430c6",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/WordUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6bef246b2f10699a56a3010bbc6fa11d241430c6",
+    "headCommit" : "181b80dcdf78e8f962a20e339b824b8e58745c0c",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "181b80dcdf78e8f962a20e339b824b8e58745c0c",
+    "headCommit" : "13d25e0591e640e53f1238e78f6b0e69d0fd6aea",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationFormatUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationFormatUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "13d25e0591e640e53f1238e78f6b0e69d0fd6aea",
+    "headCommit" : "c4c294b0e04024d361d710985f8500f7d2412232",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c4c294b0e04024d361d710985f8500f7d2412232",
+    "headCommit" : "6dbbbb308bb77ba9c0ddab1ae400ee2ff76026b4",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringEscapeUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringEscapeUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringEscapeUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6dbbbb308bb77ba9c0ddab1ae400ee2ff76026b4",
+    "headCommit" : "f15e8806da532cbefe23a2e095e6b775d1ed94ee",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/StringEscapeUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringEscapeUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringEscapeUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f15e8806da532cbefe23a2e095e6b775d1ed94ee",
+    "headCommit" : "4f0d90a69b9ce5218dcc204c66cfe6132cfba8bb",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringEscapeUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4f0d90a69b9ce5218dcc204c66cfe6132cfba8bb",
+    "headCommit" : "1a256d3e74dd547b0ec7ea3b4b31ce1039cff312",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringEscapeUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringEscapeUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringEscapeUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringEscapeUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1a256d3e74dd547b0ec7ea3b4b31ce1039cff312",
+    "headCommit" : "13d93944ff76c6ca3e140d15478111b18acad0e6",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/Strings.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Strings"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "13d93944ff76c6ca3e140d15478111b18acad0e6",
+    "headCommit" : "0cd35067e9e01462bda2fb371d9991ca34d7e7dd",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtilsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsAbbreviateTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsAbbreviateTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtilsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationFormatUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0cd35067e9e01462bda2fb371d9991ca34d7e7dd",
+    "headCommit" : "581ce79c4d39571ac98db3e32b0d813540684324",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Strings.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Strings"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "581ce79c4d39571ac98db3e32b0d813540684324",
+    "headCommit" : "97f59d653f69f92015cc47f4db68a5c6b0f2d203",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "97f59d653f69f92015cc47f4db68a5c6b0f2d203",
+    "headCommit" : "68fc73ce56557c45decc1a37fa94c00a4f0d7b8f",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsIsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsIsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "68fc73ce56557c45decc1a37fa94c00a4f0d7b8f",
+    "headCommit" : "6917bc76d953ee16d79cd39b109a716a35ea4e01",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6917bc76d953ee16d79cd39b109a716a35ea4e01",
+    "headCommit" : "ffa30115b6eac3137d3080078178fff505215c58",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsIsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsIsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ffa30115b6eac3137d3080078178fff505215c58",
+    "headCommit" : "243d3fe492900d6338e619b1050f83d8052e8bdb",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/translate/UnicodeEscaper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.UnicodeEscaper"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/translate/UnicodeEscaperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.UnicodeEscaperTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "243d3fe492900d6338e619b1050f83d8052e8bdb",
+    "headCommit" : "dfaea97de4dd175781eeb552ff9eb29db767acc3",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "dfaea97de4dd175781eeb552ff9eb29db767acc3",
+    "headCommit" : "aae7f0e61c51040dbdc7556f9eca5786eb9f63bd",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.MethodUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/reflect/MethodUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.MethodUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "aae7f0e61c51040dbdc7556f9eca5786eb9f63bd",
+    "headCommit" : "5d10488686971a1d694ffbbedaa2f2e75ba3e8fc",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5d10488686971a1d694ffbbedaa2f2e75ba3e8fc",
+    "headCommit" : "6334440d5a61fdee73c8c7dd947f7adb6fa31331",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/CharSequenceUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharSequenceUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharSequenceUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6334440d5a61fdee73c8c7dd947f7adb6fa31331",
+    "headCommit" : "4c6abb128d952e7369fae8a18656bed9338d293c",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharSequenceUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharSequenceUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/CharSequenceUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharSequenceUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4c6abb128d952e7369fae8a18656bed9338d293c",
+    "headCommit" : "6c4269eb8a2aeb722ee81a41a4a88a46c2deccf8",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/WordUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6c4269eb8a2aeb722ee81a41a4a88a46c2deccf8",
+    "headCommit" : "0d9394c18f4f8b16bfd8888e1279854258ae6210",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0d9394c18f4f8b16bfd8888e1279854258ae6210",
+    "headCommit" : "8d325f69d97a194659f054ba389420d3800cdd82",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/WordUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8d325f69d97a194659f054ba389420d3800cdd82",
+    "headCommit" : "0d8dbd208a7329c0783df4385123877e2ca23852",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/WordUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0d8dbd208a7329c0783df4385123877e2ca23852",
+    "headCommit" : "0311b67baed404b2b12f9ced753dbee7b5bca11f",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/WordUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0311b67baed404b2b12f9ced753dbee7b5bca11f",
+    "headCommit" : "ae9c787a68a7a97aead7d2d7e02e78aed56922c9",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/WordUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ae9c787a68a7a97aead7d2d7e02e78aed56922c9",
+    "headCommit" : "7e29cde71c6c1673c2dd1d7f88f58416582d7158",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7e29cde71c6c1673c2dd1d7f88f58416582d7158",
+    "headCommit" : "2906d5f8d7f2c5d312152108882de4d1b2cb8d7d",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2906d5f8d7f2c5d312152108882de4d1b2cb8d7d",
+    "headCommit" : "64c05dc6d377516e35d8a9cc9436e890cd0e0935",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "64c05dc6d377516e35d8a9cc9436e890cd0e0935",
+    "headCommit" : "8c780bc8b9c7fe6bb0b55dc1380595de1f89ff05",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8c780bc8b9c7fe6bb0b55dc1380595de1f89ff05",
+    "headCommit" : "c3e09d34864d434ad671944d693d67ee07206cfc",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c3e09d34864d434ad671944d693d67ee07206cfc",
+    "headCommit" : "aafee70bfdfc7617ed509b54e3971441a3a5f57d",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/math/NumberUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "aafee70bfdfc7617ed509b54e3971441a3a5f57d",
+    "headCommit" : "261392f6530c3b2da59b3ecf80f514a4128cec59",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "261392f6530c3b2da59b3ecf80f514a4128cec59",
+    "headCommit" : "37a2be80434f5c393e5842c52a95afb607be2eee",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "37a2be80434f5c393e5842c52a95afb607be2eee",
+    "headCommit" : "98bc7e5e6ca00958005b7eb741377e1f834a33bd",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "98bc7e5e6ca00958005b7eb741377e1f834a33bd",
+    "headCommit" : "7b11dcf5624351a56a913f2afd6e1673efab2d31",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7b11dcf5624351a56a913f2afd6e1673efab2d31",
+    "headCommit" : "6cb563d122680d6bf82f8cebdc9fde20f0128bca",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6cb563d122680d6bf82f8cebdc9fde20f0128bca",
+    "headCommit" : "5cef4ad0079b0a321a67df44467b95fa0fb96e8f",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/math/NumberUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtilsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/WordUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5cef4ad0079b0a321a67df44467b95fa0fb96e8f",
+    "headCommit" : "170e9f28ad2667a9b0c80480c2a5a13cb4a53257",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "170e9f28ad2667a9b0c80480c2a5a13cb4a53257",
+    "headCommit" : "ae85262f04df19b6307de18758cfdcc31cae733d",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ae85262f04df19b6307de18758cfdcc31cae733d",
+    "headCommit" : "35d652e9e26461ddbeb19aa32bc6acd012ccc641",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/Strings.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Strings"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "35d652e9e26461ddbeb19aa32bc6acd012ccc641",
+    "headCommit" : "d8b8d0655b00a8d34129bd935a217857636cd841",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d8b8d0655b00a8d34129bd935a217857636cd841",
+    "headCommit" : "5115907915f4f857f03c4e9b418a87d755e0e6f7",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/AppendableJoiner.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.AppendableJoiner"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayFill.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayFill"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ArraySorter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArraySorter"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/EnumUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.EnumUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Functions.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Functions"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ObjectUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ObjectUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Range.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Range"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/SerializationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.SerializationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Streams.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Streams"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Validate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Validate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/AbstractSupplier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.AbstractSupplier"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/Builder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.Builder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/DiffBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.DiffBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/Diffable.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.Diffable"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/ToStringBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ToStringBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/compare/ComparableUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.compare.ComparableUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AbstractCircuitBreaker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AbstractCircuitBreaker"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AbstractConcurrentInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AbstractConcurrentInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AtomicInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AtomicInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AtomicSafeInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/BackgroundInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.BackgroundInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/CallableBackgroundInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.CallableBackgroundInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/CircuitBreaker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.CircuitBreaker"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/Computable.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.Computable"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/ConcurrentInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ConcurrentInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/ConcurrentUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ConcurrentUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/ConstantInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ConstantInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/LazyInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.LazyInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/Memoizer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.Memoizer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/locks/LockingVisitors.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.locks.LockingVisitors"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.event.EventListenerSupport"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.ExceptionUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/Failable.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.Failable"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableObjDoubleConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableObjDoubleConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableObjIntConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableObjIntConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableObjLongConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableObjLongConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToBooleanFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToBooleanFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToDoubleBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToDoubleBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToDoubleFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToDoubleFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToIntBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToIntBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToIntFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToIntFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToLongBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToLongBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToLongFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToLongFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/MethodInvokers.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.MethodInvokers"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/Predicates.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.Predicates"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/Suppliers.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.Suppliers"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/ToBooleanBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.ToBooleanBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/TriFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.TriFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/Mutable.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.Mutable"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableObject.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableObject"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/TypeLiteral.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.TypeLiteral"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/Typed.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.Typed"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/stream/LangCollectors.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.stream.LangCollectors"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/stream/Streams.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.stream.Streams"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrLookup.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrLookup"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrSubstitutor"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DatePrinter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DatePrinter"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDatePrinter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDatePrinter"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/ImmutablePair.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.ImmutablePair"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/ImmutableTriple.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.ImmutableTriple"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/MutablePair.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.MutablePair"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/MutableTriple.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.MutableTriple"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/Pair.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.Pair"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/Triple.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.Triple"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5115907915f4f857f03c4e9b418a87d755e0e6f7",
+    "headCommit" : "68ee18aa5ab14e1ec8ddd4a80fd7f43860fd874c",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationFormatUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationFormatUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "68ee18aa5ab14e1ec8ddd4a80fd7f43860fd874c",
+    "headCommit" : "121b4c718a9d68ba7c8906f7303bfcbda8da5189",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "121b4c718a9d68ba7c8906f7303bfcbda8da5189",
+    "headCommit" : "98a19c2cca6abc1ba6bef93b7f15aa0ceceeab7d",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "98a19c2cca6abc1ba6bef93b7f15aa0ceceeab7d",
+    "headCommit" : "1d3a74622d000b86cd2a9aa5962ffea5c7bc0ff9",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/scorecards-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1d3a74622d000b86cd2a9aa5962ffea5c7bc0ff9",
+    "headCommit" : "3f0c0fd5cb8af9f2ae6d7f869d7e87c66985ab90",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationFormatUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationFormatUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3f0c0fd5cb8af9f2ae6d7f869d7e87c66985ab90",
+    "headCommit" : "b509e0b678a8f8d1258260ee8eaa329560976c6d",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/DurationFormatUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationFormatUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b509e0b678a8f8d1258260ee8eaa329560976c6d",
+    "headCommit" : "2011ce3ba2386669086882182dc41d76148e5489",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.ExtendedMessageFormat"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.ExtendedMessageFormatTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2011ce3ba2386669086882182dc41d76148e5489",
+    "headCommit" : "f015a7ed9934c5fcb73901c47420ef0005ec0af4",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.NumericEntityUnescaper"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.NumericEntityUnescaperTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f015a7ed9934c5fcb73901c47420ef0005ec0af4",
+    "headCommit" : "7732ac9424c1d4dc8a6f24b2f1f600f99fb8f537",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7732ac9424c1d4dc8a6f24b2f1f600f99fb8f537",
+    "headCommit" : "02cc21baf6dc8d5c4536ef3929c9394a0a144e1c",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.ExtendedMessageFormatTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/translate/NumericEntityUnescaperTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.NumericEntityUnescaperTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "02cc21baf6dc8d5c4536ef3929c9394a0a144e1c",
+    "headCommit" : "d4b4d8c352d048f5dab3c85dd6ef380cfe04bdee",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDateParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d4b4d8c352d048f5dab3c85dd6ef380cfe04bdee",
+    "headCommit" : "93c073e275e0a059ba7eb37e8aeff91331577fe2",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "93c073e275e0a059ba7eb37e8aeff91331577fe2",
+    "headCommit" : "a77a32c0b7195fc7e8bece37275acd271de8d7fc",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a77a32c0b7195fc7e8bece37275acd271de8d7fc",
+    "headCommit" : "dda92830127b7486fb02932e87a05891feb9cef1",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDateParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "dda92830127b7486fb02932e87a05891feb9cef1",
+    "headCommit" : "b45186a1c0df94cb716316cb82665423bcf382be",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b45186a1c0df94cb716316cb82665423bcf382be",
+    "headCommit" : "8425918f90e8c3c6e39f14e18335ecb8e4589b91",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.ExtendedMessageFormat"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.ExtendedMessageFormatTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8425918f90e8c3c6e39f14e18335ecb8e4589b91",
+    "headCommit" : "2b175f6297e57709e7e51bdee28a04eaac0fd995",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2b175f6297e57709e7e51bdee28a04eaac0fd995",
+    "headCommit" : "9cc2097993629b87f0505fab3612386807a20845",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/text/ExtendedMessageFormatTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.ExtendedMessageFormatTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9cc2097993629b87f0505fab3612386807a20845",
+    "headCommit" : "4ef1d6b2ce6d250a288c6ca27384885dda8c524d",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/scorecards-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4ef1d6b2ce6d250a288c6ca27384885dda8c524d",
+    "headCommit" : "85db8908103187c9e55f905d2ef906f53956ba06",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/scorecards-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "85db8908103187c9e55f905d2ef906f53956ba06",
+    "headCommit" : "47590b080298858c2c633135d6515028ef996a1e",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "47590b080298858c2c633135d6515028ef996a1e",
+    "headCommit" : "7c91ce9898e2bfe0eb938ed16d4e1b8840d39aef",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7c91ce9898e2bfe0eb938ed16d4e1b8840d39aef",
+    "headCommit" : "7515777a2dbc8b7e3622f62e760e303b1f72ad4d",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7515777a2dbc8b7e3622f62e760e303b1f72ad4d",
+    "headCommit" : "84966e01e511a76a4851945b162fd0e01091c174",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/AnnotationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.AnnotationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/AppendableJoiner.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.AppendableJoiner"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayFill.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayFill"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ArraySorter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArraySorter"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/BitField.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BitField"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/BooleanUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BooleanUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharRange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharRange"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharSequenceUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharSequenceUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharSet.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharSet"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharSetUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharSetUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Charsets.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Charsets"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ClassLoaderUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassLoaderUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ClassPathUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassPathUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ClassUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/DoubleRange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.DoubleRange"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/EnumUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.EnumUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Functions.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Functions"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/IntegerRange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.IntegerRange"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/JavaVersion.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.JavaVersion"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/LocaleUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.LocaleUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/LongRange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.LongRange"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ObjectUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ObjectUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/RandomStringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomStringUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/RandomUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Range.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Range"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/RegExUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RegExUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/SerializationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.SerializationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Streams.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Streams"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/StringEscapeUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringEscapeUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Strings.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Strings"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/SystemProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.SystemProperties"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/SystemUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.SystemUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ThreadUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ThreadUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Validate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Validate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/arch/Processor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.arch.Processor"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/AbstractReflection.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.AbstractReflection"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/Builder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.Builder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/Diff.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.Diff"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/DiffBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.DiffBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/DiffResult.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.DiffResult"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/IDKey.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.IDKey"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/ReflectionDiffBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ReflectionDiffBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/ReflectionToStringBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ReflectionToStringBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/StandardToStringStyle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.StandardToStringStyle"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/ToStringBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ToStringBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/ToStringStyle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ToStringStyle"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/compare/ComparableUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.compare.ComparableUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AbstractCircuitBreaker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AbstractCircuitBreaker"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AbstractConcurrentInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AbstractConcurrentInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AbstractFutureProxy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AbstractFutureProxy"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AtomicInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AtomicInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/BackgroundInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.BackgroundInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/BasicThreadFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.BasicThreadFactory"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/CallableBackgroundInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.CallableBackgroundInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/CircuitBreaker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.CircuitBreaker"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/Computable.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.Computable"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/ConcurrentUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ConcurrentUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/ConstantInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ConstantInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/EventCountCircuitBreaker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.EventCountCircuitBreaker"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/LazyInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.LazyInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/Memoizer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.Memoizer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/MultiBackgroundInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.MultiBackgroundInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/ThresholdCircuitBreaker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ThresholdCircuitBreaker"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/TimedSemaphore.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.TimedSemaphore"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/locks/LockingVisitors.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.locks.LockingVisitors"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.event.EventListenerSupport"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/event/EventUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.event.EventUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/ContextedException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.ContextedException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/ContextedRuntimeException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.ContextedRuntimeException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/DefaultExceptionContext.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.DefaultExceptionContext"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/ExceptionContext.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.ExceptionContext"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.ExceptionUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/Consumers.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.Consumers"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/Failable.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.Failable"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableBiPredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableBiPredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleBinaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleBinaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleToIntFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleToIntFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleToLongFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleToLongFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleUnaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleUnaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntBinaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntBinaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntToDoubleFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntToDoubleFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntToFloatFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntToFloatFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntToLongFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntToLongFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntUnaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntUnaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongBinaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongBinaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongToDoubleFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongToDoubleFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongToIntFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongToIntFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongUnaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongUnaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailablePredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailablePredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToBooleanFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToBooleanFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToDoubleBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToDoubleBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToDoubleFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToDoubleFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToIntBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToIntBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToIntFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToIntFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToLongBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToLongBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToLongFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToLongFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/Functions.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.Functions"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/IntToCharFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.IntToCharFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/Predicates.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.Predicates"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/ToBooleanBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.ToBooleanBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/TriFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.TriFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/math/Fraction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.Fraction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/math/IEEE754rUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.IEEE754rUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/math/NumberUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/Mutable.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.Mutable"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableBoolean.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableBoolean"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableByte.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableByte"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableDouble.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableDouble"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableFloat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableFloat"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableInt.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableInt"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableLong.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableLong"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableObject.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableObject"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableShort.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableShort"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/ConstructorUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.ConstructorUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/FieldUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.FieldUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/InheritanceUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.InheritanceUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.MethodUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.TypeUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/stream/IntStreams.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.stream.IntStreams"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/stream/LangCollectors.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.stream.LangCollectors"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/stream/Streams.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.stream.Streams"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/CompositeFormat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.CompositeFormat"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/FormattableUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.FormattableUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrLookup.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrLookup"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrMatcher"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrSubstitutor"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrTokenizer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrTokenizer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/translate/EntityArrays.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.EntityArrays"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/translate/JavaUnicodeEscaper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.JavaUnicodeEscaper"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/translate/NumericEntityEscaper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.NumericEntityEscaper"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/translate/UnicodeEscaper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.UnicodeEscaper"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/CalendarUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.CalendarUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DateFormatUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateFormatUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DateParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateParser"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DatePrinter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DatePrinter"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DateUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationFormatUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDateFormat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateFormat"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDatePrinter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDatePrinter"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/Instants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.Instants"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/StopWatch.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.StopWatch"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/TimeZones.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.TimeZones"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/ImmutablePair.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.ImmutablePair"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/ImmutableTriple.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.ImmutableTriple"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/MutablePair.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.MutablePair"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/MutableTriple.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.MutableTriple"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/Pair.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.Pair"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/Triple.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.Triple"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/util/FluentBitSet.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.util.FluentBitSet"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/ToStringBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ToStringBuilderTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/AbstractConcurrentInitializerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AbstractConcurrentInitializerTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/AtomicInitializerNonObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AtomicInitializerNonObjectTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/AtomicInitializerObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AtomicInitializerObjectTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/AtomicInitializerSupplierTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AtomicInitializerSupplierTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializerSupplierTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AtomicSafeInitializerSupplierTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AtomicSafeInitializerTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/LazyInitializerAnonClassTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.LazyInitializerAnonClassTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/LazyInitializerCloserTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.LazyInitializerCloserTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/LazyInitializerFailableCloserTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.LazyInitializerFailableCloserTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/LazyInitializerSimpleTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.LazyInitializerSimpleTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/LazyInitializerSingleInstanceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.LazyInitializerSingleInstanceTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/LazyInitializerSupplierTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.LazyInitializerSupplierTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/MultiBackgroundInitializerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.MultiBackgroundInitializerTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/TimedSemaphoreTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.TimedSemaphoreTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserReadObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserReadObjectTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDatePrinterTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "84966e01e511a76a4851945b162fd0e01091c174",
+    "headCommit" : "16fe275f398e21907b1d5fdf15693bd02d078b14",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/AnnotationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.AnnotationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/AppendableJoiner.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.AppendableJoiner"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/BooleanUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BooleanUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharRange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharRange"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharSequenceUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharSequenceUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharSet.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharSet"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ClassPathUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassPathUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ClassUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Conversion.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Conversion"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/EnumUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.EnumUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Functions.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Functions"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/IntegerRange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.IntegerRange"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/LocaleUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.LocaleUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/LongRange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.LongRange"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/NotImplementedException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.NotImplementedException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ObjectUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ObjectUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/RandomUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Range.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Range"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/SerializationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.SerializationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Streams.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Streams"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/StringEscapeUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringEscapeUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Strings.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Strings"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/SystemProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.SystemProperties"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/SystemUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.SystemUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.CompareToBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/DiffBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.DiffBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/DiffResult.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.DiffResult"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/Diffable.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.Diffable"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.EqualsBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.HashCodeBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/MultilineRecursiveToStringStyle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.MultilineRecursiveToStringStyle"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/ReflectionDiffBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ReflectionDiffBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/ToStringBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ToStringBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/compare/ComparableUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.compare.ComparableUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AbstractConcurrentInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AbstractConcurrentInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AtomicInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AtomicInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AtomicSafeInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/BackgroundInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.BackgroundInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/BasicThreadFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.BasicThreadFactory"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/ConcurrentUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ConcurrentUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/ConstantInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ConstantInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/EventCountCircuitBreaker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.EventCountCircuitBreaker"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/FutureTasks.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.FutureTasks"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/LazyInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.LazyInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/Memoizer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.Memoizer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/MultiBackgroundInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.MultiBackgroundInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/TimedSemaphore.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.TimedSemaphore"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/UncheckedFuture.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.UncheckedFuture"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/locks/LockingVisitors.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.locks.LockingVisitors"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.event.EventListenerSupport"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/event/EventUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.event.EventUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.ExceptionUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/BooleanConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.BooleanConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/ByteConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.ByteConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/ByteSupplier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.ByteSupplier"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/Failable.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.Failable"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableBiConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableBiConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableBiPredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableBiPredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableBooleanSupplier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableBooleanSupplier"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableByteConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableByteConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableByteSupplier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableByteSupplier"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoublePredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoublePredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleSupplier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleSupplier"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleUnaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleUnaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntPredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntPredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntSupplier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntSupplier"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntUnaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntUnaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongPredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongPredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongSupplier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongSupplier"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongUnaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongUnaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailablePredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailablePredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableShortSupplier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableShortSupplier"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableSupplier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableSupplier"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/MethodInvokers.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.MethodInvokers"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/TriConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.TriConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/TriFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.TriFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/math/Fraction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.Fraction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableBoolean.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableBoolean"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableByte.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableByte"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableDouble.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableDouble"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableFloat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableFloat"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableInt.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableInt"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableLong.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableLong"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableShort.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableShort"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/FieldUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.FieldUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/MemberUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.MemberUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.MethodUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.TypeUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/stream/IntStreams.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.stream.IntStreams"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/stream/Streams.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.stream.Streams"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrLookup.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrLookup"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrMatcher"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrTokenizer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrTokenizer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/WordUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/AbstractFormatCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.AbstractFormatCache"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/CalendarUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.CalendarUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DateParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateParser"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DateUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DurationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDateFormat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateFormat"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDateParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDatePrinter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDatePrinter"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastTimeZone.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastTimeZone"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/StopWatch.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.StopWatch"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/ImmutablePair.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.ImmutablePair"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/ImmutableTriple.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.ImmutableTriple"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/MutablePair.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.MutablePair"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/MutableTriple.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.MutableTriple"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/Pair.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.Pair"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/Triple.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.Triple"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/util/FluentBitSet.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.util.FluentBitSet"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/util/IterableStringTokenizer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.util.IterableStringTokenizer"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/ToStringBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ToStringBuilderTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/EventCountCircuitBreakerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.EventCountCircuitBreakerTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/test/NotVisibleExceptionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.test.NotVisibleExceptionFactory"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserReadObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserReadObjectTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "16fe275f398e21907b1d5fdf15693bd02d078b14",
+    "headCommit" : "376fcce78cec0a6f29d59bc1a186c1b45f848b0b",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/AnnotationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.AnnotationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayFill.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayFill"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ArraySorter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArraySorter"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/AutoCloseables.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.AutoCloseables"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/BitField.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BitField"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/BooleanUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BooleanUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharEncoding.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharEncoding"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharRange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharRange"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharSequenceUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharSequenceUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharSet.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharSet"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharSetUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharSetUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/CharUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CharUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Charsets.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Charsets"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ClassPathUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassPathUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ClassUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Conversion.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Conversion"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/DoubleRange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.DoubleRange"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/EnumUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.EnumUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Functions.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Functions"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/IntegerRange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.IntegerRange"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/JavaVersion.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.JavaVersion"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/LocaleUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.LocaleUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/LongRange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.LongRange"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/NumberRange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.NumberRange"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ObjectUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ObjectUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/RandomStringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomStringUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/RandomUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Range.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Range"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/RegExUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RegExUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/SerializationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.SerializationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Streams.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Streams"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/StringEscapeUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringEscapeUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Strings.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Strings"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/SystemProperties.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.SystemProperties"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/SystemUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.SystemUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ThreadUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ThreadUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Validate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Validate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/AbstractReflection.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.AbstractReflection"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.CompareToBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/DiffBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.DiffBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/Diffable.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.Diffable"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.EqualsBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.HashCodeBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/ReflectionDiffBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ReflectionDiffBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/StandardToStringStyle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.StandardToStringStyle"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/ToStringBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ToStringBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/ToStringStyle.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ToStringStyle"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/compare/ComparableUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.compare.ComparableUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AbstractCircuitBreaker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AbstractCircuitBreaker"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AbstractConcurrentInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AbstractConcurrentInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AbstractFutureProxy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AbstractFutureProxy"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AtomicInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AtomicInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/AtomicSafeInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.AtomicSafeInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/BackgroundInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.BackgroundInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/BasicThreadFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.BasicThreadFactory"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/CallableBackgroundInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.CallableBackgroundInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/CircuitBreakingException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.CircuitBreakingException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/ConcurrentException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ConcurrentException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/ConcurrentRuntimeException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ConcurrentRuntimeException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/ConcurrentUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ConcurrentUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/ConstantInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ConstantInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/EventCountCircuitBreaker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.EventCountCircuitBreaker"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/FutureTasks.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.FutureTasks"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/LazyInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.LazyInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/Memoizer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.Memoizer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/MultiBackgroundInitializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.MultiBackgroundInitializer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/ThresholdCircuitBreaker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ThresholdCircuitBreaker"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/TimedSemaphore.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.TimedSemaphore"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/UncheckedExecutionException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.UncheckedExecutionException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/UncheckedTimeoutException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.UncheckedTimeoutException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/concurrent/locks/LockingVisitors.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.locks.LockingVisitors"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.event.EventListenerSupport"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/event/EventUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.event.EventUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/ContextedException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.ContextedException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/ContextedRuntimeException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.ContextedRuntimeException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/DefaultExceptionContext.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.DefaultExceptionContext"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/ExceptionContext.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.ExceptionContext"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/ExceptionUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.ExceptionUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/UncheckedException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.UncheckedException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/UncheckedIllegalAccessException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.UncheckedIllegalAccessException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/UncheckedInterruptedException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.UncheckedInterruptedException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/exception/UncheckedReflectiveOperationException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.exception.UncheckedReflectiveOperationException"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/BooleanConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.BooleanConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/ByteConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.ByteConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/Consumers.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.Consumers"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/Failable.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.Failable"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableBiConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableBiConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableBiPredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableBiPredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableByteConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableByteConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleBinaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleBinaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoublePredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoublePredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleToIntFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleToIntFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleToLongFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleToLongFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleUnaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleUnaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntBinaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntBinaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntPredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntPredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntToDoubleFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntToDoubleFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntToFloatFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntToFloatFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntToLongFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntToLongFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntUnaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntUnaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongBinaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongBinaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongPredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongPredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongToDoubleFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongToDoubleFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongToIntFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongToIntFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongUnaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongUnaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableObjDoubleConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableObjDoubleConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableObjIntConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableObjIntConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableObjLongConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableObjLongConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailablePredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailablePredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToBooleanFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToBooleanFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToDoubleBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToDoubleBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToDoubleFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToDoubleFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToIntBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToIntBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToIntFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToIntFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToLongBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToLongBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableToLongFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableToLongFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/Functions.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.Functions"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/IntToCharFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.IntToCharFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/MethodInvokers.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.MethodInvokers"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/Suppliers.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.Suppliers"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/ToBooleanBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.ToBooleanBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/TriConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.TriConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/TriFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.TriFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/math/Fraction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.Fraction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/math/IEEE754rUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.IEEE754rUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/math/NumberUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.NumberUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/Mutable.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.Mutable"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableBoolean.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableBoolean"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableByte.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableByte"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableDouble.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableDouble"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableFloat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableFloat"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableInt.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableInt"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableLong.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableLong"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableObject.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableObject"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/mutable/MutableShort.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.mutable.MutableShort"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/ConstructorUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.ConstructorUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/InheritanceUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.InheritanceUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/MemberUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.MemberUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/MethodUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.MethodUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/TypeUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.TypeUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/stream/IntStreams.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.stream.IntStreams"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/stream/LangCollectors.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.stream.LangCollectors"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/stream/Streams.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.stream.Streams"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/CompositeFormat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.CompositeFormat"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.ExtendedMessageFormat"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/FormattableUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.FormattableUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrLookup.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrLookup"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrMatcher"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrSubstitutor"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrTokenizer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrTokenizer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/WordUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.WordUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/translate/OctalUnescaper.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.translate.OctalUnescaper"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/AbstractFormatCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.AbstractFormatCache"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/CalendarUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.CalendarUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DateFormatUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateFormatUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DateParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateParser"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DatePrinter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DatePrinter"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DateUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationFormatUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DurationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDateFormat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateFormat"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDateParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDatePrinter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDatePrinter"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/Instants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.Instants"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/StopWatch.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.StopWatch"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/TimeZones.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.TimeZones"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/ImmutablePair.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.ImmutablePair"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/ImmutableTriple.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.ImmutableTriple"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/MutablePair.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.MutablePair"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/MutableTriple.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.MutableTriple"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/Pair.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.Pair"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/tuple/Triple.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.tuple.Triple"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/util/FluentBitSet.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.util.FluentBitSet"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/util/IterableStringTokenizer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.util.IterableStringTokenizer"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/LocaleUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.LocaleUtilsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ObjectUtilsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/RandomStringUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.RandomStringUtilsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/CompareToBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.CompareToBuilderTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.EqualsBuilderTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/ToStringBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.ToStringBuilderTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/BackgroundInitializerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.BackgroundInitializerTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/BasicThreadFactoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.BasicThreadFactoryTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/ConstantInitializerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.ConstantInitializerTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/EventCountCircuitBreakerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.EventCountCircuitBreakerTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/MultiBackgroundInitializerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.MultiBackgroundInitializerTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/concurrent/TimedSemaphoreTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.concurrent.TimedSemaphoreTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/test/NotVisibleExceptionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.test.NotVisibleExceptionFactory"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/DateUtilsRoundingTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateUtilsRoundingTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserReadObjectTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserReadObjectTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDatePrinterTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "376fcce78cec0a6f29d59bc1a186c1b45f848b0b",
+    "headCommit" : "2a7b90f57cd94763d259128ae73bbc73fde9f829",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2a7b90f57cd94763d259128ae73bbc73fde9f829",
+    "headCommit" : "7b7be629d6383ae8ddd7e0ed8c6d700ec23aebd0",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.HashCodeBuilder"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.HashCodeBuilderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7b7be629d6383ae8ddd7e0ed8c6d700ec23aebd0",
+    "headCommit" : "6618a42197256bd3893836d9a774615209ab2411",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.HashCodeBuilder"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.HashCodeBuilderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6618a42197256bd3893836d9a774615209ab2411",
+    "headCommit" : "27e195c7f665160e0c61607ac2caa56f89cb45fe",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.HashCodeBuilder"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.HashCodeBuilderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "27e195c7f665160e0c61607ac2caa56f89cb45fe",
+    "headCommit" : "0c409392897ac41e06f76ecdd1c639e4bee52505",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/reflect/FieldUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.FieldUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.FieldUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0c409392897ac41e06f76ecdd1c639e4bee52505",
+    "headCommit" : "89f5c4df4064536b4090a65b1127e317a3382e30",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "89f5c4df4064536b4090a65b1127e317a3382e30",
+    "headCommit" : "2618069761868edb2ca03d4b930b3ccc2b42a9cd",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/LocaleProblems.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.LocaleProblems"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2618069761868edb2ca03d4b930b3ccc2b42a9cd",
+    "headCommit" : "f3e4ff730c9cfd3c359e6b5e715798d082cd1da2",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f3e4ff730c9cfd3c359e6b5e715798d082cd1da2",
+    "headCommit" : "9f57c08e749b7b027f3efad1e2124b6d2343eac7",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9f57c08e749b7b027f3efad1e2124b6d2343eac7",
+    "headCommit" : "c99f2ddfe2fc9294070b697cdd1f603b0a31078b",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c99f2ddfe2fc9294070b697cdd1f603b0a31078b",
+    "headCommit" : "b6ae058bfabc3144c0a19e566c3765f108f9eed1",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.HashCodeBuilder"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/ArrayUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtilsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/HashCodeBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.HashCodeBuilderTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/reflect/FieldUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.reflect.FieldUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b6ae058bfabc3144c0a19e566c3765f108f9eed1",
+    "headCommit" : "1a7ffb62400e6d7a666943de7f0c81d218ea7d0c",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1a7ffb62400e6d7a666943de7f0c81d218ea7d0c",
+    "headCommit" : "98dc24990bf93234cf63ed5c5dd43a4f07847baa",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/BitField.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BitField"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/BitFieldTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BitFieldTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "98dc24990bf93234cf63ed5c5dd43a4f07847baa",
+    "headCommit" : "d8d0a028ce1469a93d2a6aa835c305eba22d8338",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/BitFieldTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BitFieldTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d8d0a028ce1469a93d2a6aa835c305eba22d8338",
+    "headCommit" : "a265320dff1c9d19d84021d9ca5e0b20ff5a297b",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/BitFieldTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BitFieldTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a265320dff1c9d19d84021d9ca5e0b20ff5a297b",
+    "headCommit" : "a11beebc1e1c15119f6b73ef3af59fca5fc30f6e",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/BitFieldTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.BitFieldTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a11beebc1e1c15119f6b73ef3af59fca5fc30f6e",
+    "headCommit" : "1d1044848b38fa82063de9e33b9e54caaddfbf09",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/util/FluentBitSet.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.util.FluentBitSet"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/util/FluentBitSetTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.util.FluentBitSetTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1d1044848b38fa82063de9e33b9e54caaddfbf09",
+    "headCommit" : "4b777772b37e4d610adeb24a3950d982153b4b66",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4b777772b37e4d610adeb24a3950d982153b4b66",
+    "headCommit" : "9c27b9902e6fff4430a14346839aa8acc00c464c",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9c27b9902e6fff4430a14346839aa8acc00c464c",
+    "headCommit" : "5fd73e2d57b4a0be343b880e520237137c1283c2",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/scorecards-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5fd73e2d57b4a0be343b880e520237137c1283c2",
+    "headCommit" : "73e0df37e1c4328511679312db2f807659b14f08",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "73e0df37e1c4328511679312db2f807659b14f08",
+    "headCommit" : "a821cc4b80c7d3c8a301c0e9886aa9e3bbb3e94a",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/ThreadUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ThreadUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/Validate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Validate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/Diff.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.Diff"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/DiffBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.DiffBuilder"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/event/EventListenerSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.event.EventListenerSupport"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/BooleanConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.BooleanConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/ByteConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.ByteConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableBiConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableBiConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableBiFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableBiFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableBiPredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableBiPredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableByteConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableByteConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoublePredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoublePredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableDoubleUnaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableDoubleUnaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntPredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntPredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableIntUnaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableIntUnaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongPredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongPredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailableLongUnaryOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailableLongUnaryOperator"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/FailablePredicate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.FailablePredicate"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/TriConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.TriConsumer"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/function/TriFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.TriFunction"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrSubstitutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrSubstitutor"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DurationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/ClassUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a821cc4b80c7d3c8a301c0e9886aa9e3bbb3e94a",
+    "headCommit" : "592b44f457a70b06b1a40b06828fab5e1a2638c5",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "592b44f457a70b06b1a40b06828fab5e1a2638c5",
+    "headCommit" : "09bffd68fea99a739ca0668d2b50dd1d944c431a",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/function/Failable.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.function.Failable"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "09bffd68fea99a739ca0668d2b50dd1d944c431a",
+    "headCommit" : "0fd6d48ea482841d8c7e3be501fa243e8865e5ff",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0fd6d48ea482841d8c7e3be501fa243e8865e5ff",
+    "headCommit" : "9defa770ab24b0f7e4a8b8f57b2d1a88f88b9542",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/AbstractFormatCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.AbstractFormatCache"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9defa770ab24b0f7e4a8b8f57b2d1a88f88b9542",
+    "headCommit" : "6b89cfc423c949291f95d6f31d1e0bec382e02d1",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayFill.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayFill"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6b89cfc423c949291f95d6f31d1e0bec382e02d1",
+    "headCommit" : "8e3d585fa5a5415f1afeaa3bbf243e6ff2b72469",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ArrayUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ArrayUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8e3d585fa5a5415f1afeaa3bbf243e6ff2b72469",
+    "headCommit" : "451d4e604402157c8df68be30bd5ec7209adcb9d",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/CachedRandomBits.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.CachedRandomBits"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "451d4e604402157c8df68be30bd5ec7209adcb9d",
+    "headCommit" : "08f6de4de5b922f5994130461a8532a231539b29",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/EqualsBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.EqualsBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "08f6de4de5b922f5994130461a8532a231539b29",
+    "headCommit" : "15f1834be0f63527dfd20a113d3756bed8729ced",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/ExtendedMessageFormat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.ExtendedMessageFormat"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "15f1834be0f63527dfd20a113d3756bed8729ced",
+    "headCommit" : "6036da7d75bd140a658d9209c6ccac304b1b9a7c",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDateParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6036da7d75bd140a658d9209c6ccac304b1b9a7c",
+    "headCommit" : "0392b4204dbeb894a44c209b982fbc959d53cc86",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/math/Fraction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.math.Fraction"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0392b4204dbeb894a44c209b982fbc959d53cc86",
+    "headCommit" : "c1a7fb9892884523440bb46b4b18ae6614671f2f",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/Strings.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.Strings"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c1a7fb9892884523440bb46b4b18ae6614671f2f",
+    "headCommit" : "f78a858a1a99fb81d102149337be6586bdc8ad4c",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f78a858a1a99fb81d102149337be6586bdc8ad4c",
+    "headCommit" : "425412e3a4f6144beab1483cce5f36438d23b99e",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/StopWatch.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.StopWatch"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "425412e3a4f6144beab1483cce5f36438d23b99e",
+    "headCommit" : "4e4a042cab48cc4425199cc2cc80cbce7b9aeb45",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/LocaleUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.LocaleUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4e4a042cab48cc4425199cc2cc80cbce7b9aeb45",
+    "headCommit" : "4b52ff89a68408dfe5e73786eceb23d0e75f967f",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/HashCodeBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.HashCodeBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4b52ff89a68408dfe5e73786eceb23d0e75f967f",
+    "headCommit" : "4f5af28cdc8aa99ab9b782925c71f2be59f90a8f",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/DurationFormatUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DurationFormatUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4f5af28cdc8aa99ab9b782925c71f2be59f90a8f",
+    "headCommit" : "76d957ee5e32d27cfce2453d779ef1e520fa8c53",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.CompareToBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "76d957ee5e32d27cfce2453d779ef1e520fa8c53",
+    "headCommit" : "3fdc8fd43fe7c1a6ed7418653a75bc118b0758e5",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.CompareToBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3fdc8fd43fe7c1a6ed7418653a75bc118b0758e5",
+    "headCommit" : "f3320ba6e34081bca2c7698913ac9bbb36ed2320",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/CompareToBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.CompareToBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f3320ba6e34081bca2c7698913ac9bbb36ed2320",
+    "headCommit" : "c4316d20a8f5a6520379feab11b052acf859700d",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/dependency-review.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c4316d20a8f5a6520379feab11b052acf859700d",
+    "headCommit" : "ea9c4d62b847a8ccf3a43e4c738498faadc5dee4",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ea9c4d62b847a8ccf3a43e4c738498faadc5dee4",
+    "headCommit" : "4ac3885ec2512b17c83700e848bf9e0ec229132a",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4ac3885ec2512b17c83700e848bf9e0ec229132a",
+    "headCommit" : "983e46d9e955bab42b6f86f6c449667b00a47d11",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "983e46d9e955bab42b6f86f6c449667b00a47d11",
+    "headCommit" : "e14f7bf32acf52ba3a0f2306bbe1b0899c61b7c0",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e14f7bf32acf52ba3a0f2306bbe1b0899c61b7c0",
+    "headCommit" : "12ba066f701b9a289d3b730940160ad6c2078016",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "12ba066f701b9a289d3b730940160ad6c2078016",
+    "headCommit" : "2ffb336343b1a8ee7ac8a4bf35433331da17c98b",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/ClassUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ClassUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2ffb336343b1a8ee7ac8a4bf35433331da17c98b",
+    "headCommit" : "a316188a6d03b60528ed03e24b7266035007ebb4",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a316188a6d03b60528ed03e24b7266035007ebb4",
+    "headCommit" : "92c275f1f1ec800523ee247b1133f76712b9ff2a",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ObjectUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "92c275f1f1ec800523ee247b1133f76712b9ff2a",
+    "headCommit" : "5ad44b41a430c226b336cf48fe57445fd4b80946",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5ad44b41a430c226b336cf48fe57445fd4b80946",
+    "headCommit" : "87b7b3a26390f4a095f63b9f7b1baf0689a22634",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "87b7b3a26390f4a095f63b9f7b1baf0689a22634",
+    "headCommit" : "8a28feb1334b782ad5c0f5312137de7defcc7e4c",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/EqualsBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.EqualsBuilderTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8a28feb1334b782ad5c0f5312137de7defcc7e4c",
+    "headCommit" : "0a1b0f46a75c9913be9dcfad037230170d24af6b",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ObjectUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0a1b0f46a75c9913be9dcfad037230170d24af6b",
+    "headCommit" : "94ad3a756aad97add12e48ed8ff54d630a927d4b",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "94ad3a756aad97add12e48ed8ff54d630a927d4b",
+    "headCommit" : "e0dba35f9e41dfdbbbb646fcd377b8af8ef7344e",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDateParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e0dba35f9e41dfdbbbb646fcd377b8af8ef7344e",
+    "headCommit" : "6fd967bf2047c3d1a3b00a4f746e08b459f8de1d",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6fd967bf2047c3d1a3b00a4f746e08b459f8de1d",
+    "headCommit" : "3d662f052b5f0d62fc30e2e89e697c3637f644f4",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/time/DateUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.DateUtilsTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDateParserTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParserTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3d662f052b5f0d62fc30e2e89e697c3637f644f4",
+    "headCommit" : "e8bafeb6a347f1cb529db6c4b33cc81ca069e337",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDateParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDateParser"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e8bafeb6a347f1cb529db6c4b33cc81ca069e337",
+    "headCommit" : "fe573042d12e4457d81b7fbbdcd68d0e82381c6b",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/scorecards-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "fe573042d12e4457d81b7fbbdcd68d0e82381c6b",
+    "headCommit" : "50d1508c30dc5ce44ef9f7008b77edc34615c542",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/scorecards-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "50d1508c30dc5ce44ef9f7008b77edc34615c542",
+    "headCommit" : "0cd37ebe9743cc206a53fd6274ac18d5cbeda8e3",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/scorecards-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0cd37ebe9743cc206a53fd6274ac18d5cbeda8e3",
+    "headCommit" : "b1aba6833f31ac2c9cc5a1302cac966f997db31e",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/text/StrBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilder"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/text/StrBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.text.StrBuilderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b1aba6833f31ac2c9cc5a1302cac966f997db31e",
+    "headCommit" : "c47b2fab58d72383ab39db02452020d219eebc29",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c47b2fab58d72383ab39db02452020d219eebc29",
+    "headCommit" : "0add789ed39fb3d59ce16048a3960821ee313bf7",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/time/FastDatePrinter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDatePrinter"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/time/FastDatePrinterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.time.FastDatePrinterTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0add789ed39fb3d59ce16048a3960821ee313bf7",
+    "headCommit" : "4a6fcb04ea563d551f7247da766e212add464703",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4a6fcb04ea563d551f7247da766e212add464703",
+    "headCommit" : "28c71a2ae4d20d564d210a5dec6ae7b68cc68ab6",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ObjectUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "28c71a2ae4d20d564d210a5dec6ae7b68cc68ab6",
+    "headCommit" : "a593c2f5c12c4a851908f043540e1908ede1b179",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/ObjectUtilsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.ObjectUtilsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a593c2f5c12c4a851908f043540e1908ede1b179",
+    "headCommit" : "e0394dccff43d878051c7cbcbf3255b47858a439",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e0394dccff43d878051c7cbcbf3255b47858a439",
+    "headCommit" : "4c83821cf01bfd13314ffb6a026b9c2e96fd2b63",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsAbbreviateTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsAbbreviateTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4c83821cf01bfd13314ffb6a026b9c2e96fd2b63",
+    "headCommit" : "c84d1a32551be1ae9c7e0a4a0051b6ca492e37d8",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c84d1a32551be1ae9c7e0a4a0051b6ca492e37d8",
+    "headCommit" : "7e5906fb0cb679d630527fc1bc18018f935518dc",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/AnnotationUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.AnnotationUtils"
+    }, {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/AbstractReflection.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.AbstractReflection"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/AbstractReflectionSetAccessibleTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.AbstractReflectionSetAccessibleTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/external/AnnotationEqualsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.external.AnnotationEqualsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7e5906fb0cb679d630527fc1bc18018f935518dc",
+    "headCommit" : "e76dcd755dc1affc48bd0e3475e6a2cd97ae2567",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e76dcd755dc1affc48bd0e3475e6a2cd97ae2567",
+    "headCommit" : "65f6692fb2225edfdb1d54d29a48da4e2f7f6f89",
+    "changedFiles" : [ {
+      "path" : "src/test/java/org/apache/commons/lang3/builder/AbstractReflectionSetAccessibleTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.AbstractReflectionSetAccessibleTest"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/external/AnnotationEqualsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.external.AnnotationEqualsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "65f6692fb2225edfdb1d54d29a48da4e2f7f6f89",
+    "headCommit" : "285cd2fc42a16de63f1ea518cfd7ea1851563c46",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/builder/AbstractReflection.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.builder.AbstractReflection"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "285cd2fc42a16de63f1ea518cfd7ea1851563c46",
+    "headCommit" : "a1c12e6d4887d66d2112def35d6109905806410d",
+    "changedFiles" : [ {
+      "path" : "src/main/java/org/apache/commons/lang3/StringUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtils"
+    }, {
+      "path" : "src/test/java/org/apache/commons/lang3/StringUtilsAbbreviateTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.commons.lang3.StringUtilsAbbreviateTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a1c12e6d4887d66d2112def35d6109905806410d",
+    "headCommit" : "8f8f3b26e8cb81e0879fc676068db1212652dcaf",
+    "changedFiles" : [ {
+      "path" : "src/changes/changes.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  } ],
+  "excludedCommitPairs" : [ ],
+  "wouldMissCases" : [ ],
+  "flakyFailures" : [ ],
+  "savingsSummary" : {
+    "totalTestExecutions" : 23610943,
+    "totalSelected" : 9297241,
+    "proportionSkipped" : 0.6062316951931992,
+    "fallbackDrivenSelections" : 7898992,
+    "moduleScopedFallbackSelections" : 0,
+    "dependencyMatchedSelections" : 639752,
+    "newOrModifiedTestSelections" : 417365
+  }
+}

--- a/analyses/common-lang-summary.txt
+++ b/analyses/common-lang-summary.txt
@@ -1,0 +1,9 @@
+Verdict: PASS
+Analyzed: 300 commit pair(s)
+Would-miss cases: 0
+
+Savings: 9297241 / 23610943 test executions selected (60.6% skipped)
+  - dependency-matched: 639752
+  - fallback-driven: 7898992
+  - module-scoped fallback: 0
+  - new-or-modified: 417365


### PR DESCRIPTION
## Summary

- add a 300-pair Apache Commons Lang shadow-mode validation result
- include the exact sequential commit range, report, and summary artifacts
- present ShenYu and Commons Lang as separate early-validation evidence

## Validation

- `jq empty analyses/common-lang-report.json`
- `git diff --check`