### PR TITLE
release: prepare 0.3.2

### DIFF
--- a/MATURITY.md
+++ b/MATURITY.md
@@ -72,7 +72,7 @@ The status labels below are evidence-based:
 | QU10 | **Met** | The README documents limitations and the recommended full-suite safety net, and publishes validator evidence rather than making an unconditional safety claim. |
 | QU20 | **Partial** | CI and dependency updates exist, but there is no documented secure-development or vulnerability-management policy. |
 | QU30 | **Gap** | Add `SECURITY.md` with a private reporting channel, disclosure expectations, and response process. |
-| QU40 | **Partial** | [`CHANGELOG.md`](CHANGELOG.md) documents notable changes and compatibility requirements, but there is no stated compatibility/deprecation policy and the current 0.3.1 release is not yet represented. |
+| QU40 | **Partial** | [`CHANGELOG.md`](CHANGELOG.md) documents notable changes and compatibility requirements, but there is no stated compatibility/deprecation policy. |
 | QU50 | **Not assessed** | GitHub Issues is configured in the POM, but the repository does not define or report a bug-response expectation. |
 
 ### Community

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ These are early results from three Maven projects and three 300-pair history win
 <plugin>
   <groupId>io.github.baokhang83.blastradius</groupId>
   <artifactId>blastradius-maven-plugin</artifactId>
-  <version>0.3.0</version>
+  <version>0.3.2</version>
   <executions>
     <execution>
       <phase>process-test-classes</phase>

--- a/blastradius-core/pom.xml
+++ b/blastradius-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.1</version>
+        <version>0.3.2</version>
     </parent>
 
     <artifactId>blastradius-core</artifactId>

--- a/blastradius-maven-plugin/pom.xml
+++ b/blastradius-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.1</version>
+        <version>0.3.2</version>
     </parent>
 
     <artifactId>blastradius-maven-plugin</artifactId>

--- a/blastradius-s3-index-store/pom.xml
+++ b/blastradius-s3-index-store/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.1</version>
+        <version>0.3.2</version>
     </parent>
     <artifactId>blastradius-s3-index-store</artifactId>
     <name>blastradius S3 index store</name>

--- a/blastradius-validator/pom.xml
+++ b/blastradius-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.1</version>
+        <version>0.3.2</version>
     </parent>
 
     <artifactId>blastradius-validator</artifactId>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.1</version>
+        <version>0.3.2</version>
     </parent>
 
     <artifactId>coverage</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.baokhang83.blastradius</groupId>
     <artifactId>blastradius-parent</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2</version>
     <packaging>pom</packaging>
 
     <name>Blastradius parent</name>
@@ -38,7 +38,7 @@
         <connection>scm:git:https://github.com/baokhang83/blastradius.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/baokhang83/blastradius.git</developerConnection>
         <url>https://github.com/baokhang83/blastradius</url>
-        <tag>v0.3.1</tag>
+        <tag>v0.3.2</tag>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
## Summary
- prepare the Maven reactor and SCM metadata for version 0.3.2
- update the installation example to 0.3.2
- align the maturity assessment with the completed 0.3.1 changelog entry

## Validation
- `JAVA_HOME=/opt/homebrew/Cellar/openjdk/25.0.1/libexec/openjdk.jdk/Contents/Home mvn -B --no-transfer-progress clean verify`
- inspected generated Surefire/Failsafe reports: 132 reports, no failures or errors