### PR TITLE
docs: report Apache HttpClient validator result

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ The validator replayed sequential commit pairs in shadow mode and compared the s
 | <h4><img width="20" height="20" align="center" src="https://github.com/apache.png?size=40"/><a href="https://github.com/apache/shenyu">shenyu</a></h4> | [`ce3719d`](https://github.com/apache/shenyu/commit/ce3719d4d68cb51df0704a154fb1da8b2a1778ed) → [`3a411e0`](https://github.com/apache/shenyu/commit/3a411e017acfc47636e2bbfeb2958108d1f15a05) | 300 (0) | 0 | 233,603 / 747,680 | **68.8%** |
 | <h4><a href="https://github.com/apache/commons-lang"><img width="20" height="20" align="center" src="https://github.com/apache.png?size=40"/>commons-lang</a></h4>  | [`13c9949`](https://github.com/apache/commons-lang/commit/13c99492bf695b8ca378d0976919fcea10010c7f) → [`8f8f3b2`](https://github.com/apache/commons-lang/commit/8f8f3b26e8cb81e0879fc676068db1212652dcaf) | 300 (0) | 0 | 9,297,241 / 23,610,943 | **60.6%** |
 | <h4><a href="https://github.com/jhy/jsoup">jsoup</a></h4> | [`e10e04d`](https://github.com/jhy/jsoup/commit/e10e04da6c7d93daf5f74d449594cba7ea3683e3) → [`9d2241f`](https://github.com/jhy/jsoup/commit/9d2241ff467d03accbf902a650adc60513bf5c11) | 300 (0) | 0 | 304,060 / 536,850 | **43.4%** |
-|<img width=400 />|  |  |  |  | **57.6%** |
+| <h4><img width="20" height="20" align="center" src="https://github.com/apache.png?size=40"/><a href="https://github.com/apache/httpcomponents-client">httpclient</a></h4> | [`d84079d`](https://github.com/apache/httpcomponents-client/commit/d84079d9fc1c252f4262d0246a0f012ac22f811e) → [`3b4ff29`](https://github.com/apache/httpcomponents-client/commit/3b4ff29208b307f141a1989cbf038941d445a72e) | 300 (0) | **13** | 282,351 / 670,643 | **57.9%** |
+|<img width=400 />|  |  |  |  | **57.7%** |
 
-These are early results from three Maven projects and three 300-pair history windows, not a universal guarantee. All runs stayed conservative: most selected tests came from fallback rules rather than direct dependency matches. Full suites still remain the recommended daily safety net.
+These are early results from four Maven projects and four 300-pair history windows, not a universal guarantee. Apache HttpClient produced 13 confirmed failures that selection would have skipped, while the other three windows produced none. The result is a limitation to investigate, not evidence that selection is safe for every project. Full suites remain the recommended daily safety net.
 
 ## How it works
 

--- a/analyses/httpclient-report.json
+++ b/analyses/httpclient-report.json
@@ -1,0 +1,8042 @@
+{
+  "verdict" : "FAIL",
+  "analyzedCommitPairs" : [ {
+    "baseCommit" : "d84079d9fc1c252f4262d0246a0f012ac22f811e",
+    "headCommit" : "0e65c6efab3411c21f07b6b5fce706f00e0f68f3",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractClassicOverAsyncIntegrationTestBase.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.AbstractClassicOverAsyncIntegrationTestBase"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/ClassicOverAsyncIntegrationTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.ClassicOverAsyncIntegrationTests"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestClassicOverAsync.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestClassicOverAsync"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestClassicOverAsyncHttp1.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestClassicOverAsyncHttp1"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClients.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClients"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalAbstractHttpAsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalAbstractHttpAsyncClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/CloseableDelegate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.CloseableDelegate"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/CloseableHttpResponse.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.CloseableHttpResponse"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MainClientExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.MainClientExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/MinimalHttpClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.MinimalHttpClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/AbstractSharedBuffer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.AbstractSharedBuffer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/ClassicToAsyncAdaptor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.ClassicToAsyncAdaptor"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/ClassicToAsyncRequestProducer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.ClassicToAsyncRequestProducer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/ClassicToAsyncResponseConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.ClassicToAsyncResponseConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/ClassicToAsyncSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.ClassicToAsyncSupport"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/IOCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.IOCallback"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/ProtocolException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.ProtocolException"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/SharedInputBuffer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.SharedInputBuffer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/SharedOutputBuffer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.SharedOutputBuffer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/TransportException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.TransportException"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientClassicOverAsync.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ClientClassicOverAsync"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0e65c6efab3411c21f07b6b5fce706f00e0f68f3",
+    "headCommit" : "cde80cb32c57c90c00d6c94167db94540cfc9366",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cde80cb32c57c90c00d6c94167db94540cfc9366",
+    "headCommit" : "53fecf39ff98fe6f56e030a8e044182fd33cfbd1",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "53fecf39ff98fe6f56e030a8e044182fd33cfbd1",
+    "headCommit" : "0f39e56d57e7e87193323d55bd948aced79c64d6",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0f39e56d57e7e87193323d55bd948aced79c64d6",
+    "headCommit" : "a68d4a2b2f8f96583c31889b402a2a9e251da2c1",
+    "changedFiles" : [ {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a68d4a2b2f8f96583c31889b402a2a9e251da2c1",
+    "headCommit" : "a1243ed22fdc3284468411073203774ba56815ee",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.protocol.RequestAddCookies"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a1243ed22fdc3284468411073203774ba56815ee",
+    "headCommit" : "a16abbf56350b8658177f550a41aa3e2529e7f12",
+    "changedFiles" : [ {
+      "path" : "httpclient5-fluent/src/main/java/org/apache/hc/client5/http/fluent/Executor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.fluent.Executor"
+    }, {
+      "path" : "httpclient5-fluent/src/main/java/org/apache/hc/client5/http/fluent/Request.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.fluent.Request"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a16abbf56350b8658177f550a41aa3e2529e7f12",
+    "headCommit" : "daaa08fc7a6996df041c2646c1d6ef6a96dc53d2",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/auth/AuthScheme.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.auth.AuthScheme"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/AuthenticationHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.AuthenticationHandler"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "daaa08fc7a6996df041c2646c1d6ef6a96dc53d2",
+    "headCommit" : "bed9c65002ceec78e2444d85c5032a3809a9998d",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/io/DetachedSocketFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.io.DetachedSocketFactory"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestBasicHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.TestBasicHttpClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.TestHttpClientConnectionOperator"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestPoolingHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.TestPoolingHttpClientConnectionManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bed9c65002ceec78e2444d85c5032a3809a9998d",
+    "headCommit" : "05497d50fa0ad691ec6ddeb3d4ca0f895ee76ce5",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "05497d50fa0ad691ec6ddeb3d4ca0f895ee76ce5",
+    "headCommit" : "1fb9a4e60c977d2abe9e3a9466070cd8b7defe3b",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-fluent/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-testing/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1fb9a4e60c977d2abe9e3a9466070cd8b7defe3b",
+    "headCommit" : "0e5497a72f3e04261cc8755d5cb10ea2635e7441",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/ClientTlsStrategyBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0e5497a72f3e04261cc8755d5cb10ea2635e7441",
+    "headCommit" : "fc3b11e98bed28a47fe000bf308c3c027d34df83",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/FormBodyPartBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.FormBodyPartBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.HttpRFC7578Multipart"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/TestMultipartForm.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.TestMultipartForm"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "fc3b11e98bed28a47fe000bf308c3c027d34df83",
+    "headCommit" : "c68724713ab8e4a41992d230d41f8dfe0a1a7ba5",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/psl/PublicSuffixMatcherLoader.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.psl.PublicSuffixMatcherLoader"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/psl/TestPublicSuffixMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.psl.TestPublicSuffixMatcher"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/psl/TestPublicSuffixMatcherLoader.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.psl.TestPublicSuffixMatcherLoader"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c68724713ab8e4a41992d230d41f8dfe0a1a7ba5",
+    "headCommit" : "85be78d781b3fed6579acfab0fa1f86fdda62967",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/TestMultipartEntityBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.TestMultipartEntityBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/TestMultipartFormHttpEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.TestMultipartFormHttpEntity"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "85be78d781b3fed6579acfab0fa1f86fdda62967",
+    "headCommit" : "9b03e6e3021e867ea4c5cdb30b08b1a4ad0f6a3a",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9b03e6e3021e867ea4c5cdb30b08b1a4ad0f6a3a",
+    "headCommit" : "10f7b78bbfb0fed86f6900ea8b5b61389b7dceee",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractHttpAsyncRedirectsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.AbstractHttpAsyncRedirectsTest"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestRedirects.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestRedirects"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultRedirectStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.DefaultRedirectStrategy"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncRedirectExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.AsyncRedirectExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/RedirectExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.RedirectExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RedirectStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.protocol.RedirectStrategy"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultRedirectStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.TestDefaultRedirectStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "10f7b78bbfb0fed86f6900ea8b5b61389b7dceee",
+    "headCommit" : "1ec5c38d9f5d6c3775ad69cf7e0c75e9303725d3",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientProtocolStarter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.H2AsyncClientProtocolStarter"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientProtocolNegotiationStarter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientProtocolNegotiationStarter"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClients.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClients"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1ec5c38d9f5d6c3775ad69cf7e0c75e9303725d3",
+    "headCommit" : "a12853f6e4a5798ada6c5a81feaa194fca027240",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a12853f6e4a5798ada6c5a81feaa194fca027240",
+    "headCommit" : "b69acc969456b4a0b6d3e3d9d42d1fdbc4b824ef",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b69acc969456b4a0b6d3e3d9d42d1fdbc4b824ef",
+    "headCommit" : "f5d0b77417ad718baebbad237da531fcf791cf8b",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f5d0b77417ad718baebbad237da531fcf791cf8b",
+    "headCommit" : "35f40aec13c19f02bbe22639ebade55e4e95f136",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "35f40aec13c19f02bbe22639ebade55e4e95f136",
+    "headCommit" : "9a3591333f03525a77fec815d567905863e6d340",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9a3591333f03525a77fec815d567905863e6d340",
+    "headCommit" : "c40c1f07875686d0209482d52a09b5e0c4e84d4c",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c40c1f07875686d0209482d52a09b5e0c4e84d4c",
+    "headCommit" : "57d5a13763006099a292f058fc5495218b2fd968",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalAbstractHttpAsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalAbstractHttpAsyncClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalHttpClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.InternalHttpClient"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "57d5a13763006099a292f058fc5495218b2fd968",
+    "headCommit" : "5e62dac13b3075a90c2e84139861356035e2ed31",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/TestMultipartEntityBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.TestMultipartEntityBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/TestMultipartFormHttpEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.TestMultipartFormHttpEntity"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5e62dac13b3075a90c2e84139861356035e2ed31",
+    "headCommit" : "446a6d6c174b05b3ccff265a0e705aa389988d97",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientMultipartFormPost.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ClientMultipartFormPost"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "446a6d6c174b05b3ccff265a0e705aa389988d97",
+    "headCommit" : "f3b153684320344ca000aada210b9130d422ff0c",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.TestHttpClientConnectionOperator"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f3b153684320344ca000aada210b9130d422ff0c",
+    "headCommit" : "a06030afac030b83c2c9687b6314fbaeae323f96",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/PublicSuffixDomainFilter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cookie.PublicSuffixDomainFilter"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/psl/PublicSuffixMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.psl.PublicSuffixMatcher"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultHostnameVerifier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.DefaultHostnameVerifier"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/psl/TestPublicSuffixMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.psl.TestPublicSuffixMatcher"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/ssl/TestDefaultHostnameVerifier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.TestDefaultHostnameVerifier"
+    }, {
+      "path" : "httpclient5/src/test/resources/suffixlistmatcher.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a06030afac030b83c2c9687b6314fbaeae323f96",
+    "headCommit" : "c52c7d21ed80a99b546f1d9c470d57d87dcb1cc4",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/RequestEntityProxy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.RequestEntityProxy"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/RequestEntityProxyTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.RequestEntityProxyTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c52c7d21ed80a99b546f1d9c470d57d87dcb1cc4",
+    "headCommit" : "ffc12f119f4a5546c72cccd03d2a83ae440aea05",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/psl/PublicSuffixMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.psl.PublicSuffixMatcher"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultHostnameVerifier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.DefaultHostnameVerifier"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/utils/DnsUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.utils.DnsUtils"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/ssl/TestDefaultHostnameVerifier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.TestDefaultHostnameVerifier"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ffc12f119f4a5546c72cccd03d2a83ae440aea05",
+    "headCommit" : "0ba6102e65d793d4b4106e5b7bfabef7ec2d0a66",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/ProtocolSwitchStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.ProtocolSwitchStrategy"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestProtocolSwitchStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.TestProtocolSwitchStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0ba6102e65d793d4b4106e5b7bfabef7ec2d0a66",
+    "headCommit" : "9bae3020efbcafecdeec366814cd3bd970e101c0",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/cookie/Cookie.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.cookie.Cookie"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/cookie/TestRFC6265CookieSpec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cookie.TestRFC6265CookieSpec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9bae3020efbcafecdeec366814cd3bd970e101c0",
+    "headCommit" : "ef06a272f25ff401eb8a8853370d7bd743f70e16",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ef06a272f25ff401eb8a8853370d7bd743f70e16",
+    "headCommit" : "19c02789e811419a449e8cc7a74290b80428a9f8",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "19c02789e811419a449e8cc7a74290b80428a9f8",
+    "headCommit" : "f5f9ae8b024c164351210d3cc8fb96858f6b859f",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalAbstractHttpAsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalAbstractHttpAsyncClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalHttpClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.InternalHttpClient"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestInternalHttpClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TestInternalHttpClient"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f5f9ae8b024c164351210d3cc8fb96858f6b859f",
+    "headCommit" : "be441c1352615685df51c23b74cd061b5b8faa06",
+    "changedFiles" : [ {
+      "path" : "SECURITY.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "be441c1352615685df51c23b74cd061b5b8faa06",
+    "headCommit" : "4021b7c47914efaf9cf30b8d00bbd129295c0639",
+    "changedFiles" : [ {
+      "path" : "SECURITY.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4021b7c47914efaf9cf30b8d00bbd129295c0639",
+    "headCommit" : "14a9208ad775032a7ab10ac26dae4aeb31c4b25e",
+    "changedFiles" : [ {
+      "path" : "NOTICE.txt",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "14a9208ad775032a7ab10ac26dae4aeb31c4b25e",
+    "headCommit" : "3061c34bf93da6470a9bd495b279cae6d676b79c",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3061c34bf93da6470a9bd495b279cae6d676b79c",
+    "headCommit" : "712ad648cc9929a316e34bd599ec552010dac00f",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-fluent/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-testing/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "712ad648cc9929a316e34bd599ec552010dac00f",
+    "headCommit" : "7e6458027408f2315f043b05b50fca0fdb2a4253",
+    "changedFiles" : [ {
+      "path" : ".mvn/wrapper/maven-wrapper.properties",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "mvnw",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "mvnw.cmd",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7e6458027408f2315f043b05b50fca0fdb2a4253",
+    "headCommit" : "cd42b057e3666dd1cc91165aaa5758f10c88f10e",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientAbortMethod.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ClientAbortMethod"
+    }, {
+      "path" : "run-example.sh",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cd42b057e3666dd1cc91165aaa5758f10c88f10e",
+    "headCommit" : "b104297092c64c736ab4d7ee12061d7c2a080384",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b104297092c64c736ab4d7ee12061d7c2a080384",
+    "headCommit" : "371647fa149aa1bdc1be5a8e31fd43680dd698fd",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "371647fa149aa1bdc1be5a8e31fd43680dd698fd",
+    "headCommit" : "e2e07eb4fb069a84a6b8d18d4b56d40dd3b349e6",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e2e07eb4fb069a84a6b8d18d4b56d40dd3b349e6",
+    "headCommit" : "c5f98fb5736aa251e498651e1cf406767a38b002",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-fluent/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-testing/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c5f98fb5736aa251e498651e1cf406767a38b002",
+    "headCommit" : "03043d65f5c9c872b1b92716f44ece1512c75846",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/StandardTestClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.sync.StandardTestClientBuilder"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.sync.TestClientBuilder"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestClientResources.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.sync.TestClientResources"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.sync.TestServer"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/UnixDomainProxyServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.sync.UnixDomainProxyServer"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/AbstractIntegrationTestBase.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.AbstractIntegrationTestBase"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestConnectionReuse.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestConnectionReuse"
+    }, {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/HttpRoute.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.HttpRoute"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/RouteInfo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.RouteInfo"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/RouteTracker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.RouteTracker"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.config.RequestConfig"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultAsyncClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.DefaultAsyncClientConnectionOperator"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/routing/DefaultRoutePlanner.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.routing.DefaultRoutePlanner"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/io/HttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.io.HttpClientConnectionOperator"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.nio.AsyncClientConnectionOperator"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/socket/UnixDomainSocketFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.socket.UnixDomainSocketFactory"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/TestHttpRoute.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.TestHttpRoute"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/UnixDomainSocket.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.UnixDomainSocket"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/UnixDomainSocketAsync.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.UnixDomainSocketAsync"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "03043d65f5c9c872b1b92716f44ece1512c75846",
+    "headCommit" : "350066116a1c705f461820be1c9184a9ad6b1455",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncConnectionTimeouts.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestConnectionTimeouts.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestConnectionTimeouts"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "350066116a1c705f461820be1c9184a9ad6b1455",
+    "headCommit" : "6df72d17e9fadae6d536043a8e8338dca44d0771",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/MultipartEntityBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/PathBody.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.PathBody"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/FormBodyPartTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.FormBodyPartTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/TestMultipartEntityBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.TestMultipartEntityBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/TestMultipartMixed.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.TestMultipartMixed"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/TestPathBody.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.TestPathBody"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6df72d17e9fadae6d536043a8e8338dca44d0771",
+    "headCommit" : "c65eb9bec60d3f0c024d3b461520c53fec7e57bb",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/TestHttpRoute.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.TestHttpRoute"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c65eb9bec60d3f0c024d3b461520c53fec7e57bb",
+    "headCommit" : "5cef6edeb74d3bb458ed7ccbfbebc21838519746",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultRedirectStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.DefaultRedirectStrategy"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultRedirectStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.TestDefaultRedirectStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5cef6edeb74d3bb458ed7ccbfbebc21838519746",
+    "headCommit" : "ac19392e31109749aac1ad2b4fbd5e3747b1ffdd",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/PublicSuffixLoaderBenchmark.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.PublicSuffixLoaderBenchmark"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ac19392e31109749aac1ad2b4fbd5e3747b1ffdd",
+    "headCommit" : "1f90c1a60e098baaec39eb26981d99bb9a8b06f1",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncTlsHandshakeTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncTlsHandshakeTimeout"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestTlsHandshakeTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestTlsHandshakeTimeout"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/tls/TlsHandshakeTimeoutServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.tls.TlsHandshakeTimeoutServer"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1f90c1a60e098baaec39eb26981d99bb9a8b06f1",
+    "headCommit" : "c5bd9af6a47af3f2683209f0b818f1cf109026f6",
+    "changedFiles" : [ {
+      "path" : "README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c5bd9af6a47af3f2683209f0b818f1cf109026f6",
+    "headCommit" : "d89fdfeb6f66a20aefac6b50375e30613b2fc08b",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestTlsHandshakeTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestTlsHandshakeTimeout"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/AbstractClientTlsStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.AbstractClientTlsStrategy"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/ClientTlsStrategyBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/ConscryptClientTlsStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.ConscryptClientTlsStrategy"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultClientTlsStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d89fdfeb6f66a20aefac6b50375e30613b2fc08b",
+    "headCommit" : "a70d169f46fc0f7d276594065ca5d6e64ccf41f5",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a70d169f46fc0f7d276594065ca5d6e64ccf41f5",
+    "headCommit" : "fe260015d2d9ed37d85cda02a467cf879f062851",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "fe260015d2d9ed37d85cda02a467cf879f062851",
+    "headCommit" : "06481a09cbbd34d8e08bf074c4371fd6bbaea9ec",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/main/java/org/apache/hc/client5/testing/async/AsyncRandomHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.AsyncRandomHandler"
+    }, {
+      "path" : "httpclient5-testing/src/main/java/org/apache/hc/client5/testing/classic/RandomHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.classic.RandomHandler"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractIntegrationTestBase.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.AbstractIntegrationTestBase"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncSocketTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncSocketTimeout"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/StandardTestClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.async.StandardTestClientBuilder"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.async.TestAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncResources.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.async.TestAsyncResources"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.async.TestAsyncServer"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/AbstractIntegrationTestBase.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.AbstractIntegrationTestBase"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSocketTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestSocketTimeout"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "06481a09cbbd34d8e08bf074c4371fd6bbaea9ec",
+    "headCommit" : "fd2870edec85c0a37429fb357f13f844ff755c0c",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.ContentCompressionExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "fd2870edec85c0a37429fb357f13f844ff755c0c",
+    "headCommit" : "d1eb5b8b09b32bfe72b364edce378eb21a416167",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestRedirects.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestRedirects"
+    }, {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/BrotliInputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.BrotliInputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/DeflateInputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.DeflateInputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/GZIPInputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.GZIPInputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/InputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.InputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressDecoderFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.CommonsCompressDecoderFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/ContentCoding.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.ContentCoding"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/ContentDecoderRegistry.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.ContentDecoderRegistry"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.ContentCompressionExec"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d1eb5b8b09b32bfe72b364edce378eb21a416167",
+    "headCommit" : "78977443a53a1c63c78d7485cb2f00d020736f60",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSocketTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestSocketTimeout"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "78977443a53a1c63c78d7485cb2f00d020736f60",
+    "headCommit" : "5b829b387fe57188362a7314edc7d39a6afcf9cc",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractH2AsyncFundamentalsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.AbstractH2AsyncFundamentalsTest"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractHttpAsyncFundamentalsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.AbstractHttpAsyncFundamentalsTest"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttp1Async.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestHttp1Async"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttp1RequestReExecution.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestHttp1RequestReExecution"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/UdsAsyncIntegrationTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.UdsAsyncIntegrationTests"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncResources.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.async.TestAsyncResources"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestClientResources.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.sync.TestClientResources"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/UnixDomainProxyServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.sync.UnixDomainProxyServer"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientRequestExecution.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestClientRequestExecution"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestContentCodings.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestContentCodings"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/UdsIntegrationTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.UdsIntegrationTests"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5b829b387fe57188362a7314edc7d39a6afcf9cc",
+    "headCommit" : "20a4e9f765bf6bcf959c852dbb2caddd2d90939d",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/BrotliInputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.BrotliInputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/DeflateInputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.DeflateInputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/GZIPInputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.GZIPInputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/InputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.InputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressDecoderFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.CommonsCompressDecoderFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/ContentCoding.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.ContentCoding"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.ContentCompressionExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "20a4e9f765bf6bcf959c852dbb2caddd2d90939d",
+    "headCommit" : "550cd4dc0755e439872c6276e4d54671fe1fb046",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "550cd4dc0755e439872c6276e4d54671fe1fb046",
+    "headCommit" : "842e70aaa7d5aefb66d0e8abc8d1772b1b0e0e1d",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "842e70aaa7d5aefb66d0e8abc8d1772b1b0e0e1d",
+    "headCommit" : "21083862f7fce76d159d8ca0add973855fc05a88",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "21083862f7fce76d159d8ca0add973855fc05a88",
+    "headCommit" : "cdd8e934d08d6802b874f8f287fa33c83a041ab4",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cdd8e934d08d6802b874f8f287fa33c83a041ab4",
+    "headCommit" : "158234144113f741f0b0cfbad8bb9fe845778128",
+    "changedFiles" : [ {
+      "path" : ".mvn/wrapper/maven-wrapper.properties",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "158234144113f741f0b0cfbad8bb9fe845778128",
+    "headCommit" : "025275bcce959864fd9481ea23806e5d7e7d6b7b",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "025275bcce959864fd9481ea23806e5d7e7d6b7b",
+    "headCommit" : "c568701210c475f07c96b3b9cc2a1cb07fbabf67",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/UdsAsyncIntegrationTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.UdsAsyncIntegrationTests"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/UdsIntegrationTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.UdsIntegrationTests"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/HttpRoute.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.HttpRoute"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/RouteTracker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.RouteTracker"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/routing/DefaultRoutePlanner.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.routing.DefaultRoutePlanner"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/TestHttpRoute.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.TestHttpRoute"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c568701210c475f07c96b3b9cc2a1cb07fbabf67",
+    "headCommit" : "239948e2e2890e5f3417835da1c2cef28d9bc77c",
+    "changedFiles" : [ {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/DeflateCompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.DeflateCompressingEntity"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/EntityBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.EntityBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.CommonsCompressSupport"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.CommonsCompressingEntity"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/ContentDecoderRegistry.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.ContentDecoderRegistry"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/ContentEncoderRegistry.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.ContentEncoderRegistry"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/TestEntityBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.TestEntityBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientServerCompressionExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ClientServerCompressionExample"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "239948e2e2890e5f3417835da1c2cef28d9bc77c",
+    "headCommit" : "97703d9015e861e0676a8e0e601be06bca4a9610",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/socket/Jep380SocketChannelAdapter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.socket.Jep380SocketChannelAdapter"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/socket/Jep380SocketChannelImplAdapter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.socket.Jep380SocketChannelImplAdapter"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/socket/UnixDomainSocketFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.socket.UnixDomainSocketFactory"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "97703d9015e861e0676a8e0e601be06bca4a9610",
+    "headCommit" : "5c6c135a8b33eadd3b6867fe280c7fd9b69dc1d9",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/nio/H2SharingConnPoolTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.H2SharingConnPoolTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5c6c135a8b33eadd3b6867fe280c7fd9b69dc1d9",
+    "headCommit" : "6e0a18f2c2a6f976773b911869340b97545c632c",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultAsyncClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.DefaultAsyncClientConnectionOperator"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6e0a18f2c2a6f976773b911869340b97545c632c",
+    "headCommit" : "7993d00d9f7ba8d81f5c98a6fe4a3b980e3aea6d",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7993d00d9f7ba8d81f5c98a6fe4a3b980e3aea6d",
+    "headCommit" : "dd906f33612f2544d1d797911dbd5f99cd5b0038",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "dd906f33612f2544d1d797911dbd5f99cd5b0038",
+    "headCommit" : "22c0d6027ac9403beb5c27feef61dd50c6b1cd1f",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "22c0d6027ac9403beb5c27feef61dd50c6b1cd1f",
+    "headCommit" : "de4e3e9b25a2ce84ba27b7dddca64cc3b7be6430",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "de4e3e9b25a2ce84ba27b7dddca64cc3b7be6430",
+    "headCommit" : "be41f5cd67e41e32d84d16ad03e9569562678e5b",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/TestValidateAfterInactivity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.TestValidateAfterInactivity"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "be41f5cd67e41e32d84d16ad03e9569562678e5b",
+    "headCommit" : "c01d4125aee25a5254fb0c05a99a6cc4fade25fd",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/socket/Jep380SocketChannelAdapter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.socket.Jep380SocketChannelAdapter"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/socket/Jep380SocketChannelImplAdapter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.socket.Jep380SocketChannelImplAdapter"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c01d4125aee25a5254fb0c05a99a6cc4fade25fd",
+    "headCommit" : "b1efda3a35e5b991353c54e0d2ec17d7c6dcc299",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/H2SharingConnPool.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.H2SharingConnPool"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/nio/H2SharingConnPoolTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.H2SharingConnPoolTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/nio/H2SharingPerRoutePoolTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.H2SharingPerRoutePoolTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b1efda3a35e5b991353c54e0d2ec17d7c6dcc299",
+    "headCommit" : "727ff737718f6ebaa949ed58f878b757f23485c2",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "727ff737718f6ebaa949ed58f878b757f23485c2",
+    "headCommit" : "7000b9ea2988b673d551aa4a2423684857b0da88",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/TestValidateAfterInactivity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.TestValidateAfterInactivity"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7000b9ea2988b673d551aa4a2423684857b0da88",
+    "headCommit" : "e02c106d54e5ca27d146579af96dc458de7cc01d",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/main/java/org/apache/hc/client5/testing/classic/ServiceUnavailableDecorator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.classic.ServiceUnavailableDecorator"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/HttpIntegrationTests.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.HttpIntegrationTests"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientRequestReExecution.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestClientRequestReExecution"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.config.RequestConfig"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultHttpRequestRetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncHttpRequestRetryExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.AsyncHttpRequestRetryExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpRequestRetryExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpRequestRetryExec"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultHttpRequestRetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.TestDefaultHttpRequestRetryStrategy"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestHttpRequestRetryExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TestHttpRequestRetryExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e02c106d54e5ca27d146579af96dc458de7cc01d",
+    "headCommit" : "909997872cd1a794e4751143d18499750302e57c",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/BrotliDecompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.BrotliDecompressingEntity"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/BrotliInputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.BrotliInputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/DecompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.DecompressingEntity"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/DeflateDecompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.DeflateDecompressingEntity"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/DeflateInputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.DeflateInputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/EntityBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.EntityBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/GZIPInputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.GZIPInputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/GzipDecompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.GzipDecompressingEntity"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/InputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.InputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/LazyDecompressingInputStream.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.LazyDecompressingInputStream"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressDecoderFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.CommonsCompressDecoderFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/ContentCodecRegistry.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.ContentCodecRegistry"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/ContentDecoderRegistry.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.ContentDecoderRegistry"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/ContentEncoderRegistry.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.ContentEncoderRegistry"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/DecompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.DecompressingEntity"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/IOFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.IOFunction"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.ContentCompressionExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/TestBrotli.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.TestBrotli"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/TestDecompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.TestDecompressingEntity"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/TestDeflate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.TestDeflate"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/TestGZip.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.TestGZip"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TestContentCompressionExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "909997872cd1a794e4751143d18499750302e57c",
+    "headCommit" : "945a75dd361193620d4961ceeacbef77e69e8c76",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncHttpRequestRetryExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.AsyncHttpRequestRetryExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpRequestRetryExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpRequestRetryExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "945a75dd361193620d4961ceeacbef77e69e8c76",
+    "headCommit" : "e907ae0ba71753b4e6941326245d7cfeb7c10cab",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/StandardTestClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.sync.StandardTestClientBuilder"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.sync.TestClientBuilder"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestRedirects.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestRedirects"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/LaxRedirectStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.LaxRedirectStrategy"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultRedirectStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.TestDefaultRedirectStrategy"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestLaxRedirectStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.TestLaxRedirectStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e907ae0ba71753b4e6941326245d7cfeb7c10cab",
+    "headCommit" : "9d38e5fb4438e8fb6442ac8e5ff304142938cf83",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/InputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.InputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9d38e5fb4438e8fb6442ac8e5ff304142938cf83",
+    "headCommit" : "b55f106c3383233ee0cf3c8a11a36fd832b0a8a1",
+    "changedFiles" : [ {
+      "path" : ".mvn/wrapper/maven-wrapper.properties",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b55f106c3383233ee0cf3c8a11a36fd832b0a8a1",
+    "headCommit" : "97fd9319e1960a026bd0020237932be7f958b997",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/config/ExpectContinueTrigger.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.config.ExpectContinueTrigger"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.config.RequestConfig"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestExpectContinue.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.protocol.RequestExpectContinue"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestExpectContinue.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.protocol.TestRequestExpectContinue"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "97fd9319e1960a026bd0020237932be7f958b997",
+    "headCommit" : "97a0d1a74e6a877b2c0b0f384feafad4fb4b3d84",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "97a0d1a74e6a877b2c0b0f384feafad4fb4b3d84",
+    "headCommit" : "9b3dffb3b0353fd33115feafb9de0fefb997e911",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ReactiveClientFullDuplexExchange.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ReactiveClientFullDuplexExchange"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/UnixDomainSocketAsync.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.UnixDomainSocketAsync"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9b3dffb3b0353fd33115feafb9de0fefb997e911",
+    "headCommit" : "0d4b9a91174dd6a9b9c32634344dd0d1be988622",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultManagedHttpClientConnection.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultManagedHttpClientConnection"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultManagedAsyncClientConnection.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.DefaultManagedAsyncClientConnection"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0d4b9a91174dd6a9b9c32634344dd0d1be988622",
+    "headCommit" : "9780a8f9097f4539ea7beb3f99a9c97819e5fb96",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/DecompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.DecompressingEntity"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9780a8f9097f4539ea7beb3f99a9c97819e5fb96",
+    "headCommit" : "dc9d9685b383f80a5dbda27dfb613f9ac9cff7d0",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/DeflatingAsyncEntityProducer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.DeflatingAsyncEntityProducer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingAsyncDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingAsyncDataConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/ContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.ContentCompressionAsyncExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/DeflatingAsyncEntityProducerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.DeflatingAsyncEntityProducerTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/InflatingAsyncEntityConsumerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingAsyncEntityConsumerTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientDeflateCompressionExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientDeflateCompressionExample"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientInflateDecompressionExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientInflateDecompressionExample"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.TestContentCompressionAsyncExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "dc9d9685b383f80a5dbda27dfb613f9ac9cff7d0",
+    "headCommit" : "99d4a5e081f31616a2558e72824ed8cf52198596",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "99d4a5e081f31616a2558e72824ed8cf52198596",
+    "headCommit" : "97e4041ad63bf2ccdc809d8ed0b30002b6d6a250",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/ContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.ContentCompressionAsyncExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.ContentCompressionExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TestContentCompressionExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "97e4041ad63bf2ccdc809d8ed0b30002b6d6a250",
+    "headCommit" : "40b41119b93d7251d4394a875e2c9289d5e786f9",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestTlsHandshakeTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestTlsHandshakeTimeout"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "40b41119b93d7251d4394a875e2c9289d5e786f9",
+    "headCommit" : "1bfeaaf84df77c5c5bd7502aeb9176443e51bd44",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/DeflatingGzipEntityProducer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.DeflatingGzipEntityProducer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingGzipDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingGzipDataConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/ContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.ContentCompressionAsyncExec"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/GzipRoundTripTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.GzipRoundTripTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientGzipCompressionExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientGzipCompressionExample"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientGzipDecompressionExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientGzipDecompressionExample"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.TestContentCompressionAsyncExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1bfeaaf84df77c5c5bd7502aeb9176443e51bd44",
+    "headCommit" : "2bd05c79635b3b00f667539a98e19e468cb022af",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultClientTlsStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2bd05c79635b3b00f667539a98e19e468cb022af",
+    "headCommit" : "238edf3dc0cff4b54611d2ed04c5866765981cdc",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultAsyncClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.DefaultAsyncClientConnectionOperator"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/AbstractClientTlsStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.AbstractClientTlsStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "238edf3dc0cff4b54611d2ed04c5866765981cdc",
+    "headCommit" : "08b4160403d344e5536f50cd5bf4d70dff5197ae",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "08b4160403d344e5536f50cd5bf4d70dff5197ae",
+    "headCommit" : "ef34bfa8fd6f2f6181ba2e41051050ed877e56df",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncSocketTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncSocketTimeout"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ef34bfa8fd6f2f6181ba2e41051050ed877e56df",
+    "headCommit" : "3947600c638342ee7667aa43960819b71b817920",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/ContentCodingSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.ContentCodingSupport"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/ContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.ContentCompressionAsyncExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.ContentCompressionExec"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/ContentCodingSupportTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.ContentCodingSupportTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3947600c638342ee7667aa43960819b71b817920",
+    "headCommit" : "72a00a0c2c2184b09c4cbbdb01064be3f0613811",
+    "changedFiles" : [ {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/DeflatingZstdEntityProducer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.DeflatingZstdEntityProducer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingZstdDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingZstdDataConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/ZstdRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.ZstdRuntime"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/ContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.ContentCompressionAsyncExec"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/InflatingZstdDataConsumerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingZstdDataConsumerTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientServerZstdExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientServerZstdExample"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientZstdCompressionExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientZstdCompressionExample"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.TestContentCompressionAsyncExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "72a00a0c2c2184b09c4cbbdb01064be3f0613811",
+    "headCommit" : "f176d922df466bf06924f2b19474352141bafa7c",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f176d922df466bf06924f2b19474352141bafa7c",
+    "headCommit" : "ddd2d58f38dbf6d198554a9c6a280eeb11b02f17",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ddd2d58f38dbf6d198554a9c6a280eeb11b02f17",
+    "headCommit" : "90294dc68af1341a14e04faaa73484b21ccb2cb4",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "90294dc68af1341a14e04faaa73484b21ccb2cb4",
+    "headCommit" : "3eda5098f82c0d5cf1ceaa72afb1c24d9836ff56",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncTlsHandshakeTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncTlsHandshakeTimeout"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3eda5098f82c0d5cf1ceaa72afb1c24d9836ff56",
+    "headCommit" : "89da74220a11341b42ec455324b36094cc29f225",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/DigestScheme.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.DigestScheme"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestDigestScheme.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.TestDigestScheme"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "89da74220a11341b42ec455324b36094cc29f225",
+    "headCommit" : "b95d90d7fd6e9a7e339a317ea1aab6fdc576499b",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncConnectionManagement.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncConnectionManagement"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/MinimalTestClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.async.MinimalTestClientBuilder"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/StandardTestClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.async.StandardTestClientBuilder"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.async.TestAsyncClient"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.async.TestAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.sync.TestClientBuilder"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestConnectionManagement.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestConnectionManagement"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/ConnectionHolder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.ConnectionHolder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AbstractHttpAsyncClientBase.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.AbstractHttpAsyncClientBase"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b95d90d7fd6e9a7e339a317ea1aab6fdc576499b",
+    "headCommit" : "57423c02a7ac075cff7204b596c3da5c3cfea4e4",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncConnectionManagement.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncConnectionManagement"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestConnectionManagement.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestConnectionManagement"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/BasicHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "57423c02a7ac075cff7204b596c3da5c3cfea4e4",
+    "headCommit" : "67f56a27fc846258c36939c4b59d5479bb056cf4",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/config/ConnectionConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.config.ConnectionConfig"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.config.RequestConfig"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "67f56a27fc846258c36939c4b59d5479bb056cf4",
+    "headCommit" : "830b06203d5250a867a40a85134267cfa3baa90d",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "830b06203d5250a867a40a85134267cfa3baa90d",
+    "headCommit" : "91d32f87846401bf64a427ebe510f3d817fb9c93",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AbstractHttpAsyncClientBase.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.AbstractHttpAsyncClientBase"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "91d32f87846401bf64a427ebe510f3d817fb9c93",
+    "headCommit" : "4d30dbb4c4c22a724397b33a6f8f4e047f4298d6",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.HttpRFC7578Multipart"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/TestMultipartEntityBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.TestMultipartEntityBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4d30dbb4c4c22a724397b33a6f8f4e047f4298d6",
+    "headCommit" : "345aca1a71b857d6348521c715f94e23f922f9d2",
+    "changedFiles" : [ {
+      "path" : "httpclient5-observation/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/HttpClientObservationSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.HttpClientObservationSupport"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/MetricConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.MetricConfig"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/ObservingOptions.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.ObservingOptions"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/binder/ConnPoolMeters.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.binder.ConnPoolMeters"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/binder/ConnPoolMetersAsync.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.binder.ConnPoolMetersAsync"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/binder/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.binder.package-info"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/impl/MeteredDnsResolver.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.MeteredDnsResolver"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/impl/MeteredTlsStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.MeteredTlsStrategy"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/impl/ObservationAsyncExecInterceptor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.ObservationAsyncExecInterceptor"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/impl/ObservationClassicExecInterceptor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.ObservationClassicExecInterceptor"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/impl/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.package-info"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/interceptors/AsyncIoByteCounterExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.AsyncIoByteCounterExec"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/interceptors/AsyncTimerExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.AsyncTimerExec"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/interceptors/IoByteCounterExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.IoByteCounterExec"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/interceptors/TimerExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.TimerExec"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/interceptors/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.package-info"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.package-info"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/HttpClientObservationSupportTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.HttpClientObservationSupportTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/MetricConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.MetricConfigTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/ObservingOptionsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.ObservingOptionsTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/binder/ConnPoolMetersAsyncTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.binder.ConnPoolMetersAsyncTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/binder/ConnPoolMetersTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.binder.ConnPoolMetersTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/AsyncMetricsDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.AsyncMetricsDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/ClassicWithMetricConfigDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.ClassicWithMetricConfigDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/DnsMetricsDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.DnsMetricsDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/PoolGaugesDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.PoolGaugesDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/SpanSamplingDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.SpanSamplingDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/TagLevelDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.TagLevelDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/TlsMetricsDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.TlsMetricsDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/TracingAndMetricsDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.TracingAndMetricsDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/impl/MeteredDnsResolverTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.MeteredDnsResolverTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/impl/MeteredTlsStrategyTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.MeteredTlsStrategyTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/impl/ObservationAsyncExecInterceptorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.ObservationAsyncExecInterceptorTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/impl/ObservationClassicExecInterceptorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.ObservationClassicExecInterceptorTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/interceptors/AsyncIoByteCounterExecTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.AsyncIoByteCounterExecTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/interceptors/AsyncTimerExecTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.AsyncTimerExecTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/interceptors/IoByteCounterExecTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.IoByteCounterExecTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/interceptors/TimerExecTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.TimerExecTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/resources/ApacheLogo.png",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-observation/src/test/resources/log4j2.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "345aca1a71b857d6348521c715f94e23f922f9d2",
+    "headCommit" : "c21ec4507e9f491c8d2f95a843ca5bd3824b0a1d",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SpkiPinningClientTlsStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.SpkiPinningClientTlsStrategy"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientSpkiPinningExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ClientSpkiPinningExample"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/ssl/SpkiPinningClientTlsStrategyTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.SpkiPinningClientTlsStrategyTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c21ec4507e9f491c8d2f95a843ca5bd3824b0a1d",
+    "headCommit" : "88c315d23d9689e9160219ce89156c5b3d2ec8b3",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/OffLockDisposalCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.OffLockDisposalCallback"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManagerBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/NoopOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.NoopOperator"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/io/TestPoolingHttpClientConnectionManagerOffLockDisposal.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.TestPoolingHttpClientConnectionManagerOffLockDisposal"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "88c315d23d9689e9160219ce89156c5b3d2ec8b3",
+    "headCommit" : "23906f60d3fcbc42667a54f64621a581839396ea",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "23906f60d3fcbc42667a54f64621a581839396ea",
+    "headCommit" : "5e73e17ae6c3886b8217d026a713303fd903ca4b",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/auth/StandardAuthScheme.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.auth.StandardAuthScheme"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultAuthenticationStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.DefaultAuthenticationStrategy"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/ScramException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.ScramException"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SaslPrep.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.SaslPrep"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/ScramExtension.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.ScramExtension"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/ScramScheme.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.ScramScheme"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/ScramSchemeFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.ScramSchemeFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProxyClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.ProxyClient"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/SaslPrepTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.SaslPrepTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestScramScheme.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.TestScramScheme"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5e73e17ae6c3886b8217d026a713303fd903ca4b",
+    "headCommit" : "277adc34a76d26051387fa496b7de6e2d2c80215",
+    "changedFiles" : [ {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/DeflatingBrotliEntityProducer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.DeflatingBrotliEntityProducer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingBrotliDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/Brotli4jRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.Brotli4jRuntime"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/ContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.ContentCompressionAsyncExec"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/DeflatingBrotliEntityProducerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.DeflatingBrotliEntityProducerTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/InflatingBrotliDataConsumerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumerTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientServerBrotliRoundTrip.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientServerBrotliRoundTrip"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.TestContentCompressionAsyncExec"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "277adc34a76d26051387fa496b7de6e2d2c80215",
+    "headCommit" : "ceeac021cf5ab9735d7c44ff91ed2856b5f60a0b",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ConnectExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.ConnectExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ceeac021cf5ab9735d7c44ff91ed2856b5f60a0b",
+    "headCommit" : "570cc3e4314fc9ba14b0c00b782902cff600c54f",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestConnectionClosureRace.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestConnectionClosureRace"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "570cc3e4314fc9ba14b0c00b782902cff600c54f",
+    "headCommit" : "665325cead548da21b85d1edc99ae6cefb0b5cab",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressDecoderFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.CommonsCompressDecoderFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/DecompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.DecompressingEntity"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/IOFunction.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.IOFunction"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/AbstractSharedBuffer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.AbstractSharedBuffer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/ClassicToAsyncAdaptor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.ClassicToAsyncAdaptor"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/ClassicToAsyncRequestProducer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.ClassicToAsyncRequestProducer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/ClassicToAsyncResponseConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.ClassicToAsyncResponseConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/ClassicToAsyncSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.ClassicToAsyncSupport"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/IOCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.IOCallback"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/ProtocolException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.ProtocolException"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/SharedInputBuffer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.SharedInputBuffer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/SharedOutputBuffer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.SharedOutputBuffer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/compat/TransportException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.compat.TransportException"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "665325cead548da21b85d1edc99ae6cefb0b5cab",
+    "headCommit" : "46816101ad6b1d7a09588892b7a40bbcf07e1d4c",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/config/ConnectionConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.config.ConnectionConfig"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "46816101ad6b1d7a09588892b7a40bbcf07e1d4c",
+    "headCommit" : "add1ed94a66466b902b7c9295bf6d05d4aca8a68",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/socket/UnixDomainSocketFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.socket.UnixDomainSocketFactory"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "add1ed94a66466b902b7c9295bf6d05d4aca8a68",
+    "headCommit" : "a8a04b146df2fde55cd8b9b5d80d801ec8e49f76",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a8a04b146df2fde55cd8b9b5d80d801ec8e49f76",
+    "headCommit" : "168e7b229896dc9e5444f60baf288e4dc96c70c1",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "168e7b229896dc9e5444f60baf288e4dc96c70c1",
+    "headCommit" : "5f3d0066c36afbeb424269320d1fb4afe45e2e66",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.config.RequestConfig"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5f3d0066c36afbeb424269320d1fb4afe45e2e66",
+    "headCommit" : "26d51f66cd4986ef718fd429c8db7ab0c7b232d0",
+    "changedFiles" : [ {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/BrotliInputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.BrotliInputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/BrotliCodecFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.BrotliCodecFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressCodecFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.CommonsCompressCodecFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressDecoderFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.CommonsCompressDecoderFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.CommonsCompressRuntime"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.CommonsCompressSupport"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CommonsCompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.CommonsCompressingEntity"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/CompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.CompressingEntity"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/ContentCodecRegistry.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.ContentCodecRegistry"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/DecompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.DecompressingEntity"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/TestBrotli.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.TestBrotli"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "26d51f66cd4986ef718fd429c8db7ab0c7b232d0",
+    "headCommit" : "092cae8bfc4cb646aaaa156583952fdc4cb340aa",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestClassicOverAsync.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestClassicOverAsync"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "092cae8bfc4cb646aaaa156583952fdc4cb340aa",
+    "headCommit" : "f4027e78c0f39975c7b7534887677173cc1d18ae",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/EarlyHintsListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.EarlyHintsListener"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/EarlyHintsAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.EarlyHintsAsyncExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientEarlyHintsEndToEnd.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientEarlyHintsEndToEnd"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/EarlyHintsAsyncExecTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.EarlyHintsAsyncExecTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f4027e78c0f39975c7b7534887677173cc1d18ae",
+    "headCommit" : "bc3475680c02c57424cc0a389cc2cede1cce605c",
+    "changedFiles" : [ {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/HttpClientObservationSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.HttpClientObservationSupport"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/binder/ConnPoolMeters.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.binder.ConnPoolMeters"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/binder/ConnPoolMetersAsync.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.binder.ConnPoolMetersAsync"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/DeflatingBrotliEntityProducer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.DeflatingBrotliEntityProducer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/DeflatingZstdEntityProducer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.DeflatingZstdEntityProducer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingBrotliDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingZstdDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingZstdDataConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/GZIPInputStreamFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.GZIPInputStreamFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestValidateTrace.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.protocol.RequestValidateTrace"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientServerZstdExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientServerZstdExample"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientZstdCompressionExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientZstdCompressionExample"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bc3475680c02c57424cc0a389cc2cede1cce605c",
+    "headCommit" : "799bbc957f44fe2f6a379f912588ef07e0343d0a",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "799bbc957f44fe2f6a379f912588ef07e0343d0a",
+    "headCommit" : "56122fd33fb8a67d23369a81f6e1d89aabf4ba10",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/ContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.ContentCompressionAsyncExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.ContentCompressionExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "56122fd33fb8a67d23369a81f6e1d89aabf4ba10",
+    "headCommit" : "8f3d3fc773e22c8c33a6e3c2f5deb598d9ff8e25",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.config.RequestConfig"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/protocol/H2RequestPriority.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.protocol.H2RequestPriority"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientH2Priority.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientH2Priority"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/protocol/H2RequestPriorityTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.protocol.H2RequestPriorityTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8f3d3fc773e22c8c33a6e3c2f5deb598d9ff8e25",
+    "headCommit" : "c8b60aedc68b775ccb1efdac72f84d4295afd663",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/config/ExpectContinueTrigger.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.config.ExpectContinueTrigger"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/config/RequestConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.config.RequestConfig"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestExpectContinue.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.protocol.RequestExpectContinue"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestExpectContinue.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.protocol.TestRequestExpectContinue"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c8b60aedc68b775ccb1efdac72f84d4295afd663",
+    "headCommit" : "426ad2c27a2f3c07dbc8bde2c692795f8dbd0086",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncProtocolExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.AsyncProtocolExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/AuthenticationHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.AuthenticationHandler"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProtocolExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.ProtocolExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "426ad2c27a2f3c07dbc8bde2c692795f8dbd0086",
+    "headCommit" : "7e7b9c04340d9ece7d4f5b61a762dc7739a5e237",
+    "changedFiles" : [ {
+      "path" : "README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7e7b9c04340d9ece7d4f5b61a762dc7739a5e237",
+    "headCommit" : "fbb6badc168c541435232dca2aef5fe7c0cb63e8",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "fbb6badc168c541435232dca2aef5fe7c0cb63e8",
+    "headCommit" : "f0afb8e6b73ed74c785747dea4dec43383c3d5db",
+    "changedFiles" : [ {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/MetricConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.MetricConfig"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f0afb8e6b73ed74c785747dea4dec43383c3d5db",
+    "headCommit" : "8d7358f33b1da52a9f75d33ad2767be4ea3bc99a",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-fluent/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-observation/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-testing/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8d7358f33b1da52a9f75d33ad2767be4ea3bc99a",
+    "headCommit" : "8767978952506c6792d117aab19fdedb68110bd7",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestTlsHandshakeTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestTlsHandshakeTimeout"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8767978952506c6792d117aab19fdedb68110bd7",
+    "headCommit" : "28d29f9df27b1d709a3237401d980372f2113684",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/socket/PlainConnectionSocketFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.socket.PlainConnectionSocketFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/HttpsSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.HttpsSupport"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "28d29f9df27b1d709a3237401d980372f2113684",
+    "headCommit" : "36e7b3b8586b9006915184b3f413ac446cbf7414",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/depsreview.yaml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "36e7b3b8586b9006915184b3f413ac446cbf7414",
+    "headCommit" : "082552ce8e0c2b72aa5ed248c2d8b0bce554923b",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/codeql-analysis.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "082552ce8e0c2b72aa5ed248c2d8b0bce554923b",
+    "headCommit" : "420ddc2c6d44081a25a0e1e64d3a660e7fd5c3bb",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "420ddc2c6d44081a25a0e1e64d3a660e7fd5c3bb",
+    "headCommit" : "419c9703b2382324efcad393042a494dd94931e5",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "419c9703b2382324efcad393042a494dd94931e5",
+    "headCommit" : "62e5fac92e42767f3d403082a2ca977345bc648f",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "62e5fac92e42767f3d403082a2ca977345bc648f",
+    "headCommit" : "95ecc88e48389687b328257fcc279cbb517c3ac8",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "95ecc88e48389687b328257fcc279cbb517c3ac8",
+    "headCommit" : "9a438988ae4db95b01be6d5045d3630f4ded2d9d",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9a438988ae4db95b01be6d5045d3630f4ded2d9d",
+    "headCommit" : "8888d42a32ed0000d56687e80a5f2ec2519faf1f",
+    "changedFiles" : [ {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/impl/MeteredTlsStrategyTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.MeteredTlsStrategyTest"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BasicAuthCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.BasicAuthCache"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientCustomSSL.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientCustomSSL"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientCustomSSL.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ClientCustomSSL"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.TestContentCompressionAsyncExec"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TestContentCompressionExec"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestInternalHttpClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TestInternalHttpClient"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/ssl/SpkiPinningClientTlsStrategyTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.SpkiPinningClientTlsStrategyTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/ssl/TestDefaultHostnameVerifier.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.TestDefaultHostnameVerifier"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8888d42a32ed0000d56687e80a5f2ec2519faf1f",
+    "headCommit" : "929f5216ea594c36d2a7d0a4d059d1b78a3a70c3",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncTlsHandshakeTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncTlsHandshakeTimeout"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestTlsHandshakeTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestTlsHandshakeTimeout"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "929f5216ea594c36d2a7d0a4d059d1b78a3a70c3",
+    "headCommit" : "a0471320350221cee073043e5590b77dbcf5d74d",
+    "changedFiles" : [ {
+      "path" : "httpclient5-observation/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a0471320350221cee073043e5590b77dbcf5d74d",
+    "headCommit" : "43aa98845a180305df7cd940103c4adc02fcfbc5",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "43aa98845a180305df7cd940103c4adc02fcfbc5",
+    "headCommit" : "72dfe6e0b8cb13eb877de4d561811d9a71848d13",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "72dfe6e0b8cb13eb877de4d561811d9a71848d13",
+    "headCommit" : "3b4bc96532824182404a35a8735e6bf0aca719f4",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3b4bc96532824182404a35a8735e6bf0aca719f4",
+    "headCommit" : "06634831effa5c83536f4ed035fb13af8ffc78ea",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "06634831effa5c83536f4ed035fb13af8ffc78ea",
+    "headCommit" : "919dfe013e82e444fadb5e3725db285ecf207984",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/caffeine/CaffeineHttpCacheStorage.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.caffeine.CaffeineHttpCacheStorage"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/caffeine/TestCaffeineHttpCacheStorage.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.caffeine.TestCaffeineHttpCacheStorage"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "919dfe013e82e444fadb5e3725db285ecf207984",
+    "headCommit" : "79992d832cc5d9fb4ce8307200dae844085b9d3d",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AbstractSerializingCacheStorage.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.AbstractSerializingCacheStorage"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpCacheStorage.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.memcached.MemcachedHttpCacheStorage"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "79992d832cc5d9fb4ce8307200dae844085b9d3d",
+    "headCommit" : "e943a15eb856d4f2890ed39d0396415bee06724c",
+    "changedFiles" : [ {
+      "path" : "httpclient5-sse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/BackoffStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.BackoffStrategy"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/EventSource.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.EventSource"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/EventSourceConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.EventSourceConfig"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/EventSourceListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.EventSourceListener"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/SseExecutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.SseExecutor"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/SseExecutorBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.SseExecutorBuilder"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/ByteSseEntityConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.ByteSseEntityConsumer"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/DefaultEventSource.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.DefaultEventSource"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/ExponentialJitterBackoff.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.ExponentialJitterBackoff"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/FixedBackoffStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.FixedBackoffStrategy"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/NoBackoffStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.NoBackoffStrategy"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/ServerSentEventReader.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.ServerSentEventReader"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/SseCallbacks.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.SseCallbacks"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/SseEntityConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.SseEntityConsumer"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/SseParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.SseParser"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/SseResponseConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.SseResponseConsumer"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.package-info"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.package-info"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/ByteSseEntityConsumerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.ByteSseEntityConsumerTest"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/DefaultEventSourceIntegrationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.DefaultEventSourceIntegrationTest"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/ExponentialJitterBackoffTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.ExponentialJitterBackoffTest"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/NoBackoffStrategyTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.NoBackoffStrategyTest"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/ServerSentEventReaderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.ServerSentEventReaderTest"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/SseEntityConsumerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.SseEntityConsumerTest"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/SseExecutorBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.SseExecutorBuilderTest"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/SseResponseConsumerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.SseResponseConsumerTest"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/example/ClientSseExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.example.ClientSseExample"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/example/performance/LogHistogram.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.example.performance.LogHistogram"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/example/performance/SsePerfClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.example.performance.SsePerfClient"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/example/performance/SsePerfServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.example.performance.SsePerfServer"
+    }, {
+      "path" : "httpclient5-sse/src/test/resources/log4j2-debug.xml.template",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-sse/src/test/resources/log4j2.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/DefaultAsyncClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.DefaultAsyncClientConnectionOperator"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e943a15eb856d4f2890ed39d0396415bee06724c",
+    "headCommit" : "9518c643a95f16b3a272e5a3f194af46d85d4711",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-fluent/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-observation/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-sse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-testing/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9518c643a95f16b3a272e5a3f194af46d85d4711",
+    "headCommit" : "c82268d7f8904c0fb6879a60247b5c30feb7ea67",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AbstractSerializingCacheStorage.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.AbstractSerializingCacheStorage"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/caffeine/CaffeineHttpCacheStorage.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.caffeine.CaffeineHttpCacheStorage"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/memcached/MemcachedHttpCacheStorage.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.memcached.MemcachedHttpCacheStorage"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/EventSource.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.EventSource"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/EventSourceConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.EventSourceConfig"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/EventSourceListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.EventSourceListener"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/SseExecutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.SseExecutor"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/SseExecutorBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.SseExecutorBuilder"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/DefaultEventSource.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.DefaultEventSource"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/ExponentialJitterBackoff.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.ExponentialJitterBackoff"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/FixedBackoffStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.FixedBackoffStrategy"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/NoBackoffStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.NoBackoffStrategy"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/SseCallbacks.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.SseCallbacks"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/SseEntityConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.SseEntityConsumer"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/SseParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.SseParser"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/SseResponseConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.SseResponseConsumer"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.package-info"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.package-info"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c82268d7f8904c0fb6879a60247b5c30feb7ea67",
+    "headCommit" : "2682625fe0daf8a22ee897680b9f77a7ffe340f4",
+    "changedFiles" : [ {
+      "path" : "httpclient5-observation/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2682625fe0daf8a22ee897680b9f77a7ffe340f4",
+    "headCommit" : "dfb0211d3017cf28a7a90314e324635259101afc",
+    "changedFiles" : [ {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/BackoffStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.BackoffStrategy"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/EventSourceListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.EventSourceListener"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/SseExecutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.SseExecutor"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/SseExecutorBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.SseExecutorBuilder"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/ServerSentEventReader.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.ServerSentEventReader"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/SseParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.SseParser"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.package-info"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "dfb0211d3017cf28a7a90314e324635259101afc",
+    "headCommit" : "297ec89d951522d0d544797ba1436b86b7069c76",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/OffLockDisposalCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.OffLockDisposalCallback"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManagerBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "297ec89d951522d0d544797ba1436b86b7069c76",
+    "headCommit" : "a14264daca5dab878800ba8d42fea50c670a98ba",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a14264daca5dab878800ba8d42fea50c670a98ba",
+    "headCommit" : "378982f64db09185909a3d010b9bd9b07b994d1b",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "378982f64db09185909a3d010b9bd9b07b994d1b",
+    "headCommit" : "c63ea8ea3be1bc8f8b1ea86f5ec3c89dc64bcfea",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/ContentCodingSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.ContentCodingSupport"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/ContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.ContentCompressionAsyncExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.ContentCompressionExec"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/InflatingAsyncEntityConsumerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingAsyncEntityConsumerTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/InflatingBrotliDataConsumerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumerTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.TestContentCompressionAsyncExec"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TestContentCompressionExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c63ea8ea3be1bc8f8b1ea86f5ec3c89dc64bcfea",
+    "headCommit" : "7746feb16ef49a58dac163f739b38611e8c76abd",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManagerBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManagerBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7746feb16ef49a58dac163f739b38611e8c76abd",
+    "headCommit" : "297624e83b4c3b5e4e0106a6810e4b5de392ce5c",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/TestValidateAfterInactivity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.TestValidateAfterInactivity"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientEarlyHintsEndToEnd.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientEarlyHintsEndToEnd"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/EarlyHintsAsyncExecTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.EarlyHintsAsyncExecTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "297624e83b4c3b5e4e0106a6810e4b5de392ce5c",
+    "headCommit" : "3e0e5c1a0eb0960190dfd46495a9e71fda404113",
+    "changedFiles" : [ {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/DefaultEventSourceIntegrationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.DefaultEventSourceIntegrationTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3e0e5c1a0eb0960190dfd46495a9e71fda404113",
+    "headCommit" : "8a2ae8e6a53cbccdea88dd6b65fab37202e94d68",
+    "changedFiles" : [ {
+      "path" : "httpclient5-observation/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8a2ae8e6a53cbccdea88dd6b65fab37202e94d68",
+    "headCommit" : "d07c8e26cbe69cc94e1b98ba8b5fdfb284244b6a",
+    "changedFiles" : [ {
+      "path" : "httpclient5-observation/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d07c8e26cbe69cc94e1b98ba8b5fdfb284244b6a",
+    "headCommit" : "789769890b0551b1453bdebe8703a58d1d676c7e",
+    "changedFiles" : [ {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/example/ClientSseH2Example.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.example.ClientSseH2Example"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/example/SsePerfClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.example.SsePerfClient"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/example/SsePerfServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.example.SsePerfServer"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "789769890b0551b1453bdebe8703a58d1d676c7e",
+    "headCommit" : "6eff659a42d576f0b572daf63bccd0073e3374d5",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/UnixDomainProxyServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.sync.UnixDomainProxyServer"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6eff659a42d576f0b572daf63bccd0073e3374d5",
+    "headCommit" : "80622f5fb41c4aa32d466460791674a78c09f8e5",
+    "changedFiles" : [ {
+      "path" : ".mvn/wrapper/maven-wrapper.properties",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "mvnw",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "mvnw.cmd",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "80622f5fb41c4aa32d466460791674a78c09f8e5",
+    "headCommit" : "bbc3ac34a30457dc42bb28281f578c991f3ebd45",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestHttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TestHttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestHttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TestHttpClientBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "bbc3ac34a30457dc42bb28281f578c991f3ebd45",
+    "headCommit" : "43d35fc1db9f6531f0e33ec81a29899c61667c2c",
+    "changedFiles" : [ {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/HttpClientObservationSupportTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.HttpClientObservationSupportTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/impl/ObservationAsyncExecInterceptorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.ObservationAsyncExecInterceptorTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/impl/ObservationClassicExecInterceptorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.ObservationClassicExecInterceptorTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/interceptors/AsyncTimerExecTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.AsyncTimerExecTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/interceptors/IoByteCounterExecTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.IoByteCounterExecTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/interceptors/TimerExecTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.TimerExecTest"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestCookieVirtualHost.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestCookieVirtualHost"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestDefaultClientTlsStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestDefaultClientTlsStrategy"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestFutureRequestExecutionService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestFutureRequestExecutionService"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestMalformedServerResponse.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestMalformedServerResponse"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientEarlyHintsEndToEnd.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientEarlyHintsEndToEnd"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientServerBrotliRoundTrip.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientServerBrotliRoundTrip"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientServerZstdExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientServerZstdExample"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientZstdCompressionExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientZstdCompressionExample"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientServerCompressionExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ClientServerCompressionExample"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "43d35fc1db9f6531f0e33ec81a29899c61667c2c",
+    "headCommit" : "e30b8670f45ba4ad516f49474aa0a0b55ade5eac",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/TestValidateAfterInactivity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.TestValidateAfterInactivity"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e30b8670f45ba4ad516f49474aa0a0b55ade5eac",
+    "headCommit" : "ee6ebee1896f3ef00460182faccc6e96b1243b35",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalH2AsyncClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalH2AsyncExecRuntime"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncExecRuntime"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/ReleasingAsyncClientExchangeHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.ReleasingAsyncClientExchangeHandler"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientQueueCap.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientQueueCap"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilderMaxQueuedRequestsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilderMaxQueuedRequestsTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntimeQueueCapTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalH2AsyncExecRuntimeQueueCapTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntimeQueueCapTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncExecRuntimeQueueCapTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ee6ebee1896f3ef00460182faccc6e96b1243b35",
+    "headCommit" : "c37e6e590f0241dd2139a08234c909f3ebeddc1b",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestRedirects.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestRedirects"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c37e6e590f0241dd2139a08234c909f3ebeddc1b",
+    "headCommit" : "e0aa5ba3a619e5541044c55e0f60728e8e8c00d2",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e0aa5ba3a619e5541044c55e0f60728e8e8c00d2",
+    "headCommit" : "d07ff4d2fbc094582b342bcc7edb9d69f18fb30f",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCacheConformance.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.ResponseCacheConformance"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCacheConformance.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestResponseCacheConformance"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d07ff4d2fbc094582b342bcc7edb9d69f18fb30f",
+    "headCommit" : "1c96bdee3a0e5204156ad3d921c16b01b2ac90dc",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "src/site/site.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1c96bdee3a0e5204156ad3d921c16b01b2ac90dc",
+    "headCommit" : "68435f2b8e22a2465717cc39d0c40ecad8968d71",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/ChainElement.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.ChainElement"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/TlsRequiredAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.TlsRequiredAsyncExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/TlsRequiredExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TlsRequiredExec"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/TlsRequiredAsyncExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.TlsRequiredAsyncExample"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/TlsRequiredClassicExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.TlsRequiredClassicExample"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "68435f2b8e22a2465717cc39d0c40ecad8968d71",
+    "headCommit" : "d51c80e786788d3b2d7aea1a678990af6b3e6f30",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SystemDefaultCredentialsProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.SystemDefaultCredentialsProvider"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d51c80e786788d3b2d7aea1a678990af6b3e6f30",
+    "headCommit" : "af1d3e0f4f50acc0cb1dfa4c13346af8c197cecc",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "af1d3e0f4f50acc0cb1dfa4c13346af8c197cecc",
+    "headCommit" : "64608806506031bb0139f4cb8c1dae91d51976fa",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "64608806506031bb0139f4cb8c1dae91d51976fa",
+    "headCommit" : "f0e7a7eb902fb080c21a3ac857c6dcd8dd486353",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/Wire.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.Wire"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/WireTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.WireTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f0e7a7eb902fb080c21a3ac857c6dcd8dd486353",
+    "headCommit" : "17a75066306226217c826676ad925dc41f24c3ee",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/LoggingIOSession.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.LoggingIOSession"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/LoggingIOSessionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.LoggingIOSessionTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "17a75066306226217c826676ad925dc41f24c3ee",
+    "headCommit" : "3170532325909437b315ccd6639cb92a99b67a79",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3170532325909437b315ccd6639cb92a99b67a79",
+    "headCommit" : "f7c126eb96a24a5bd283ff8eeea66848849c6508",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f7c126eb96a24a5bd283ff8eeea66848849c6508",
+    "headCommit" : "f025640f7d2521741824ee5e2652ce455039c000",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncSocketTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncSocketTimeout"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSocketTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestSocketTimeout"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f025640f7d2521741824ee5e2652ce455039c000",
+    "headCommit" : "4e5ad6e29683a2648ba0a84dcb21519edd265d06",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestLinearBackoffManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TestLinearBackoffManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4e5ad6e29683a2648ba0a84dcb21519edd265d06",
+    "headCommit" : "aab60036b62439404ea1887de604cf5504b5670e",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/LoggingIOSession.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.LoggingIOSession"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/LoggingIOSessionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.LoggingIOSessionTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "aab60036b62439404ea1887de604cf5504b5670e",
+    "headCommit" : "31598133f22067cc77de551761259956abd8f5af",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/Wire.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.Wire"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/WireTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.WireTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "31598133f22067cc77de551761259956abd8f5af",
+    "headCommit" : "775d80ee0861d02fb747c6c19a5f4aaa7e935c4a",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "775d80ee0861d02fb747c6c19a5f4aaa7e935c4a",
+    "headCommit" : "5815326d73f3444d30ef2fe9612b08592e445de6",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/SystemDefaultCredentialsProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.SystemDefaultCredentialsProvider"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "5815326d73f3444d30ef2fe9612b08592e445de6",
+    "headCommit" : "6e41ddaf9461f2e739f6b9bcb352cb549a761130",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncSocketTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncSocketTimeout"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestSocketTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestSocketTimeout"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultHttpClientConnectionOperator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultHttpClientConnectionOperator"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/DefaultManagedHttpClientConnection.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.DefaultManagedHttpClientConnection"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6e41ddaf9461f2e739f6b9bcb352cb549a761130",
+    "headCommit" : "6b7f5e3842b586cfdf9ff52f9063c637de8d8411",
+    "changedFiles" : [ {
+      "path" : ".github/dependabot.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6b7f5e3842b586cfdf9ff52f9063c637de8d8411",
+    "headCommit" : "41412119dafc29dcbad31bbbd5ab8facf4aae6aa",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-testing/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/ExecSupportTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.ExecSupportTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestSystemDefaultCredentialsProvider.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.TestSystemDefaultCredentialsProvider"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "41412119dafc29dcbad31bbbd5ab8facf4aae6aa",
+    "headCommit" : "a158c2e94b0eefe8e946a19b127e3d84b4575d4d",
+    "changedFiles" : [ {
+      "path" : "httpclient5-sse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a158c2e94b0eefe8e946a19b127e3d84b4575d4d",
+    "headCommit" : "8a42b19823a290ef58c07369b5ab3c0403b704eb",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManagerBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManagerBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/ClientTlsStrategyBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/ConscryptClientTlsStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.ConscryptClientTlsStrategy"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultClientTlsStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/HttpsSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.HttpsSupport"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8a42b19823a290ef58c07369b5ab3c0403b704eb",
+    "headCommit" : "c20b31235a705d0808eb69ed2424aa6926d0b411",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/IdleConnectionEvictor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.IdleConnectionEvictor"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestIdleConnectionEvictor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.TestIdleConnectionEvictor"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c20b31235a705d0808eb69ed2424aa6926d0b411",
+    "headCommit" : "f457c8ba73fe7ea65a078f67ccabbc98a4d6bd61",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultExchangeIdGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.DefaultExchangeIdGenerator"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalAbstractHttpAsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalAbstractHttpAsyncClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalH2AsyncClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalHttpClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.InternalHttpClient"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestInternalHttpClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TestInternalHttpClient"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f457c8ba73fe7ea65a078f67ccabbc98a4d6bd61",
+    "headCommit" : "b78c2ad55dcff4228911cef3184cca8a76ef5d4b",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncTlsHandshakeTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncTlsHandshakeTimeout"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestTlsHandshakeTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestTlsHandshakeTimeout"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/tls/TlsHandshakeTimeoutServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.tls.TlsHandshakeTimeoutServer"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b78c2ad55dcff4228911cef3184cca8a76ef5d4b",
+    "headCommit" : "6af0624d62a1787f74e49137905cecff04d89bcc",
+    "changedFiles" : [ {
+      "path" : "httpclient5-fluent/src/main/java/org/apache/hc/client5/http/fluent/Async.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.fluent.Async"
+    }, {
+      "path" : "httpclient5-fluent/src/test/java/org/apache/hc/client5/http/examples/fluent/FluentAsyncCompletableFuture.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.fluent.FluentAsyncCompletableFuture"
+    }, {
+      "path" : "httpclient5-fluent/src/test/java/org/apache/hc/client5/http/examples/fluent/FluentAsyncCompletableFutureCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.fluent.FluentAsyncCompletableFutureCallback"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6af0624d62a1787f74e49137905cecff04d89bcc",
+    "headCommit" : "ab404c46af3bb68349ad8eca364f3e4e57727b6b",
+    "changedFiles" : [ {
+      "path" : "httpclient5-fluent/src/main/java/org/apache/hc/client5/http/fluent/Executor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.fluent.Executor"
+    }, {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/SseExecutor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.SseExecutor"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/example/ClientSseExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.example.ClientSseExample"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/example/ClientSseH2Example.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.example.ClientSseH2Example"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/example/SsePerfClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.example.SsePerfClient"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/example/performance/SsePerfClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.example.performance.SsePerfClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClients.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClients"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/HttpClients.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.HttpClients"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManagerBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManagerBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/ClientTlsStrategyBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/ConscryptClientTlsStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.ConscryptClientTlsStrategy"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/DefaultClientTlsStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/ssl/SSLConnectionSocketFactoryBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.SSLConnectionSocketFactoryBuilder"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientSNI.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientSNI"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientConfiguration.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ClientConfiguration"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientSNI.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ClientSNI"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientSpkiPinningExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ClientSpkiPinningExample"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ab404c46af3bb68349ad8eca364f3e4e57727b6b",
+    "headCommit" : "e20603d982430cdb5216f185498c663e9c7933b2",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ConnectionReuseDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ConnectionReuseDemo"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e20603d982430cdb5216f185498c663e9c7933b2",
+    "headCommit" : "784177e913c81e98dea840a664185f28b3b0b869",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/TestHttpCacheEntryFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.cache.TestHttpCacheEntryFactory"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/CacheControlGeneratorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheControlGeneratorTest"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/ContainsHeaderMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.ContainsHeaderMatcher"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpCacheEntryMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.HttpCacheEntryMatcher"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestAbstractSerializingAsyncCacheStorage.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestAbstractSerializingAsyncCacheStorage"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestAbstractSerializingCacheStorage.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestAbstractSerializingCacheStorage"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpAsyncCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestBasicHttpAsyncCache"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestBasicHttpCache"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestByteArrayCacheEntrySerializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestByteArrayCacheEntrySerializer"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestConditionalRequestBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestConditionalRequestBuilder"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestHttpByteArrayCacheEntrySerializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestHttpByteArrayCacheEntrySerializer"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRecommendations.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestProtocolRecommendations"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRequirements.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestProtocolRequirements"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestViaCacheGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestViaCacheGenerator"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/schedule/TestConcurrentCountMap.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.schedule.TestConcurrentCountMap"
+    }, {
+      "path" : "httpclient5-fluent/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-sse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-testing/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractHttpAsyncClientAuthenticationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.AbstractHttpAsyncClientAuthenticationTest"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractHttpAsyncFundamentalsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.AbstractHttpAsyncFundamentalsTest"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractHttpAsyncRedirectsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.AbstractHttpAsyncRedirectsTest"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractHttpReactiveFundamentalsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.AbstractHttpReactiveFundamentalsTest"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttp1Async.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestHttp1Async"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttp1AsyncMinimal.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestHttp1AsyncMinimal"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttp1Reactive.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestHttp1Reactive"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttp1ReactiveMinimal.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestHttp1ReactiveMinimal"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttp1RequestReExecution.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestHttp1RequestReExecution"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttpAsyncProtocolPolicy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestHttpAsyncProtocolPolicy"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttpAsyncRequestMultiplexing.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestHttpAsyncRequestMultiplexing"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientAuthentication.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestClientAuthentication"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientRequestReExecution.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestClientRequestReExecution"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestDefaultClientTlsStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestDefaultClientTlsStrategy"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestFutureRequestExecutionService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestFutureRequestExecutionService"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestRedirects.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestRedirects"
+    }, {
+      "path" : "httpclient5/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/ContentTypeMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ContentTypeMatcher"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/HeaderMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.HeaderMatcher"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/HeadersMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.HeadersMatcher"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/NameValuePairMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.NameValuePairMatcher"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/NameValuePairsMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.NameValuePairsMatcher"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/TestSimpleMessageBuilders.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.TestSimpleMessageBuilders"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/ContentCodingSupportTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.ContentCodingSupportTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestAuthChallengeParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.TestAuthChallengeParser"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/routing/TestRoutingSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.routing.TestRoutingSupport"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestUpgrade.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.protocol.TestRequestUpgrade"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/ssl/TestDistinguishedNameParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.ssl.TestDistinguishedNameParser"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/utils/TestDnsUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.utils.TestDnsUtils"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "784177e913c81e98dea840a664185f28b3b0b869",
+    "headCommit" : "ec0474cbda07043e5c10992b8badb67653ca047d",
+    "changedFiles" : [ {
+      "path" : "httpclient5-sse/src/main/java/org/apache/hc/client5/http/sse/impl/DefaultEventSource.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.DefaultEventSource"
+    }, {
+      "path" : "httpclient5-sse/src/test/java/org/apache/hc/client5/http/sse/impl/DefaultEventSourceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.sse.impl.DefaultEventSourceTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ec0474cbda07043e5c10992b8badb67653ca047d",
+    "headCommit" : "d8d09ed89605cbd41d759fab2626bba561602ed0",
+    "changedFiles" : [ {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/HttpClientObservationSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.HttpClientObservationSupport"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/ObservingOptions.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.ObservingOptions"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/impl/MeteredAsyncConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.MeteredAsyncConnectionManager"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/impl/MeteredConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.MeteredConnectionManager"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/impl/ObservationClassicExecInterceptor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.ObservationClassicExecInterceptor"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/interceptors/IoByteCounterExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.IoByteCounterExec"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/interceptors/TimerExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.interceptors.TimerExec"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/HttpClientObservationSupportTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.HttpClientObservationSupportTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/AsyncConnectionManagerLeaseDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.AsyncConnectionManagerLeaseDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/AsyncMetricsDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.AsyncMetricsDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/ConnectionManagerLeaseDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.ConnectionManagerLeaseDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/DnsMetricsDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.DnsMetricsDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/PoolGaugesDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.PoolGaugesDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/example/TlsMetricsDemo.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.example.TlsMetricsDemo"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/impl/MeteredConnectionManagerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.MeteredConnectionManagerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d8d09ed89605cbd41d759fab2626bba561602ed0",
+    "headCommit" : "9189d11abf60ecfae84f1d324629b4f47ead4e62",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/protocol/RequestAddCookies.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.protocol.RequestAddCookies"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/cookie/TestCookieOrigin.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.cookie.TestCookieOrigin"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/cookie/TestBasicCookieAttribHandlers.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cookie.TestBasicCookieAttribHandlers"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/protocol/TestRequestAddCookies.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.protocol.TestRequestAddCookies"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9189d11abf60ecfae84f1d324629b4f47ead4e62",
+    "headCommit" : "0a18950331ef328c4a0bc61285601a2415aba249",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestClientAuthentication.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestClientAuthentication"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/AsyncProtocolExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.AsyncProtocolExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ProtocolExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.ProtocolExec"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestAsyncProtocolExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.TestAsyncProtocolExec"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestProtocolExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TestProtocolExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0a18950331ef328c4a0bc61285601a2415aba249",
+    "headCommit" : "70b9e94076aabe8deff8ae9fa7d6d22bcd4e8089",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheControlHeaderParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheControlHeaderParser"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/CacheControlParserTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheControlParserTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "70b9e94076aabe8deff8ae9fa7d6d22bcd4e8089",
+    "headCommit" : "ede07e6ea846a0dd9d60d5505cb2d8386307e790",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/BasicMaxAgeHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cookie.BasicMaxAgeHandler"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/cookie/TestBasicCookieAttribHandlers.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cookie.TestBasicCookieAttribHandlers"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ede07e6ea846a0dd9d60d5505cb2d8386307e790",
+    "headCommit" : "a21d2d106da68fe58abdd831cd23d61b6497d757",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a21d2d106da68fe58abdd831cd23d61b6497d757",
+    "headCommit" : "8290f5ac52c436ea18520a7215cce67de1735773",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/cookie/BasicCookieStore.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.cookie.BasicCookieStore"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/cookie/SetCookie.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.cookie.SetCookie"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/cookie/BasicClientCookie.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cookie.BasicClientCookie"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/cookie/TestBasicCookieStore.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cookie.TestBasicCookieStore"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "8290f5ac52c436ea18520a7215cce67de1735773",
+    "headCommit" : "08f3fdcdd33846aa3919ae969cac7d7318e4d60c",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/sync/TestServerResources.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.sync.TestServerResources"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestConnectionManagement.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestConnectionManagement"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "08f3fdcdd33846aa3919ae969cac7d7318e4d60c",
+    "headCommit" : "cee67d86809aa23577968f9e7e7bf922a9892512",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cee67d86809aa23577968f9e7e7bf922a9892512",
+    "headCommit" : "795ef1fb55b76ffe64a095a93c8352e6a732a6e2",
+    "changedFiles" : [ {
+      "path" : ".mvn/wrapper/maven-wrapper.properties",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "795ef1fb55b76ffe64a095a93c8352e6a732a6e2",
+    "headCommit" : "09ff1889885f56812443f127a8a69f2d06b79f23",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "09ff1889885f56812443f127a8a69f2d06b79f23",
+    "headCommit" : "4325ba13a5b470ded091e5c977f4562295cb36bd",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4325ba13a5b470ded091e5c977f4562295cb36bd",
+    "headCommit" : "9a2a24bdc2e7f1ae8750194ec5b2f9cd79728d38",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9a2a24bdc2e7f1ae8750194ec5b2f9cd79728d38",
+    "headCommit" : "323251c69c4e56689c0e962995271403f5693bd2",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalH2AsyncExecRuntime"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/MinimalH2AsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.MinimalH2AsyncClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "323251c69c4e56689c0e962995271403f5693bd2",
+    "headCommit" : "63c5ebd813a489fbb4e312e0bdeec5fd4ceefcfc",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "63c5ebd813a489fbb4e312e0bdeec5fd4ceefcfc",
+    "headCommit" : "1aac37625715cfa1faf4ccf824f3cec95b628ba2",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1aac37625715cfa1faf4ccf824f3cec95b628ba2",
+    "headCommit" : "89669060b9688104054630fd8609528117a05428",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/http/impl/async/InternalTestHttpAsyncExecRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalTestHttpAsyncExecRuntime"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestInternalHttpAsyncExecRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestInternalHttpAsyncExecRuntime"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncServerBootstrap.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.async.TestAsyncServerBootstrap"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncExecRuntime"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "89669060b9688104054630fd8609528117a05428",
+    "headCommit" : "558d851b8512c6163ce324f9ad765b39286d8faa",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/websocket/H2WebSocketEchoIT.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.websocket.H2WebSocketEchoIT"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/websocket/WebSocketClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.websocket.WebSocketClientTest"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/websocket/performance/WsPerfBatchRunner.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.websocket.performance.WsPerfBatchRunner"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/websocket/performance/WsPerfEchoServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.websocket.performance.WsPerfEchoServer"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/websocket/performance/WsPerfHarness.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.websocket.performance.WsPerfHarness"
+    }, {
+      "path" : "httpclient5-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/api/WebSocket.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.api.WebSocket"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/api/WebSocketClientConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.api.WebSocketClientConfig"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/api/WebSocketListener.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.api.WebSocketListener"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/api/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.api.package-info"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/CloseableWebSocketClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.CloseableWebSocketClient"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/WebSocketClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.WebSocketClient"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/WebSocketClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.WebSocketClientBuilder"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/WebSocketClients.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.WebSocketClients"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/impl/DefaultWebSocketClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.DefaultWebSocketClient"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/impl/connector/WebSocketEndpointConnector.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.connector.WebSocketEndpointConnector"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/impl/connector/WebSocketProtocolConnector.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.connector.WebSocketProtocolConnector"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/impl/connector/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.connector.package-info"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/impl/logging/WsLoggingExceptionCallback.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.logging.WsLoggingExceptionCallback"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/impl/logging/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.logging.package-info"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/impl/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.package-info"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/impl/protocol/Http1UpgradeProtocol.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.protocol.Http1UpgradeProtocol"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/impl/protocol/Http2ExtendedConnectProtocol.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.protocol.Http2ExtendedConnectProtocol"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/impl/protocol/WebSocketProtocolStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.protocol.WebSocketProtocolStrategy"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/impl/protocol/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.protocol.package-info"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.package-info"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.package-info"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/transport/DataStreamChannelTransport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.DataStreamChannelTransport"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/transport/IOSessionTransport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.IOSessionTransport"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/transport/OutboundFlowSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.OutboundFlowSupport"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/transport/WebSocketFrameDecoder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WebSocketFrameDecoder"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/transport/WebSocketIoHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WebSocketIoHandler"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/transport/WebSocketSessionEngine.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WebSocketSessionEngine"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/transport/WebSocketTransport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WebSocketTransport"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/transport/WebSocketUpgrader.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WebSocketUpgrader"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/transport/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.package-info"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/PerMessageDeflateExtension.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.PerMessageDeflateExtension"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/PerMessageDeflateExtensionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.PerMessageDeflateExtensionFactory"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketBufferOps.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketBufferOps"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketCloseStatus.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketCloseStatus"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketConfig"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketConstants.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketConstants"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketException"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketExtension.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtension"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketExtensionData.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensionData"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketExtensionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensionFactory"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketExtensionNegotiation.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensionNegotiation"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketExtensionRegistry.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensionRegistry"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketExtensions.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensions"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketFrame.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrame"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketFrameReader.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameReader"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketFrameType.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameType"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketFrameWriter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameWriter"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketHandler"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketHandshake.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketHandshake"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketSession.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketSession"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/exceptions/WebSocketProtocolException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.exceptions.WebSocketProtocolException"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/exceptions/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.exceptions.package-info"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/extension/ExtensionChain.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.ExtensionChain"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/extension/PerMessageDeflate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.PerMessageDeflate"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/extension/WebSocketExtensionChain.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.WebSocketExtensionChain"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/extension/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.package-info"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/frame/FrameHeaderBits.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.frame.FrameHeaderBits"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/frame/FrameOpcode.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.frame.FrameOpcode"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/frame/WebSocketFrameWriter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.frame.WebSocketFrameWriter"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/frame/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.frame.package-info"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/message/CloseCodec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.message.CloseCodec"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/message/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.message.package-info"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.package-info"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketContextKeys.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketContextKeys"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketH2Server.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketH2Server"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketH2ServerBootstrap.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketH2ServerBootstrap"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketH2ServerExchangeHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketH2ServerExchangeHandler"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketHttpService.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketHttpService"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServer"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketServerBootstrap.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerBootstrap"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketServerConnection.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerConnection"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketServerConnectionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerConnectionFactory"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketServerProcessor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerProcessor"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketServerRequestHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerRequestHandler"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/api/WebSocketClientConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.api.WebSocketClientConfigTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/client/WebSocketClientBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.WebSocketClientBuilderTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/client/WebSocketClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.WebSocketClientTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/client/impl/WebSocketClientImplTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.WebSocketClientImplTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/client/impl/connector/WebSocketEndpointConnectorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.connector.WebSocketEndpointConnectorTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/client/impl/protocol/Http1UpgradeProtocolExtensionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.protocol.Http1UpgradeProtocolExtensionTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/client/impl/protocol/Http2ExtendedConnectProtocolTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.protocol.Http2ExtendedConnectProtocolTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/example/WebSocketEchoClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.example.WebSocketEchoClient"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/example/WebSocketEchoServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.example.WebSocketEchoServer"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/example/WebSocketH2EchoClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.example.WebSocketH2EchoClient"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/example/WebSocketH2EchoServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.example.WebSocketH2EchoServer"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/example/WebSocketH2TlsEchoClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.example.WebSocketH2TlsEchoClient"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/example/WebSocketH2TlsEchoServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.example.WebSocketH2TlsEchoServer"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/transport/OutboundFlowSupportTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.OutboundFlowSupportTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/transport/StubTransport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.StubTransport"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/transport/WebSocketInboundRfcTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WebSocketInboundRfcTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/transport/WebSocketIoHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WebSocketIoHandlerTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/transport/WebSocketUpgraderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WebSocketUpgraderTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/transport/WsDecoderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WsDecoderTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/transport/WsInboundBufferTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WsInboundBufferTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/transport/WsInboundCoverageTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WsInboundCoverageTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/transport/WsOutboundCompressionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WsOutboundCompressionTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/transport/WsOutboundQueueTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WsOutboundQueueTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/PerMessageDeflateExtensionFactoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.PerMessageDeflateExtensionFactoryTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/PerMessageDeflateExtensionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.PerMessageDeflateExtensionTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketCloseStatusTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketCloseStatusTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketConfigTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketConfigTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketConstantsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketConstantsTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketExceptionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExceptionTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketExtensionDataTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensionDataTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketExtensionNegotiationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensionNegotiationTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketExtensionRegistryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensionRegistryTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketExtensionsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensionsTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketFrameCodecTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameCodecTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketFrameReaderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameReaderTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketFrameTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketFrameTypeTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameTypeTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketFrameWriterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameWriterTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketHandshakeTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketHandshakeTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketSessionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketSessionTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/exceptions/WebSocketProtocolExceptionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.exceptions.WebSocketProtocolExceptionTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/extension/ExtensionChainTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.ExtensionChainTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/extension/MessageDeflateTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.MessageDeflateTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/frame/FrameHeaderBitsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.frame.FrameHeaderBitsTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/frame/FrameOpcodeTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.frame.FrameOpcodeTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/frame/FrameWriterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.frame.FrameWriterTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/message/CloseCodecTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.message.CloseCodecTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/server/WebSocketContextKeysTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketContextKeysTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/server/WebSocketH2ServerBootstrapTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketH2ServerBootstrapTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/server/WebSocketH2ServerExchangeHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketH2ServerExchangeHandlerTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/server/WebSocketH2ServerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketH2ServerTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/server/WebSocketHttpServiceTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketHttpServiceTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/server/WebSocketServerBootstrapTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerBootstrapTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/server/WebSocketServerConnectionFactoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerConnectionFactoryTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/server/WebSocketServerProcessorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerProcessorTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/server/WebSocketServerRequestHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerRequestHandlerTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/server/WebSocketServerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/resources/log4j2.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-websocket/src/test/resources/test.keystore",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "558d851b8512c6163ce324f9ad765b39286d8faa",
+    "headCommit" : "c586766a7cb2007c20329010db6a5fc0b16ca3b3",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/ProtocolSwitchStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.ProtocolSwitchStrategy"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestProtocolSwitchStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.TestProtocolSwitchStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c586766a7cb2007c20329010db6a5fc0b16ca3b3",
+    "headCommit" : "e005c48465068e811c1533b4232df05a3239cd3a",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedHttpResponseGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CachedHttpResponseGenerator"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedResponseSuitabilityChecker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CachedResponseSuitabilityChecker"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.ResponseCachingPolicy"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachedHttpResponseGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCachedHttpResponseGenerator"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachedResponseSuitabilityChecker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCachedResponseSuitabilityChecker"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRequirements.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestProtocolRequirements"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestResponseCachingPolicy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e005c48465068e811c1533b4232df05a3239cd3a",
+    "headCommit" : "797374c878ceb8733746f745b077c60300a4baa6",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttp2StreamResponseTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestHttp2StreamResponseTimeout"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestInternalHttpAsyncExecRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestInternalHttpAsyncExecRuntime"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncExecRuntime"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/nio/AsyncConnectionEndpoint.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.nio.AsyncConnectionEndpoint"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "797374c878ceb8733746f745b077c60300a4baa6",
+    "headCommit" : "0beb0f2b31bec07adc78fa8e92a906d1a739a6dc",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/config/ConnectionConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.config.ConnectionConfig"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0beb0f2b31bec07adc78fa8e92a906d1a739a6dc",
+    "headCommit" : "51ce3ebfc2fc0f268667e822f75ac85020c64be2",
+    "changedFiles" : [ {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/transport/WebSocketSessionEngine.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WebSocketSessionEngine"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/extension/ExtensionChain.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.ExtensionChain"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/extension/PerMessageDeflate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.PerMessageDeflate"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/extension/WebSocketExtensionChain.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.WebSocketExtensionChain"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/extension/MessageDeflateTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.MessageDeflateTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "51ce3ebfc2fc0f268667e822f75ac85020c64be2",
+    "headCommit" : "3d9285ae72b20b768d0bf69cf5f838eb48d2c002",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/AuthChallengeParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.AuthChallengeParser"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/AuthenticationHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.AuthenticationHandler"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestAuthChallengeParser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.TestAuthChallengeParser"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3d9285ae72b20b768d0bf69cf5f838eb48d2c002",
+    "headCommit" : "77d7d17b719e482d04b43d9d2b6f336cd2d6f665",
+    "changedFiles" : [ {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/PerMessageDeflateExtension.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.PerMessageDeflateExtension"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketExtension.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtension"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketFrameReader.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameReader"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketH2ServerExchangeHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketH2ServerExchangeHandler"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/PerMessageDeflateExtensionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.PerMessageDeflateExtensionTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "77d7d17b719e482d04b43d9d2b6f336cd2d6f665",
+    "headCommit" : "726eac2323d370435d8afca1e0540aa099927f18",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultAuthenticationStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.DefaultAuthenticationStrategy"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/AuthenticationHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.AuthenticationHandler"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/ScramScheme.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.ScramScheme"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientScramAuthentication.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ClientScramAuthentication"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestAuthenticationHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.TestAuthenticationHandler"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestScramScheme.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.TestScramScheme"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "726eac2323d370435d8afca1e0540aa099927f18",
+    "headCommit" : "f75d2833e6d5f6127c13b5c6911bc07830bb9382",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/SimpleBody.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.SimpleBody"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/SimpleBodyTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.SimpleBodyTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f75d2833e6d5f6127c13b5c6911bc07830bb9382",
+    "headCommit" : "2c36560fad44ad15ed3d93d44caf7bdd16840bb4",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/ProtocolSwitchStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.ProtocolSwitchStrategy"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestProtocolSwitchStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.TestProtocolSwitchStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2c36560fad44ad15ed3d93d44caf7bdd16840bb4",
+    "headCommit" : "4b26224c33e3854454ab95fc69f850b59322a1c3",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/tls/TlsHandshakeTimeoutServer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.tls.TlsHandshakeTimeoutServer"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4b26224c33e3854454ab95fc69f850b59322a1c3",
+    "headCommit" : "1c5d8236392f0b0d45708bed6b4d746e7f7bcbb6",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncConnectionTimeouts.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestConnectionTimeouts.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestConnectionTimeouts"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1c5d8236392f0b0d45708bed6b4d746e7f7bcbb6",
+    "headCommit" : "022c6872688901dc5e26589f65769a629d2cca06",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "022c6872688901dc5e26589f65769a629d2cca06",
+    "headCommit" : "2ee445728efa81ea3cd6003faa6a9a4cca488015",
+    "changedFiles" : [ {
+      "path" : "httpclient5-jakarta-rest-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/ClientResourceMethod.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.ClientResourceMethod"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientBuilder"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestClientResponseException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientResponseException"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestInvocationHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestInvocationHandler"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/StringResponseConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.StringResponseConsumer"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/package-info.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.package-info"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/ClientResourceMethodTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.ClientResourceMethodTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientBuilderTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientH2Test.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientH2Test"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientIntegrationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientIntegrationTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestInvocationHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestInvocationHandlerTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/examples/RestClientMain.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.examples.RestClientMain"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2ee445728efa81ea3cd6003faa6a9a4cca488015",
+    "headCommit" : "b3451829e63aa9b866e5c711b6789c00e41943e9",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/http/impl/async/InternalTestHttpAsyncExecRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalTestHttpAsyncExecRuntime"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalH2AsyncClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalH2AsyncExecRuntime"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncExecRuntime"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/ReleasingAsyncClientExchangeHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.ReleasingAsyncClientExchangeHandler"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/SharedRequestExecutionQueue.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.SharedRequestExecutionQueue"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientQueueCap.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientQueueCap"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncSharedClientQueueExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncSharedClientQueueExample"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/H2SharedClientQueueLocalExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.H2SharedClientQueueLocalExample"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilderMaxQueuedRequestsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilderMaxQueuedRequestsTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntimeQueueCapTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalH2AsyncExecRuntimeQueueCapTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntimeQueueCapTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncExecRuntimeQueueCapTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b3451829e63aa9b866e5c711b6789c00e41943e9",
+    "headCommit" : "c21e825aec29b6cbbfe58e12b6b3aa87f948a751",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalH2AsyncClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalH2AsyncExecRuntime"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncClient"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntime.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncExecRuntime"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/SharedRequestExecutionQueue.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.SharedRequestExecutionQueue"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestSharedRequestExecutionQueue.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.TestSharedRequestExecutionQueue"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c21e825aec29b6cbbfe58e12b6b3aa87f948a751",
+    "headCommit" : "f275252ab220587c81b59fa0744fd50e767f386d",
+    "changedFiles" : [ {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientBuilder"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestClientResponse.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientResponse"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestInvocationHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestInvocationHandler"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientResponseTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientResponseTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f275252ab220587c81b59fa0744fd50e767f386d",
+    "headCommit" : "407776b3d9afef82a395317bbfad486057eb7946",
+    "changedFiles" : [ {
+      "path" : "README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "407776b3d9afef82a395317bbfad486057eb7946",
+    "headCommit" : "12f7c149a64c88e4f19c05e1b162dbe6bed3c975",
+    "changedFiles" : [ {
+      "path" : ".asf.yaml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "12f7c149a64c88e4f19c05e1b162dbe6bed3c975",
+    "headCommit" : "f069c136445103bb0691b205199bdfa703e6160b",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultHttpRequestRetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultHttpRequestRetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.TestDefaultHttpRequestRetryStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "f069c136445103bb0691b205199bdfa703e6160b",
+    "headCommit" : "6dd7b5ddae2a452ead910007ed29790f01c4e047",
+    "changedFiles" : [ {
+      "path" : "httpclient5-jakarta-rest-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/ClientResourceMethod.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.ClientResourceMethod"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/PathSegment.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.PathSegment"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/ResourceIfaceScanner.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.ResourceIfaceScanner"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/ResourceMethod.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.ResourceMethod"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/ResourceParam.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.ResourceParam"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientBuilder"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestInvocationHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestInvocationHandler"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestResourceException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestResourceException"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/ClientResourceMethodTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.ClientResourceMethodTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/ResourceIfaceScannerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.ResourceIfaceScannerTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientBuilderTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestInvocationHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestInvocationHandlerTest"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "6dd7b5ddae2a452ead910007ed29790f01c4e047",
+    "headCommit" : "599eb09207d64126967645b40bb2e9b507c6ce25",
+    "changedFiles" : [ {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientBuilderTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientH2Test.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientH2Test"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientIntegrationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientIntegrationTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientResponseTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientResponseTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestInvocationHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestInvocationHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "599eb09207d64126967645b40bb2e9b507c6ce25",
+    "headCommit" : "96897cdbf2d3cc8b8cfa80e3b59d150a51e123f3",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/validator/ETag.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.validator.ETag"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "96897cdbf2d3cc8b8cfa80e3b59d150a51e123f3",
+    "headCommit" : "0d5d05fc7a55afb6c69dc360a0ac216bab3ad26f",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/utils/DateUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.utils.DateUtils"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/utils/TestDateUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.utils.TestDateUtils"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0d5d05fc7a55afb6c69dc360a0ac216bab3ad26f",
+    "headCommit" : "b6dab493cb37306e719f0069420ea037e54d5bd0",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.AsyncCachingExec"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheConfig"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheRequestCollapser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheRequestCollapser"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/example/AsyncClientCacheRequestCollapsing.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.cache.example.AsyncClientCacheRequestCollapsing"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestAsyncCachingExecRequestCollapsing.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestAsyncCachingExecRequestCollapsing"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheRequestCollapser.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCacheRequestCollapser"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/AsyncClientCacheRequestCollapsingSmokeTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.extension.async.AsyncClientCacheRequestCollapsingSmokeTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b6dab493cb37306e719f0069420ea037e54d5bd0",
+    "headCommit" : "594fd4cb30acb673430f7c892182a46bf26f852e",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/example/AsyncClientCacheRequestCollapsing.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.cache.example.AsyncClientCacheRequestCollapsing"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "594fd4cb30acb673430f7c892182a46bf26f852e",
+    "headCommit" : "d989173f9e9c67e1710be47ac44a4617507e1c53",
+    "changedFiles" : [ {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestClientResponse.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientResponse"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestInvocationHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestInvocationHandler"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestResponseConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestResponseConsumer"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientResponseTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientResponseTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "d989173f9e9c67e1710be47ac44a4617507e1c53",
+    "headCommit" : "4b0cbd4bf94a92b703985630aa42144eed20402c",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/DecompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.compress.DecompressingEntity"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/TestDecompressingEntity.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.TestDecompressingEntity"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "4b0cbd4bf94a92b703985630aa42144eed20402c",
+    "headCommit" : "992faa51146dbd1aa22587cd1708e03f5b433e48",
+    "changedFiles" : [ {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestClientResponse.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientResponse"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestContent.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestContent"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestContentConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestContentConsumer"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestInvocationHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestInvocationHandler"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestResponseConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestResponseConsumer"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientResponseTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientResponseTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestContentConsumerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestContentConsumerTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestContentTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestContentTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "992faa51146dbd1aa22587cd1708e03f5b433e48",
+    "headCommit" : "59ef293558d773fc358fe6a4fd608f2ddf8f09ea",
+    "changedFiles" : [ {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestClientBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientBuilder"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestClientResponseException.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientResponseException"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestInvocationHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestInvocationHandler"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestResponseConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestResponseConsumer"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/StringResponseConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.StringResponseConsumer"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientBuilderTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientH2Test.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientH2Test"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "59ef293558d773fc358fe6a4fd608f2ddf8f09ea",
+    "headCommit" : "cef10a62df9aec1a7129ab83a63a251126523d86",
+    "changedFiles" : [ {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestInvocationHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestInvocationHandler"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientBuilderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "cef10a62df9aec1a7129ab83a63a251126523d86",
+    "headCommit" : "afba680b24370b85430e5314512fb2e955dd1b88",
+    "changedFiles" : [ {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/impl/HttpClientObservationContext.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.HttpClientObservationContext"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/impl/ObservationAsyncExecInterceptor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.ObservationAsyncExecInterceptor"
+    }, {
+      "path" : "httpclient5-observation/src/main/java/org/apache/hc/client5/http/observation/impl/ObservationClassicExecInterceptor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.ObservationClassicExecInterceptor"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/impl/ObservationAsyncExecInterceptorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.ObservationAsyncExecInterceptorTest"
+    }, {
+      "path" : "httpclient5-observation/src/test/java/org/apache/hc/client5/http/observation/impl/ObservationClassicExecInterceptorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.observation.impl.ObservationClassicExecInterceptorTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "afba680b24370b85430e5314512fb2e955dd1b88",
+    "headCommit" : "585893d80953eca17a2fed7d035843f934c94c96",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/ProtocolSwitchStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.ProtocolSwitchStrategy"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/io/PoolingHttpClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManager.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManager"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/utils/DateUtils.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.utils.DateUtils"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/validator/ETag.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.validator.ETag"
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "585893d80953eca17a2fed7d035843f934c94c96",
+    "headCommit" : "0fde2d4ad446f600290dfbc060bd11c05775c3fd",
+    "changedFiles" : [ {
+      "path" : "httpclient5-fluent/src/main/java/org/apache/hc/client5/http/fluent/Request.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.fluent.Request"
+    }, {
+      "path" : "httpclient5-fluent/src/test/java/org/apache/hc/client5/http/fluent/TestRequest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.fluent.TestRequest"
+    }, {
+      "path" : "httpclient5-testing/src/main/java/org/apache/hc/client5/testing/classic/EchoHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.classic.EchoHandler"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestRedirects.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestRedirects"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/SimpleRequestBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.SimpleRequestBuilder"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/classic/methods/HttpQuery.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.classic.methods.HttpQuery"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/TestSimpleMessageBuilders.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.TestSimpleMessageBuilders"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/classic/methods/TestHttpRequestBase.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.classic.methods.TestHttpRequestBase"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultHttpRequestRetryStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.TestDefaultHttpRequestRetryStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "0fde2d4ad446f600290dfbc060bd11c05775c3fd",
+    "headCommit" : "77641d68a7bd119abaf8a5d1ecac46626dfa4ec9",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "77641d68a7bd119abaf8a5d1ecac46626dfa4ec9",
+    "headCommit" : "06aac6df0b80c721e8025da15b4967f714409474",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingAsyncDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingAsyncDataConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingBrotliDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingGzipDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingGzipDataConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingZstdDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingZstdDataConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/ContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.ContentCompressionAsyncExec"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/TestInflatingGzipDataConsumerNullDownstream.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.TestInflatingGzipDataConsumerNullDownstream"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/TestContentCompressionAsyncExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.async.TestContentCompressionAsyncExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "06aac6df0b80c721e8025da15b4967f714409474",
+    "headCommit" : "da6f1b279d2795f72e81c6062386359927c96f3b",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/AbstractMultipartFormat.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.AbstractMultipartFormat"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.HttpRFC7578Multipart"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578MultipartTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.entity.mime.HttpRFC7578MultipartTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "da6f1b279d2795f72e81c6062386359927c96f3b",
+    "headCommit" : "62716cf44edead47a8ba82a71142e0e5e170c05e",
+    "changedFiles" : [ {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/ResourceIfaceScanner.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.ResourceIfaceScanner"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/RestInvocationHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestInvocationHandler"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientBuilderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientBuilderTest"
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientIntegrationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.RestClientIntegrationTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "62716cf44edead47a8ba82a71142e0e5e170c05e",
+    "headCommit" : "17079a128b9de9b43c7b96f650f36a7f714ef995",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "17079a128b9de9b43c7b96f650f36a7f714ef995",
+    "headCommit" : "649c849ee431f8fc42515ea490d328bf2ab9cc21",
+    "changedFiles" : [ {
+      "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/ResourceIfaceScanner.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.rest.ResourceIfaceScanner"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "649c849ee431f8fc42515ea490d328bf2ab9cc21",
+    "headCommit" : "7f316c08dd447c88f4b151820523f884dac69db5",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheEntryFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.cache.HttpCacheEntryFactory"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpAsyncCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.BasicHttpAsyncCache"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.BasicHttpCache"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheKeyGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheKeyGenerator"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheSupport"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedResponseSuitabilityChecker.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CachedResponseSuitabilityChecker"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpCacheSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.HttpCacheSupport"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheKeyGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCacheKeyGenerator"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheSupport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCacheSupport"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7f316c08dd447c88f4b151820523f884dac69db5",
+    "headCommit" : "3a46ebc02afa9e9530d1b289c9ac9c96e2aa7727",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.AsyncCachingExec"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpAsyncCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.BasicHttpAsyncCache"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.BasicHttpCache"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CachingExec"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ConditionalRequestBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.ConditionalRequestBuilder"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpAsyncCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.HttpAsyncCache"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.HttpCache"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpAsyncCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestBasicHttpAsyncCache"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestBasicHttpCache"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCachingExecChain"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestConditionalRequestBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestConditionalRequestBuilder"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestProtocolRequirements.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestProtocolRequirements"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "3a46ebc02afa9e9530d1b289c9ac9c96e2aa7727",
+    "headCommit" : "b3676f3a78ac854451b19f29409cf62550f3c3e8",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.AsyncCachingExec"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CachingExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b3676f3a78ac854451b19f29409cf62550f3c3e8",
+    "headCommit" : "7978d713719ec79673a0d51b50f25bdc793ad079",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultRedirectStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.DefaultRedirectStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7978d713719ec79673a0d51b50f25bdc793ad079",
+    "headCommit" : "43cb5c3c60c2fd3275ad8eab3d66a009449093c3",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultRedirectStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.DefaultRedirectStrategy"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultRedirectStrategy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.TestDefaultRedirectStrategy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "43cb5c3c60c2fd3275ad8eab3d66a009449093c3",
+    "headCommit" : "1e18d54bb0fefbfd5c96d7f7fd7af3668d8e5df9",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.AsyncCachingExec"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestAsyncCachingExecChain.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestAsyncCachingExecChain"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "1e18d54bb0fefbfd5c96d7f7fd7af3668d8e5df9",
+    "headCommit" : "66b541b8cd7da3f061da496500a22b9ac65a8916",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.AsyncCachingExec"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpAsyncCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.BasicHttpAsyncCache"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.BasicHttpCache"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheKeyGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheKeyGenerator"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpAsyncCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestBasicHttpAsyncCache"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestBasicHttpCache"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheKeyGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCacheKeyGenerator"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "66b541b8cd7da3f061da496500a22b9ac65a8916",
+    "headCommit" : "a9f86cee5fb595a166e8af121c4cd8b542bc14bf",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/depsreview.yaml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a9f86cee5fb595a166e8af121c4cd8b542bc14bf",
+    "headCommit" : "e7b2407c96fb2bc3c8f4e0552c96a2bd55ddb563",
+    "changedFiles" : [ {
+      "path" : "httpclient5-sse/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-websocket/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "e7b2407c96fb2bc3c8f4e0552c96a2bd55ddb563",
+    "headCommit" : "c5bce183828e51affbf481bddf00afb05652dd7d",
+    "changedFiles" : [ {
+      "path" : "httpclient5-jakarta-rest-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c5bce183828e51affbf481bddf00afb05652dd7d",
+    "headCommit" : "ad3320908d5b2a629d2c3a54f90b423be00a41f1",
+    "changedFiles" : [ {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ad3320908d5b2a629d2c3a54f90b423be00a41f1",
+    "headCommit" : "2d077f2a30aa5729662837f153ad7c532aa36f9c",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.AsyncCachingExec"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CachingExec"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.ResponseCachingPolicy"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestAsyncCachingExecRequestNoStore.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestAsyncCachingExecRequestNoStore"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCachingExecChain"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestResponseCachingPolicy"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "2d077f2a30aa5729662837f153ad7c532aa36f9c",
+    "headCommit" : "a50d07a22655e1c1739e49f16a53ecd1e6c50fb8",
+    "changedFiles" : [ {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketFrameReader.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameReader"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketFrameReaderTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameReaderTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a50d07a22655e1c1739e49f16a53ecd1e6c50fb8",
+    "headCommit" : "b1defb3113331aa11eece29d4504778e6a326304",
+    "changedFiles" : [ {
+      "path" : "README.md",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.AsyncCachingExec"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheKeyGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheKeyGenerator"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheableRequestPolicy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheableRequestPolicy"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CachingExec"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.CachingExecBase"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.ResponseCachingPolicy"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestAsyncCachingExecQuery.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestAsyncCachingExecQuery"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheKeyGenerator.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCacheKeyGenerator"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheableRequestPolicy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCacheableRequestPolicy"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCachingExecChain"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestResponseCachingPolicy"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientQueryMethod.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.ClientQueryMethod"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b1defb3113331aa11eece29d4504778e6a326304",
+    "headCommit" : "ebac9512f555c4a355cad3f59ef2db69b597cc97",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/ContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.ContentCompressionExec"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/classic/InternalHttpClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.InternalHttpClient"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/classic/TestContentCompressionExec.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.classic.TestContentCompressionExec"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ebac9512f555c4a355cad3f59ef2db69b597cc97",
+    "headCommit" : "9816640dd004ebf8e122c32f000ed4d413c2d7ab",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncConnectionManagement.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncConnectionManagement"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestConnectionManagement.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.sync.TestConnectionManagement"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "9816640dd004ebf8e122c32f000ed4d413c2d7ab",
+    "headCommit" : "7cb189efb48388e5be99498bd6fa0e19008a6041",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "7cb189efb48388e5be99498bd6fa0e19008a6041",
+    "headCommit" : "88c62e7cfc680ad83096f0165c018272abd28c4b",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingAsyncDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingAsyncDataConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingBrotliDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingCapacityChannel.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingCapacityChannel"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingGzipDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingGzipDataConsumer"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingZstdDataConsumer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingZstdDataConsumer"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/InflatingBrotliDataConsumerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumerTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/InflatingCapacityChannelTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingCapacityChannelTest"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientInflateCapacityExample.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientInflateCapacityExample"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "88c62e7cfc680ad83096f0165c018272abd28c4b",
+    "headCommit" : "a4e525dd85fdbcb9e6f062180c34ff7b58a4fa48",
+    "changedFiles" : [ {
+      "path" : ".github/workflows/maven.yml",
+      "kind" : "INERT",
+      "changedClassName" : null
+    }, {
+      "path" : "httpclient5-jakarta-rest-client/pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    }, {
+      "path" : "pom.xml",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "a4e525dd85fdbcb9e6f062180c34ff7b58a4fa48",
+    "headCommit" : "c4eb7e5a4fa095c334391138d0462c9674d99984",
+    "changedFiles" : [ {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheEntry.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.cache.HttpCacheEntry"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheEntryFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.cache.HttpCacheEntryFactory"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpAsyncCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.BasicHttpAsyncCache"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.BasicHttpCache"
+    }, {
+      "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpByteArrayCacheEntrySerializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.HttpByteArrayCacheEntrySerializer"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/TestHttpCacheEntryFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.cache.TestHttpCacheEntryFactory"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpCacheEntryMatcher.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.HttpCacheEntryMatcher"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpAsyncCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestBasicHttpAsyncCache"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpCache.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestBasicHttpCache"
+    }, {
+      "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestHttpByteArrayCacheEntrySerializer.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestHttpByteArrayCacheEntrySerializer"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c4eb7e5a4fa095c334391138d0462c9674d99984",
+    "headCommit" : "38e5063b5bc3de494413581e27063a8c89cc224b",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttp2StreamResponseTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestHttp2StreamResponseTimeout"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "38e5063b5bc3de494413581e27063a8c89cc224b",
+    "headCommit" : "b1c4b2086c59c87ed58e1a0790d49b34a9eb4ac7",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/AbstractHttpReactiveFundamentalsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.AbstractHttpReactiveFundamentalsTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "b1c4b2086c59c87ed58e1a0790d49b34a9eb4ac7",
+    "headCommit" : "c84facd020dccbe5644a8a1b50e18d84bc88da87",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestHttp2StreamResponseTimeout.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.async.TestHttp2StreamResponseTimeout"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "c84facd020dccbe5644a8a1b50e18d84bc88da87",
+    "headCommit" : "23a70f93fa95da83e679ef825a529bed88506031",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/auth/BearerScheme.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.BearerScheme"
+    }, {
+      "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/auth/TestBearerScheme.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.auth.TestBearerScheme"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "23a70f93fa95da83e679ef825a529bed88506031",
+    "headCommit" : "920be79d1573a79487a48b9c8d29fe6e2d9fee5d",
+    "changedFiles" : [ {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/websocket/H2WebSocketEchoIT.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.websocket.H2WebSocketEchoIT"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/websocket/WebSocketClientTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.websocket.WebSocketClientTest"
+    }, {
+      "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/websocket/performance/WsPerfHarness.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.testing.websocket.performance.WsPerfHarness"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/api/WebSocketClientConfig.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.api.WebSocketClientConfig"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/impl/protocol/Http1UpgradeProtocol.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.protocol.Http1UpgradeProtocol"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/client/impl/protocol/Http2ExtendedConnectProtocol.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.protocol.Http2ExtendedConnectProtocol"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/transport/DataStreamChannelTransport.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.DataStreamChannelTransport"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/client5/http/websocket/transport/WebSocketSessionEngine.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WebSocketSessionEngine"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/PerMessageDeflateExtension.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.PerMessageDeflateExtension"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/PerMessageDeflateExtensionFactory.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.PerMessageDeflateExtensionFactory"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketExtension.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtension"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketExtensionNegotiation.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensionNegotiation"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketExtensionRegistry.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensionRegistry"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketExtensions.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensions"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketFrameReader.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameReader"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/WebSocketFrameWriter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameWriter"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/extension/ExtensionChain.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.ExtensionChain"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/extension/PerMessageDeflate.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.PerMessageDeflate"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/extension/WebSocketExtensionChain.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.WebSocketExtensionChain"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/frame/WebSocketFrameWriter.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.frame.WebSocketFrameWriter"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketH2ServerExchangeHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketH2ServerExchangeHandler"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketServerProcessor.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerProcessor"
+    }, {
+      "path" : "httpclient5-websocket/src/main/java/org/apache/hc/core5/websocket/server/WebSocketServerRequestHandler.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerRequestHandler"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/client/impl/protocol/Http1UpgradeProtocolExtensionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.client.impl.protocol.Http1UpgradeProtocolExtensionTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/example/WebSocketEchoClient.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.example.WebSocketEchoClient"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/transport/DataStreamChannelTransportTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.DataStreamChannelTransportTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/client5/http/websocket/transport/WebSocketInboundRfcGapTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.websocket.transport.WebSocketInboundRfcGapTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/PerMessageDeflateExtensionFactoryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.PerMessageDeflateExtensionFactoryTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/PerMessageDeflateExtensionTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.PerMessageDeflateExtensionTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketExtensionNegotiationTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensionNegotiationTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketExtensionRegistryTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensionRegistryTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketExtensionsTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketExtensionsTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/WebSocketFrameWriterTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.WebSocketFrameWriterTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/extension/ExtensionChainTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.ExtensionChainTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/extension/MessageDeflateTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.MessageDeflateTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/extension/PerMessageDeflateFragmentedRoundTripTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.extension.PerMessageDeflateFragmentedRoundTripTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/server/WebSocketH2ServerExchangeHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketH2ServerExchangeHandlerTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/server/WebSocketServerProcessorTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerProcessorTest"
+    }, {
+      "path" : "httpclient5-websocket/src/test/java/org/apache/hc/core5/websocket/server/WebSocketServerRequestHandlerTest.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.core5.websocket.server.WebSocketServerRequestHandlerTest"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "920be79d1573a79487a48b9c8d29fe6e2d9fee5d",
+    "headCommit" : "ab543f1853f0f7233bd8fbdf8771e6ddea702f6d",
+    "changedFiles" : [ {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/H2SharingConnPool.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.H2SharingConnPool"
+    }, {
+      "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/nio/PoolingAsyncClientConnectionManagerBuilder.java",
+      "kind" : "JAVA_SOURCE",
+      "changedClassName" : "org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder"
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "ab543f1853f0f7233bd8fbdf8771e6ddea702f6d",
+    "headCommit" : "64916ee6560b7e8b53548b47e171ee792e50eec9",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  }, {
+    "baseCommit" : "64916ee6560b7e8b53548b47e171ee792e50eec9",
+    "headCommit" : "3b4ff29208b307f141a1989cbf038941d445a72e",
+    "changedFiles" : [ {
+      "path" : "RELEASE_NOTES.txt",
+      "kind" : "NON_SOURCE",
+      "changedClassName" : null
+    } ],
+    "status" : "ANALYZED",
+    "exclusionReason" : null
+  } ],
+  "excludedCommitPairs" : [ ],
+  "wouldMissCases" : [ {
+    "commitPair" : {
+      "baseCommit" : "6dd7b5ddae2a452ead910007ed29790f01c4e047",
+      "headCommit" : "599eb09207d64126967645b40bb2e9b507c6ce25",
+      "changedFiles" : [ {
+        "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientBuilderTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.rest.RestClientBuilderTest"
+      }, {
+        "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientH2Test.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.rest.RestClientH2Test"
+      }, {
+        "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientIntegrationTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.rest.RestClientIntegrationTest"
+      }, {
+        "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientResponseTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.rest.RestClientResponseTest"
+      }, {
+        "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestInvocationHandlerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.rest.RestInvocationHandlerTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts",
+      "methodName" : "testRequestConfig(String)[2]"
+    },
+    "changedClasses" : [ "org.apache.hc.client5.http.rest.RestClientBuilderTest", "org.apache.hc.client5.http.rest.RestClientH2Test", "org.apache.hc.client5.http.rest.RestClientIntegrationTest", "org.apache.hc.client5.http.rest.RestClientResponseTest", "org.apache.hc.client5.http.rest.RestInvocationHandlerTest" ],
+    "selectionReason" : "NO_MATCH"
+  }, {
+    "commitPair" : {
+      "baseCommit" : "6dd7b5ddae2a452ead910007ed29790f01c4e047",
+      "headCommit" : "599eb09207d64126967645b40bb2e9b507c6ce25",
+      "changedFiles" : [ {
+        "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientBuilderTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.rest.RestClientBuilderTest"
+      }, {
+        "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientH2Test.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.rest.RestClientH2Test"
+      }, {
+        "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientIntegrationTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.rest.RestClientIntegrationTest"
+      }, {
+        "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestClientResponseTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.rest.RestClientResponseTest"
+      }, {
+        "path" : "httpclient5-jakarta-rest-client/src/test/java/org/apache/hc/client5/http/rest/RestInvocationHandlerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.rest.RestInvocationHandlerTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts",
+      "methodName" : "testConnectionConfig(String)[1]"
+    },
+    "changedClasses" : [ "org.apache.hc.client5.http.rest.RestClientBuilderTest", "org.apache.hc.client5.http.rest.RestClientH2Test", "org.apache.hc.client5.http.rest.RestClientIntegrationTest", "org.apache.hc.client5.http.rest.RestClientResponseTest", "org.apache.hc.client5.http.rest.RestInvocationHandlerTest" ],
+    "selectionReason" : "NO_MATCH"
+  }, {
+    "commitPair" : {
+      "baseCommit" : "0d5d05fc7a55afb6c69dc360a0ac216bab3ad26f",
+      "headCommit" : "b6dab493cb37306e719f0069420ea037e54d5bd0",
+      "changedFiles" : [ {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.AsyncCachingExec"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheConfig.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheConfig"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheRequestCollapser.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheRequestCollapser"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/example/AsyncClientCacheRequestCollapsing.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.cache.example.AsyncClientCacheRequestCollapsing"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestAsyncCachingExecRequestCollapsing.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestAsyncCachingExecRequestCollapsing"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheRequestCollapser.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCacheRequestCollapser"
+      }, {
+        "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/AsyncClientCacheRequestCollapsingSmokeTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.testing.extension.async.AsyncClientCacheRequestCollapsingSmokeTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts",
+      "methodName" : "testRequestConfig(String)[1]"
+    },
+    "changedClasses" : [ "org.apache.hc.client5.http.impl.cache.AsyncCachingExec", "org.apache.hc.client5.http.impl.cache.CacheConfig", "org.apache.hc.client5.http.impl.cache.CacheRequestCollapser", "org.apache.hc.client5.http.cache.example.AsyncClientCacheRequestCollapsing", "org.apache.hc.client5.http.impl.cache.TestAsyncCachingExecRequestCollapsing", "org.apache.hc.client5.http.impl.cache.TestCacheRequestCollapser", "org.apache.hc.client5.testing.extension.async.AsyncClientCacheRequestCollapsingSmokeTest" ],
+    "selectionReason" : "NO_MATCH"
+  }, {
+    "commitPair" : {
+      "baseCommit" : "06aac6df0b80c721e8025da15b4967f714409474",
+      "headCommit" : "da6f1b279d2795f72e81c6062386359927c96f3b",
+      "changedFiles" : [ {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/AbstractMultipartFormat.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.entity.mime.AbstractMultipartFormat"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578Multipart.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.entity.mime.HttpRFC7578Multipart"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/entity/mime/HttpRFC7578MultipartTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.entity.mime.HttpRFC7578MultipartTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts",
+      "methodName" : "testRequestConfig(String)[2]"
+    },
+    "changedClasses" : [ "org.apache.hc.client5.http.entity.mime.AbstractMultipartFormat", "org.apache.hc.client5.http.entity.mime.HttpRFC7578Multipart", "org.apache.hc.client5.http.entity.mime.HttpRFC7578MultipartTest" ],
+    "selectionReason" : "NO_MATCH"
+  }, {
+    "commitPair" : {
+      "baseCommit" : "62716cf44edead47a8ba82a71142e0e5e170c05e",
+      "headCommit" : "17079a128b9de9b43c7b96f650f36a7f714ef995",
+      "changedFiles" : [ {
+        "path" : ".github/workflows/maven.yml",
+        "kind" : "INERT",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts",
+      "methodName" : "testConnectionConfig(String)[1]"
+    },
+    "changedClasses" : [ ],
+    "selectionReason" : "NO_MATCH"
+  }, {
+    "commitPair" : {
+      "baseCommit" : "17079a128b9de9b43c7b96f650f36a7f714ef995",
+      "headCommit" : "649c849ee431f8fc42515ea490d328bf2ab9cc21",
+      "changedFiles" : [ {
+        "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/ResourceIfaceScanner.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.rest.ResourceIfaceScanner"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts",
+      "methodName" : "testRequestConfig(String)[2]"
+    },
+    "changedClasses" : [ "org.apache.hc.client5.http.rest.ResourceIfaceScanner" ],
+    "selectionReason" : "NO_MATCH"
+  }, {
+    "commitPair" : {
+      "baseCommit" : "17079a128b9de9b43c7b96f650f36a7f714ef995",
+      "headCommit" : "649c849ee431f8fc42515ea490d328bf2ab9cc21",
+      "changedFiles" : [ {
+        "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/ResourceIfaceScanner.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.rest.ResourceIfaceScanner"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.TestAsyncTlsHandshakeTimeout",
+      "methodName" : "testTimeout(int, int, boolean, HttpVersionPolicy)[1]"
+    },
+    "changedClasses" : [ "org.apache.hc.client5.http.rest.ResourceIfaceScanner" ],
+    "selectionReason" : "NO_MATCH"
+  }, {
+    "commitPair" : {
+      "baseCommit" : "17079a128b9de9b43c7b96f650f36a7f714ef995",
+      "headCommit" : "649c849ee431f8fc42515ea490d328bf2ab9cc21",
+      "changedFiles" : [ {
+        "path" : "httpclient5-jakarta-rest-client/src/main/java/org/apache/hc/client5/http/rest/ResourceIfaceScanner.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.rest.ResourceIfaceScanner"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.ReactiveIntegrationTests$H2Tls",
+      "methodName" : "testSequentialHeadRequests"
+    },
+    "changedClasses" : [ "org.apache.hc.client5.http.rest.ResourceIfaceScanner" ],
+    "selectionReason" : "NO_MATCH"
+  }, {
+    "commitPair" : {
+      "baseCommit" : "a50d07a22655e1c1739e49f16a53ecd1e6c50fb8",
+      "headCommit" : "b1defb3113331aa11eece29d4504778e6a326304",
+      "changedFiles" : [ {
+        "path" : "README.md",
+        "kind" : "INERT",
+        "changedClassName" : null
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/AsyncCachingExec.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.AsyncCachingExec"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheKeyGenerator.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheKeyGenerator"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheableRequestPolicy.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheableRequestPolicy"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExec.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.CachingExec"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachingExecBase.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.CachingExecBase"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/ResponseCachingPolicy.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.ResponseCachingPolicy"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestAsyncCachingExecQuery.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestAsyncCachingExecQuery"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheKeyGenerator.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCacheKeyGenerator"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheableRequestPolicy.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCacheableRequestPolicy"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCachingExecChain.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCachingExecChain"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestResponseCachingPolicy.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestResponseCachingPolicy"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/ClientQueryMethod.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.examples.ClientQueryMethod"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts",
+      "methodName" : "testRequestConfig(String)[1]"
+    },
+    "changedClasses" : [ "org.apache.hc.client5.http.impl.cache.AsyncCachingExec", "org.apache.hc.client5.http.impl.cache.CacheKeyGenerator", "org.apache.hc.client5.http.impl.cache.CacheableRequestPolicy", "org.apache.hc.client5.http.impl.cache.CachingExec", "org.apache.hc.client5.http.impl.cache.CachingExecBase", "org.apache.hc.client5.http.impl.cache.ResponseCachingPolicy", "org.apache.hc.client5.http.impl.cache.TestAsyncCachingExecQuery", "org.apache.hc.client5.http.impl.cache.TestCacheKeyGenerator", "org.apache.hc.client5.http.impl.cache.TestCacheableRequestPolicy", "org.apache.hc.client5.http.impl.cache.TestCachingExecChain", "org.apache.hc.client5.http.impl.cache.TestResponseCachingPolicy", "org.apache.hc.client5.http.examples.ClientQueryMethod" ],
+    "selectionReason" : "NO_MATCH"
+  }, {
+    "commitPair" : {
+      "baseCommit" : "ebac9512f555c4a355cad3f59ef2db69b597cc97",
+      "headCommit" : "9816640dd004ebf8e122c32f000ed4d413c2d7ab",
+      "changedFiles" : [ {
+        "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncConnectionManagement.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncConnectionManagement"
+      }, {
+        "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestConnectionManagement.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.testing.sync.TestConnectionManagement"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$H2Tls",
+      "methodName" : "testSequentialHeadRequests"
+    },
+    "changedClasses" : [ "org.apache.hc.client5.testing.async.TestAsyncConnectionManagement", "org.apache.hc.client5.testing.sync.TestConnectionManagement" ],
+    "selectionReason" : "NO_MATCH"
+  }, {
+    "commitPair" : {
+      "baseCommit" : "7cb189efb48388e5be99498bd6fa0e19008a6041",
+      "headCommit" : "88c62e7cfc680ad83096f0165c018272abd28c4b",
+      "changedFiles" : [ {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingAsyncDataConsumer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingAsyncDataConsumer"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingBrotliDataConsumer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumer"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingCapacityChannel.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingCapacityChannel"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingGzipDataConsumer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingGzipDataConsumer"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingZstdDataConsumer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingZstdDataConsumer"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/InflatingBrotliDataConsumerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumerTest"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/InflatingCapacityChannelTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingCapacityChannelTest"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientInflateCapacityExample.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientInflateCapacityExample"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts",
+      "methodName" : "testRequestConfig(String)[2]"
+    },
+    "changedClasses" : [ "org.apache.hc.client5.http.async.methods.InflatingAsyncDataConsumer", "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumer", "org.apache.hc.client5.http.async.methods.InflatingCapacityChannel", "org.apache.hc.client5.http.async.methods.InflatingGzipDataConsumer", "org.apache.hc.client5.http.async.methods.InflatingZstdDataConsumer", "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumerTest", "org.apache.hc.client5.http.async.methods.InflatingCapacityChannelTest", "org.apache.hc.client5.http.examples.AsyncClientInflateCapacityExample" ],
+    "selectionReason" : "NO_MATCH"
+  }, {
+    "commitPair" : {
+      "baseCommit" : "7cb189efb48388e5be99498bd6fa0e19008a6041",
+      "headCommit" : "88c62e7cfc680ad83096f0165c018272abd28c4b",
+      "changedFiles" : [ {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingAsyncDataConsumer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingAsyncDataConsumer"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingBrotliDataConsumer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumer"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingCapacityChannel.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingCapacityChannel"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingGzipDataConsumer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingGzipDataConsumer"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/async/methods/InflatingZstdDataConsumer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingZstdDataConsumer"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/InflatingBrotliDataConsumerTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumerTest"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/async/methods/InflatingCapacityChannelTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.async.methods.InflatingCapacityChannelTest"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientInflateCapacityExample.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientInflateCapacityExample"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts",
+      "methodName" : "testConnectionConfig(String)[1]"
+    },
+    "changedClasses" : [ "org.apache.hc.client5.http.async.methods.InflatingAsyncDataConsumer", "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumer", "org.apache.hc.client5.http.async.methods.InflatingCapacityChannel", "org.apache.hc.client5.http.async.methods.InflatingGzipDataConsumer", "org.apache.hc.client5.http.async.methods.InflatingZstdDataConsumer", "org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumerTest", "org.apache.hc.client5.http.async.methods.InflatingCapacityChannelTest", "org.apache.hc.client5.http.examples.AsyncClientInflateCapacityExample" ],
+    "selectionReason" : "NO_MATCH"
+  }, {
+    "commitPair" : {
+      "baseCommit" : "a4e525dd85fdbcb9e6f062180c34ff7b58a4fa48",
+      "headCommit" : "c4eb7e5a4fa095c334391138d0462c9674d99984",
+      "changedFiles" : [ {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheEntry.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.cache.HttpCacheEntry"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheEntryFactory.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.cache.HttpCacheEntryFactory"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpAsyncCache.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.BasicHttpAsyncCache"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.BasicHttpCache"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpByteArrayCacheEntrySerializer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.HttpByteArrayCacheEntrySerializer"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/cache/TestHttpCacheEntryFactory.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.cache.TestHttpCacheEntryFactory"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/HttpCacheEntryMatcher.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.HttpCacheEntryMatcher"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpAsyncCache.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestBasicHttpAsyncCache"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestBasicHttpCache.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestBasicHttpCache"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestHttpByteArrayCacheEntrySerializer.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestHttpByteArrayCacheEntrySerializer"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts",
+      "methodName" : "testConnectionConfig(String)[2]"
+    },
+    "changedClasses" : [ "org.apache.hc.client5.http.cache.HttpCacheEntry", "org.apache.hc.client5.http.cache.HttpCacheEntryFactory", "org.apache.hc.client5.http.impl.cache.BasicHttpAsyncCache", "org.apache.hc.client5.http.impl.cache.BasicHttpCache", "org.apache.hc.client5.http.impl.cache.HttpByteArrayCacheEntrySerializer", "org.apache.hc.client5.http.cache.TestHttpCacheEntryFactory", "org.apache.hc.client5.http.impl.cache.HttpCacheEntryMatcher", "org.apache.hc.client5.http.impl.cache.TestBasicHttpAsyncCache", "org.apache.hc.client5.http.impl.cache.TestBasicHttpCache", "org.apache.hc.client5.http.impl.cache.TestHttpByteArrayCacheEntrySerializer" ],
+    "selectionReason" : "NO_MATCH"
+  } ],
+  "flakyFailures" : [ {
+    "commitPair" : {
+      "baseCommit" : "0d4b9a91174dd6a9b9c32634344dd0d1be988622",
+      "headCommit" : "9780a8f9097f4539ea7beb3f99a9c97819e5fb96",
+      "changedFiles" : [ {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/entity/compress/DecompressingEntity.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.entity.compress.DecompressingEntity"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.http.impl.cache.TestProtocolRequirements",
+      "methodName" : "testTransmitsAgeHeaderIfIncomingAgeHeaderTooBig"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "63c5ebd813a489fbb4e312e0bdeec5fd4ceefcfc",
+      "headCommit" : "1aac37625715cfa1faf4ccf824f3cec95b628ba2",
+      "changedFiles" : [ {
+        "path" : "pom.xml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1",
+      "methodName" : "testSequentialHeadRequests"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "1aac37625715cfa1faf4ccf824f3cec95b628ba2",
+      "headCommit" : "89669060b9688104054630fd8609528117a05428",
+      "changedFiles" : [ {
+        "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/http/impl/async/InternalTestHttpAsyncExecRuntime.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalTestHttpAsyncExecRuntime"
+      }, {
+        "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestInternalHttpAsyncExecRuntime.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.testing.async.TestInternalHttpAsyncExecRuntime"
+      }, {
+        "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/extension/async/TestAsyncServerBootstrap.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.testing.extension.async.TestAsyncServerBootstrap"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntime.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncExecRuntime"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1",
+      "methodName" : "testSequentialHeadRequests"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "797374c878ceb8733746f745b077c60300a4baa6",
+      "headCommit" : "0beb0f2b31bec07adc78fa8e92a906d1a739a6dc",
+      "changedFiles" : [ {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/config/ConnectionConfig.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.config.ConnectionConfig"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$H2Tls",
+      "methodName" : "testSequentialHeadRequests"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "4b26224c33e3854454ab95fc69f850b59322a1c3",
+      "headCommit" : "1c5d8236392f0b0d45708bed6b4d746e7f7bcbb6",
+      "changedFiles" : [ {
+        "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/async/TestAsyncConnectionTimeouts.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts"
+      }, {
+        "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/testing/sync/TestConnectionTimeouts.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.testing.sync.TestConnectionTimeouts"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1",
+      "methodName" : "testSequentialHeadRequests"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "1c5d8236392f0b0d45708bed6b4d746e7f7bcbb6",
+      "headCommit" : "022c6872688901dc5e26589f65769a629d2cca06",
+      "changedFiles" : [ {
+        "path" : "pom.xml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.TestAsyncConnectionManagement",
+      "methodName" : "testCloseExpiredTTLConnections"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "1c5d8236392f0b0d45708bed6b4d746e7f7bcbb6",
+      "headCommit" : "022c6872688901dc5e26589f65769a629d2cca06",
+      "changedFiles" : [ {
+        "path" : "pom.xml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1",
+      "methodName" : "testSequentialHeadRequests"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "2ee445728efa81ea3cd6003faa6a9a4cca488015",
+      "headCommit" : "b3451829e63aa9b866e5c711b6789c00e41943e9",
+      "changedFiles" : [ {
+        "path" : "httpclient5-testing/src/test/java/org/apache/hc/client5/http/impl/async/InternalTestHttpAsyncExecRuntime.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalTestHttpAsyncExecRuntime"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/H2AsyncClientBuilder.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.H2AsyncClientBuilder"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilder.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncClient.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalH2AsyncClient"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntime.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalH2AsyncExecRuntime"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncClient.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncClient"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntime.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncExecRuntime"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/ReleasingAsyncClientExchangeHandler.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.ReleasingAsyncClientExchangeHandler"
+      }, {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/async/SharedRequestExecutionQueue.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.SharedRequestExecutionQueue"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncClientQueueCap.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.examples.AsyncClientQueueCap"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/AsyncSharedClientQueueExample.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.examples.AsyncSharedClientQueueExample"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/examples/H2SharedClientQueueLocalExample.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.examples.H2SharedClientQueueLocalExample"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/HttpAsyncClientBuilderMaxQueuedRequestsTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilderMaxQueuedRequestsTest"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/InternalH2AsyncExecRuntimeQueueCapTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalH2AsyncExecRuntimeQueueCapTest"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/async/InternalHttpAsyncExecRuntimeQueueCapTest.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.async.InternalHttpAsyncExecRuntimeQueueCapTest"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1",
+      "methodName" : "testSequentialHeadRequests"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "649c849ee431f8fc42515ea490d328bf2ab9cc21",
+      "headCommit" : "7f316c08dd447c88f4b151820523f884dac69db5",
+      "changedFiles" : [ {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/cache/HttpCacheEntryFactory.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.cache.HttpCacheEntryFactory"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpAsyncCache.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.BasicHttpAsyncCache"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/BasicHttpCache.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.BasicHttpCache"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheKeyGenerator.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheKeyGenerator"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CacheSupport.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.CacheSupport"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/CachedResponseSuitabilityChecker.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.CachedResponseSuitabilityChecker"
+      }, {
+        "path" : "httpclient5-cache/src/main/java/org/apache/hc/client5/http/impl/cache/HttpCacheSupport.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.HttpCacheSupport"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheKeyGenerator.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCacheKeyGenerator"
+      }, {
+        "path" : "httpclient5-cache/src/test/java/org/apache/hc/client5/http/impl/cache/TestCacheSupport.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.cache.TestCacheSupport"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1",
+      "methodName" : "testSequentialHeadRequests"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "7978d713719ec79673a0d51b50f25bdc793ad079",
+      "headCommit" : "43cb5c3c60c2fd3275ad8eab3d66a009449093c3",
+      "changedFiles" : [ {
+        "path" : "httpclient5/src/main/java/org/apache/hc/client5/http/impl/DefaultRedirectStrategy.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.DefaultRedirectStrategy"
+      }, {
+        "path" : "httpclient5/src/test/java/org/apache/hc/client5/http/impl/TestDefaultRedirectStrategy.java",
+        "kind" : "JAVA_SOURCE",
+        "changedClassName" : "org.apache.hc.client5.http.impl.TestDefaultRedirectStrategy"
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.ReactiveIntegrationTests$Http1Tls",
+      "methodName" : "testSequentialHeadRequests"
+    }
+  }, {
+    "commitPair" : {
+      "baseCommit" : "e7b2407c96fb2bc3c8f4e0552c96a2bd55ddb563",
+      "headCommit" : "c5bce183828e51affbf481bddf00afb05652dd7d",
+      "changedFiles" : [ {
+        "path" : "httpclient5-jakarta-rest-client/pom.xml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      }, {
+        "path" : "pom.xml",
+        "kind" : "NON_SOURCE",
+        "changedClassName" : null
+      } ],
+      "status" : "ANALYZED",
+      "exclusionReason" : null
+    },
+    "test" : {
+      "className" : "org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1",
+      "methodName" : "testSequentialHeadRequests"
+    }
+  } ],
+  "savingsSummary" : {
+    "totalTestExecutions" : 670643,
+    "totalSelected" : 282351,
+    "proportionSkipped" : 0.578984646078465,
+    "fallbackDrivenSelections" : 212575,
+    "moduleScopedFallbackSelections" : 8619,
+    "dependencyMatchedSelections" : 46283,
+    "newOrModifiedTestSelections" : 2892
+  }
+}

--- a/analyses/httpclient-summary.txt
+++ b/analyses/httpclient-summary.txt
@@ -1,0 +1,60 @@
+Verdict: FAIL
+Analyzed: 300 commit pair(s)
+Would-miss cases: 13
+  - commit 6dd7b5ddae2a452ead910007ed29790f01c4e047..599eb09207d64126967645b40bb2e9b507c6ce25: org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts#testRequestConfig(String)[2]
+    changed: org.apache.hc.client5.http.rest.RestClientBuilderTest, org.apache.hc.client5.http.rest.RestClientH2Test, org.apache.hc.client5.http.rest.RestClientIntegrationTest, org.apache.hc.client5.http.rest.RestClientResponseTest, org.apache.hc.client5.http.rest.RestInvocationHandlerTest
+    not selected: NO_MATCH
+  - commit 6dd7b5ddae2a452ead910007ed29790f01c4e047..599eb09207d64126967645b40bb2e9b507c6ce25: org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts#testConnectionConfig(String)[1]
+    changed: org.apache.hc.client5.http.rest.RestClientBuilderTest, org.apache.hc.client5.http.rest.RestClientH2Test, org.apache.hc.client5.http.rest.RestClientIntegrationTest, org.apache.hc.client5.http.rest.RestClientResponseTest, org.apache.hc.client5.http.rest.RestInvocationHandlerTest
+    not selected: NO_MATCH
+  - commit 0d5d05fc7a55afb6c69dc360a0ac216bab3ad26f..b6dab493cb37306e719f0069420ea037e54d5bd0: org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts#testRequestConfig(String)[1]
+    changed: org.apache.hc.client5.http.impl.cache.AsyncCachingExec, org.apache.hc.client5.http.impl.cache.CacheConfig, org.apache.hc.client5.http.impl.cache.CacheRequestCollapser, org.apache.hc.client5.http.cache.example.AsyncClientCacheRequestCollapsing, org.apache.hc.client5.http.impl.cache.TestAsyncCachingExecRequestCollapsing, org.apache.hc.client5.http.impl.cache.TestCacheRequestCollapser, org.apache.hc.client5.testing.extension.async.AsyncClientCacheRequestCollapsingSmokeTest
+    not selected: NO_MATCH
+  - commit 06aac6df0b80c721e8025da15b4967f714409474..da6f1b279d2795f72e81c6062386359927c96f3b: org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts#testRequestConfig(String)[2]
+    changed: org.apache.hc.client5.http.entity.mime.AbstractMultipartFormat, org.apache.hc.client5.http.entity.mime.HttpRFC7578Multipart, org.apache.hc.client5.http.entity.mime.HttpRFC7578MultipartTest
+    not selected: NO_MATCH
+  - commit 62716cf44edead47a8ba82a71142e0e5e170c05e..17079a128b9de9b43c7b96f650f36a7f714ef995: org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts#testConnectionConfig(String)[1]
+    changed: 
+    not selected: NO_MATCH
+  - commit 17079a128b9de9b43c7b96f650f36a7f714ef995..649c849ee431f8fc42515ea490d328bf2ab9cc21: org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts#testRequestConfig(String)[2]
+    changed: org.apache.hc.client5.http.rest.ResourceIfaceScanner
+    not selected: NO_MATCH
+  - commit 17079a128b9de9b43c7b96f650f36a7f714ef995..649c849ee431f8fc42515ea490d328bf2ab9cc21: org.apache.hc.client5.testing.async.TestAsyncTlsHandshakeTimeout#testTimeout(int, int, boolean, HttpVersionPolicy)[1]
+    changed: org.apache.hc.client5.http.rest.ResourceIfaceScanner
+    not selected: NO_MATCH
+  - commit 17079a128b9de9b43c7b96f650f36a7f714ef995..649c849ee431f8fc42515ea490d328bf2ab9cc21: org.apache.hc.client5.testing.async.ReactiveIntegrationTests$H2Tls#testSequentialHeadRequests
+    changed: org.apache.hc.client5.http.rest.ResourceIfaceScanner
+    not selected: NO_MATCH
+  - commit a50d07a22655e1c1739e49f16a53ecd1e6c50fb8..b1defb3113331aa11eece29d4504778e6a326304: org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts#testRequestConfig(String)[1]
+    changed: org.apache.hc.client5.http.impl.cache.AsyncCachingExec, org.apache.hc.client5.http.impl.cache.CacheKeyGenerator, org.apache.hc.client5.http.impl.cache.CacheableRequestPolicy, org.apache.hc.client5.http.impl.cache.CachingExec, org.apache.hc.client5.http.impl.cache.CachingExecBase, org.apache.hc.client5.http.impl.cache.ResponseCachingPolicy, org.apache.hc.client5.http.impl.cache.TestAsyncCachingExecQuery, org.apache.hc.client5.http.impl.cache.TestCacheKeyGenerator, org.apache.hc.client5.http.impl.cache.TestCacheableRequestPolicy, org.apache.hc.client5.http.impl.cache.TestCachingExecChain, org.apache.hc.client5.http.impl.cache.TestResponseCachingPolicy, org.apache.hc.client5.http.examples.ClientQueryMethod
+    not selected: NO_MATCH
+  - commit ebac9512f555c4a355cad3f59ef2db69b597cc97..9816640dd004ebf8e122c32f000ed4d413c2d7ab: org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$H2Tls#testSequentialHeadRequests
+    changed: org.apache.hc.client5.testing.async.TestAsyncConnectionManagement, org.apache.hc.client5.testing.sync.TestConnectionManagement
+    not selected: NO_MATCH
+  - commit 7cb189efb48388e5be99498bd6fa0e19008a6041..88c62e7cfc680ad83096f0165c018272abd28c4b: org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts#testRequestConfig(String)[2]
+    changed: org.apache.hc.client5.http.async.methods.InflatingAsyncDataConsumer, org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumer, org.apache.hc.client5.http.async.methods.InflatingCapacityChannel, org.apache.hc.client5.http.async.methods.InflatingGzipDataConsumer, org.apache.hc.client5.http.async.methods.InflatingZstdDataConsumer, org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumerTest, org.apache.hc.client5.http.async.methods.InflatingCapacityChannelTest, org.apache.hc.client5.http.examples.AsyncClientInflateCapacityExample
+    not selected: NO_MATCH
+  - commit 7cb189efb48388e5be99498bd6fa0e19008a6041..88c62e7cfc680ad83096f0165c018272abd28c4b: org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts#testConnectionConfig(String)[1]
+    changed: org.apache.hc.client5.http.async.methods.InflatingAsyncDataConsumer, org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumer, org.apache.hc.client5.http.async.methods.InflatingCapacityChannel, org.apache.hc.client5.http.async.methods.InflatingGzipDataConsumer, org.apache.hc.client5.http.async.methods.InflatingZstdDataConsumer, org.apache.hc.client5.http.async.methods.InflatingBrotliDataConsumerTest, org.apache.hc.client5.http.async.methods.InflatingCapacityChannelTest, org.apache.hc.client5.http.examples.AsyncClientInflateCapacityExample
+    not selected: NO_MATCH
+  - commit a4e525dd85fdbcb9e6f062180c34ff7b58a4fa48..c4eb7e5a4fa095c334391138d0462c9674d99984: org.apache.hc.client5.testing.async.TestAsyncConnectionTimeouts#testConnectionConfig(String)[2]
+    changed: org.apache.hc.client5.http.cache.HttpCacheEntry, org.apache.hc.client5.http.cache.HttpCacheEntryFactory, org.apache.hc.client5.http.impl.cache.BasicHttpAsyncCache, org.apache.hc.client5.http.impl.cache.BasicHttpCache, org.apache.hc.client5.http.impl.cache.HttpByteArrayCacheEntrySerializer, org.apache.hc.client5.http.cache.TestHttpCacheEntryFactory, org.apache.hc.client5.http.impl.cache.HttpCacheEntryMatcher, org.apache.hc.client5.http.impl.cache.TestBasicHttpAsyncCache, org.apache.hc.client5.http.impl.cache.TestBasicHttpCache, org.apache.hc.client5.http.impl.cache.TestHttpByteArrayCacheEntrySerializer
+    not selected: NO_MATCH
+
+Savings: 282351 / 670643 test executions selected (57.9% skipped)
+  - dependency-matched: 46283
+  - fallback-driven: 212575
+  - module-scoped fallback: 8619
+  - new-or-modified: 2892
+Flaky failures observed: 11 (excluded from verdict)
+  - commit 0d4b9a91174dd6a9b9c32634344dd0d1be988622..9780a8f9097f4539ea7beb3f99a9c97819e5fb96: org.apache.hc.client5.http.impl.cache.TestProtocolRequirements#testTransmitsAgeHeaderIfIncomingAgeHeaderTooBig
+  - commit 63c5ebd813a489fbb4e312e0bdeec5fd4ceefcfc..1aac37625715cfa1faf4ccf824f3cec95b628ba2: org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1#testSequentialHeadRequests
+  - commit 1aac37625715cfa1faf4ccf824f3cec95b628ba2..89669060b9688104054630fd8609528117a05428: org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1#testSequentialHeadRequests
+  - commit 797374c878ceb8733746f745b077c60300a4baa6..0beb0f2b31bec07adc78fa8e92a906d1a739a6dc: org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$H2Tls#testSequentialHeadRequests
+  - commit 4b26224c33e3854454ab95fc69f850b59322a1c3..1c5d8236392f0b0d45708bed6b4d746e7f7bcbb6: org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1#testSequentialHeadRequests
+  - commit 1c5d8236392f0b0d45708bed6b4d746e7f7bcbb6..022c6872688901dc5e26589f65769a629d2cca06: org.apache.hc.client5.testing.async.TestAsyncConnectionManagement#testCloseExpiredTTLConnections
+  - commit 1c5d8236392f0b0d45708bed6b4d746e7f7bcbb6..022c6872688901dc5e26589f65769a629d2cca06: org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1#testSequentialHeadRequests
+  - commit 2ee445728efa81ea3cd6003faa6a9a4cca488015..b3451829e63aa9b866e5c711b6789c00e41943e9: org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1#testSequentialHeadRequests
+  - commit 649c849ee431f8fc42515ea490d328bf2ab9cc21..7f316c08dd447c88f4b151820523f884dac69db5: org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1#testSequentialHeadRequests
+  - commit 7978d713719ec79673a0d51b50f25bdc793ad079..43cb5c3c60c2fd3275ad8eab3d66a009449093c3: org.apache.hc.client5.testing.async.ReactiveIntegrationTests$Http1Tls#testSequentialHeadRequests
+  - commit e7b2407c96fb2bc3c8f4e0552c96a2bd55ddb563..c5bce183828e51affbf481bddf00afb05652dd7d: org.apache.hc.client5.testing.async.ReactiveMinimalIntegrationTests$Http1#testSequentialHeadRequests


### PR DESCRIPTION
## Summary

- document the Apache HttpClient 300-pair shadow-mode validation
- record the 13 would-miss cases and 57.9% test-execution reduction
- clarify that this result is a limitation to investigate, not evidence of universal safety

## Validation

- verified README table values against `analyses/httpclient-summary.txt`
- ran `git diff --check`