### PR TITLE
validator: replay real parent-child history edges and report failure coverage

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -2,7 +2,7 @@
   "feature": "replay-real-parent-child-history-edges-and-report-failure-be",
   "branch": "feature/replay-real-parent-child-history-edges-and-report-failure-be",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/surface-replay-mode-and-failure-denominator-in-reports.md",
+  "last_session": "docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/mark-adjacency-based-analyses-superseded.md",
   "base_ref": "main",
   "updated": "2026-08-01"
 }

--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -2,7 +2,7 @@
   "feature": "replay-real-parent-child-history-edges-and-report-failure-be",
   "branch": "feature/replay-real-parent-child-history-edges-and-report-failure-be",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/measure-newly-confirmed-failure-coverage-per-edge.md",
+  "last_session": "docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/surface-replay-mode-and-failure-denominator-in-reports.md",
   "base_ref": "main",
   "updated": "2026-08-01"
 }

--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -2,7 +2,7 @@
   "feature": "replay-real-parent-child-history-edges-and-report-failure-be",
   "branch": "feature/replay-real-parent-child-history-edges-and-report-failure-be",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/mark-adjacency-based-analyses-superseded.md",
+  "last_session": "docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/align-edge-terminology-in-public-validator-types.md",
   "base_ref": "main",
   "updated": "2026-08-01"
 }

--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -2,7 +2,7 @@
   "feature": "replay-real-parent-child-history-edges-and-report-failure-be",
   "branch": "feature/replay-real-parent-child-history-edges-and-report-failure-be",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/model-reachable-history-as-direct-parent-child-edges.md",
+  "last_session": "docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/measure-newly-confirmed-failure-coverage-per-edge.md",
   "base_ref": "main",
   "updated": "2026-08-01"
 }

--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "support-java-17-target-test-jvms-with-a-compatible-tracking",
-  "branch": "feature/support-java-17-target-test-jvms-with-a-compatible-tracking",
+  "feature": "replay-real-parent-child-history-edges-and-report-failure-be",
+  "branch": "feature/replay-real-parent-child-history-edges-and-report-failure-be",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/support-java-17-target-test-jvms-with-a-compatible-tracking/sessions/avoid-re-entrant-class-definition-while-tracking-junit-test.md",
+  "last_session": "docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/model-reachable-history-as-direct-parent-child-edges.md",
   "base_ref": "main",
-  "updated": "2026-07-31"
+  "updated": "2026-08-01"
 }

--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ train something probabilistic on historical flakiness. Blastradius does neither:
 uses that real, per-test dependency map to decide what to run next time. No training data,
 no heuristics, no opaque score.
 
-## Early validation
+## Historical validation (superseded for soundness claims)
 
-The validator replayed sequential commit pairs in shadow mode and compared the selected-test outcomes with each corresponding full-test outcome.
+These three 300-pair analyses used the validator's former traversal-adjacency semantics: each
+reported pair was adjacent in a `RevWalk`, but was not necessarily a direct Git parent-to-child
+edge. They are retained as historical operational data, including their selection reductions,
+but are superseded as soundness evidence and must be rerun with the current edge semantics before
+being compared to new results.
 
 | Project | Commit range | Pairs analyzed (excluded) | Would-miss cases | Test executions selected | Skipped |
 | --- | --- | ---: | ---: | ---: | ---: |
@@ -27,7 +31,10 @@ The validator replayed sequential commit pairs in shadow mode and compared the s
 | <h4><a href="https://github.com/jhy/jsoup">jsoup</a></h4> | [`e10e04d`](https://github.com/jhy/jsoup/commit/e10e04da6c7d93daf5f74d449594cba7ea3683e3) → [`9d2241f`](https://github.com/jhy/jsoup/commit/9d2241ff467d03accbf902a650adc60513bf5c11) | 300 (0) | 0 | 304,060 / 536,850 | **43.4%** |
 |<img width=400 />|  |  |  |  | **57.6%** |
 
-These are early results from three Maven projects and three 300-pair history windows, not a universal guarantee. All runs stayed conservative: most selected tests came from fallback rules rather than direct dependency matches. Full suites still remain the recommended daily safety net.
+These historical windows are not a universal guarantee. Current validator reports identify their
+`ALL_PARENTS` or `FIRST_PARENT` replay mode and make the observed-failure denominator explicit;
+zero would-miss cases without that denominator are not a soundness result. Full suites remain the
+recommended daily safety net.
 
 ## How it works
 

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/Main.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/Main.java
@@ -1,6 +1,7 @@
 package io.github.baokhang83.blastradius.validator.cli;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.baokhang83.blastradius.validator.git.HistoryMode;
 import io.github.baokhang83.blastradius.validator.report.AnalysisReport;
 import io.github.baokhang83.blastradius.validator.report.TextSummaryRenderer;
 import java.io.IOException;
@@ -11,7 +12,7 @@ import java.nio.file.Path;
  * CLI entry point. Usage:
  * {@code blastradius-validator run --project-path <path> --commits <N> --report-out <path>
  * [--summary-out <path>] [--maven-threads <N>] [--fast-ground-truth] [--build-concurrency <K>]
- * [--build-timeout-minutes <M>] [--skip-build-extras]}
+ * [--build-timeout-minutes <M>] [--skip-build-extras] [--history-mode <all-parents|first-parent>]}
  */
 public final class Main {
 
@@ -19,7 +20,8 @@ public final class Main {
         if (args.length == 0 || !"run".equals(args[0])) {
             System.err.println("usage: run --project-path <path> --commits <N> --report-out <path> "
                     + "[--summary-out <path>] [--maven-threads <N>] [--fast-ground-truth] "
-                    + "[--build-concurrency <K>] [--build-timeout-minutes <M>] [--skip-build-extras]");
+                    + "[--build-concurrency <K>] [--build-timeout-minutes <M>] [--skip-build-extras] "
+                    + "[--history-mode <all-parents|first-parent>]");
             System.exit(2);
             return;
         }
@@ -33,6 +35,7 @@ public final class Main {
         int buildConcurrency = 1;
         long buildTimeoutMinutes = RunConfig.DEFAULT_BUILD_TIMEOUT_MINUTES;
         boolean skipBuildExtras = false;
+        HistoryMode historyMode = HistoryMode.ALL_PARENTS;
 
         for (int i = 1; i < args.length; i++) {
             switch (args[i]) {
@@ -45,6 +48,7 @@ public final class Main {
                 case "--build-concurrency" -> buildConcurrency = Integer.parseInt(args[++i]);
                 case "--build-timeout-minutes" -> buildTimeoutMinutes = Long.parseLong(args[++i]);
                 case "--skip-build-extras" -> skipBuildExtras = true;
+                case "--history-mode" -> historyMode = HistoryMode.fromCliValue(args[++i]);
                 default -> {
                     System.err.println("unknown argument: " + args[i]);
                     System.exit(2);
@@ -61,7 +65,7 @@ public final class Main {
 
         try {
             RunConfig config = new RunConfig(projectPath, commits, reportOut, mavenThreads, fastGroundTruth,
-                    buildConcurrency, buildTimeoutMinutes, skipBuildExtras);
+                    buildConcurrency, buildTimeoutMinutes, skipBuildExtras, historyMode);
             int exitCode = new RunCommand().run(config);
             printSummary(reportOut, summaryOut, exitCode);
             System.exit(exitCode);

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
@@ -316,7 +316,9 @@ public final class RunCommand {
                 baseRecordSet.ambientDependencies(), reactorScope);
 
         CommitPair enrichedPair = CommitPair.analyzed(pair.baseCommit(), pair.headCommit(), changedFiles);
-        List<WouldMissCase> misses = wouldMissComparator.compare(enrichedPair, decisions, groundTruth, baseGroundTruth);
+        List<WouldMissCase> misses = wouldMissComparator
+                .compare(enrichedPair, decisions, groundTruth, baseGroundTruth)
+                .wouldMissCases();
         List<FlakyFailure> flakyFailures = groundTruth.stream()
                 .filter(r -> r.outcome() == Outcome.FLAKY)
                 .map(r -> new FlakyFailure(enrichedPair, r.test()))

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
@@ -22,6 +22,7 @@ import io.github.baokhang83.blastradius.core.reactor.TestModuleIndex;
 import io.github.baokhang83.blastradius.validator.git.CommitCheckout;
 import io.github.baokhang83.blastradius.validator.git.CommitPair;
 import io.github.baokhang83.blastradius.validator.git.CommitWindowResolver;
+import io.github.baokhang83.blastradius.validator.report.FailureCoverage;
 import io.github.baokhang83.blastradius.validator.git.PairStatus;
 import io.github.baokhang83.blastradius.validator.report.AnalysisReport;
 import io.github.baokhang83.blastradius.validator.report.ReportWriter;
@@ -35,6 +36,7 @@ import io.github.baokhang83.blastradius.core.tracking.DependencyRecordReader;
 import io.github.baokhang83.blastradius.core.tracking.DependencyRecordSet;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import io.github.baokhang83.blastradius.validator.verdict.FlakyFailure;
+import io.github.baokhang83.blastradius.validator.verdict.FailureComparison;
 import io.github.baokhang83.blastradius.validator.verdict.Verdict;
 import io.github.baokhang83.blastradius.validator.verdict.VerdictCalculator;
 import io.github.baokhang83.blastradius.validator.verdict.WouldMissCase;
@@ -122,7 +124,8 @@ public final class RunCommand {
 
             long runStart = System.currentTimeMillis();
             List<CommitPair> window =
-                    commitWindowResolver.resolveWindow(config.projectPath(), config.commitWindowSize());
+                    commitWindowResolver.resolveWindow(
+                            config.projectPath(), config.commitWindowSize(), config.historyMode());
             progress.windowResolved(window.size());
 
             int concurrency = config.buildConcurrency();
@@ -196,6 +199,7 @@ public final class RunCommand {
         List<WouldMissCase> allMisses = new ArrayList<>();
         List<SelectionDecision> allDecisions = new ArrayList<>();
         List<FlakyFailure> allFlaky = new ArrayList<>();
+        FailureCoverage failureCoverage = FailureCoverage.empty();
         // Reactor scope per HEAD commit: a repeated head across the window repays neither the
         // checkout nor the tree walk. Only populated for pairs with a NON_SOURCE change.
         Map<String, ReactorScope> reactorScopeCache = new HashMap<>();
@@ -223,6 +227,7 @@ public final class RunCommand {
                     allMisses.addAll(analysis.misses());
                     allDecisions.addAll(analysis.decisions());
                     allFlaky.addAll(analysis.flakyFailures());
+                    failureCoverage = failureCoverage.plus(analysis.failureCoverage());
                     progress.pairCompleted(pairIndex, window.size(), analysis.misses().size(), pairMillis);
                 }
             }
@@ -232,12 +237,14 @@ public final class RunCommand {
 
         Verdict verdict = verdictCalculator.calculate(allMisses);
         SavingsSummary savingsSummary = savingsSummaryAggregator.aggregate(allDecisions);
-        return new AnalysisReport(verdict, analyzedPairs, excludedPairs, allMisses, allFlaky, savingsSummary);
+        return new AnalysisReport(verdict, config.historyMode(), analyzedPairs, excludedPairs, failureCoverage,
+                allMisses, allFlaky, savingsSummary);
     }
 
     private record PairAnalysis(
             CommitPair pair,
             List<WouldMissCase> misses,
+            FailureCoverage failureCoverage,
             List<SelectionDecision> decisions,
             List<FlakyFailure> flakyFailures) {}
 
@@ -316,15 +323,14 @@ public final class RunCommand {
                 baseRecordSet.ambientDependencies(), reactorScope);
 
         CommitPair enrichedPair = CommitPair.analyzed(pair.baseCommit(), pair.headCommit(), changedFiles);
-        List<WouldMissCase> misses = wouldMissComparator
-                .compare(enrichedPair, decisions, groundTruth, baseGroundTruth)
-                .wouldMissCases();
+        FailureComparison comparison = wouldMissComparator.compare(
+                enrichedPair, decisions, groundTruth, baseGroundTruth);
         List<FlakyFailure> flakyFailures = groundTruth.stream()
                 .filter(r -> r.outcome() == Outcome.FLAKY)
                 .map(r -> new FlakyFailure(enrichedPair, r.test()))
                 .toList();
 
-        return new PairAnalysis(enrichedPair, misses, decisions, flakyFailures);
+        return new PairAnalysis(enrichedPair, comparison.wouldMissCases(), comparison.coverage(), decisions, flakyFailures);
     }
 
     /**
@@ -393,7 +399,7 @@ public final class RunCommand {
 
     private static PairAnalysis excluded(CommitPair pair, String reason) {
         CommitPair excludedPair = CommitPair.excluded(pair.baseCommit(), pair.headCommit(), reason);
-        return new PairAnalysis(excludedPair, List.of(), List.of(), List.of());
+        return new PairAnalysis(excludedPair, List.of(), FailureCoverage.empty(), List.of(), List.of());
     }
 
     /**

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunConfig.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunConfig.java
@@ -9,8 +9,8 @@ import java.util.Objects;
  * The operator-supplied input for a single validator run (FR-001, FR-012).
  *
  * @param projectPath          local git working copy of the target project
- * @param commitWindowSize     number of most-recent commits to analyze; operator-chosen,
- *                             no fixed default (FR-012)
+ * @param commitWindowSize     number of most-recent direct parent-child history edges to
+ *                             analyze; operator-chosen, no fixed default (FR-012)
  * @param reportOutputPath     file path to write the JSON {@code AnalysisReport} to
  * @param mavenParallelThreads value for the target project's own {@code mvn -T} reactor
  *                             parallelism, or {@code null} to build serially (the default)

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunConfig.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunConfig.java
@@ -1,5 +1,6 @@
 package io.github.baokhang83.blastradius.validator.cli;
 
+import io.github.baokhang83.blastradius.validator.git.HistoryMode;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
@@ -43,7 +44,8 @@ import java.util.Objects;
  */
 public record RunConfig(
         Path projectPath, int commitWindowSize, Path reportOutputPath, Integer mavenParallelThreads,
-        boolean fastGroundTruth, int buildConcurrency, long buildTimeoutMinutes, boolean skipBuildExtras) {
+        boolean fastGroundTruth, int buildConcurrency, long buildTimeoutMinutes, boolean skipBuildExtras,
+        HistoryMode historyMode) {
 
     /** Default build timeout in minutes when the operator doesn't override it. */
     public static final long DEFAULT_BUILD_TIMEOUT_MINUTES = 5;
@@ -78,6 +80,14 @@ public record RunConfig(
                 buildConcurrency, buildTimeoutMinutes, false);
     }
 
+    /** Preserves the established configuration API while defaulting to broad graph coverage. */
+    public RunConfig(
+            Path projectPath, int commitWindowSize, Path reportOutputPath, Integer mavenParallelThreads,
+            boolean fastGroundTruth, int buildConcurrency, long buildTimeoutMinutes, boolean skipBuildExtras) {
+        this(projectPath, commitWindowSize, reportOutputPath, mavenParallelThreads, fastGroundTruth,
+                buildConcurrency, buildTimeoutMinutes, skipBuildExtras, HistoryMode.ALL_PARENTS);
+    }
+
     public RunConfig {
         Objects.requireNonNull(projectPath, "projectPath");
         if (!Files.isDirectory(projectPath)) {
@@ -90,6 +100,7 @@ public record RunConfig(
             throw new IllegalArgumentException("commitWindowSize must be positive, got: " + commitWindowSize);
         }
         Objects.requireNonNull(reportOutputPath, "reportOutputPath");
+        Objects.requireNonNull(historyMode, "historyMode");
         if (Files.isDirectory(reportOutputPath)) {
             throw new IllegalArgumentException("reportOutputPath must be a file path, not a directory: " + reportOutputPath);
         }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/CommitPair.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/CommitPair.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * A before/after pair of consecutive commits within the analyzed range.
+ * A direct parent-to-child history edge within the analyzed range.
  *
  * @param baseCommit      the earlier commit's SHA
  * @param headCommit      the later commit's SHA; ground truth is captured here

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/CommitWindowResolver.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/CommitWindowResolver.java
@@ -3,8 +3,8 @@ package io.github.baokhang83.blastradius.validator.git;
 import io.github.baokhang83.blastradius.core.git.ChangedFileClassifier;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Repository;
@@ -12,21 +12,33 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 
 /**
- * Resolves a fixed, operator-configurable window of the most recent consecutive commit
- * pairs on a target project's default branch (FR-012). Only the ordered (base, head) SHA
- * pairs are resolved here; {@code changedFiles} classification is a separate concern
- * (see {@link ChangedFileClassifier}) applied later in the pipeline.
+ * Resolves a fixed, operator-configurable window of direct parent-to-child edges in a target
+ * project's reachable history (FR-012). Only the ordered (base, head) SHA pairs are resolved
+ * here; {@code changedFiles} classification is a separate concern (see {@link
+ * ChangedFileClassifier}) applied later in the pipeline.
  */
 public final class CommitWindowResolver {
 
     /**
      * @param repoPath   local working copy with full git history
-     * @param windowSize number of most-recent commit pairs to resolve; a window of N
-     *                   requires N+1 commits and yields N pairs. Returns fewer pairs if
-     *                   the repository's history is shorter than requested.
-     * @return pairs ordered oldest-to-newest (chronological replay order)
+     * @param windowSize number of most-recent parent-child edges to resolve
+     * @return pairs ordered oldest-to-newest (replay order), including every direct parent edge
+     *         for a reachable merge commit
      */
     public List<CommitPair> resolveWindow(Path repoPath, int windowSize) {
+        return resolveWindow(repoPath, windowSize, HistoryMode.ALL_PARENTS);
+    }
+
+    /**
+     * Resolves a fixed window of direct parent-to-child history edges according to {@code mode}.
+     *
+     * @param repoPath   local working copy with full git history
+     * @param windowSize number of most-recent parent-child edges to resolve
+     * @param mode       whether every parent edge or only first-parent edges are included
+     * @return pairs ordered oldest-to-newest (replay order)
+     */
+    public List<CommitPair> resolveWindow(Path repoPath, int windowSize, HistoryMode mode) {
+        Objects.requireNonNull(mode, "mode");
         try (Git git = Git.open(repoPath.toFile())) {
             Repository repo = git.getRepository();
             ObjectId head = repo.resolve("HEAD");
@@ -34,29 +46,29 @@ public final class CommitWindowResolver {
                 return List.of();
             }
 
-            List<RevCommit> newestFirst = new ArrayList<>();
+            List<CommitPair> newestFirst = new ArrayList<>();
             try (RevWalk walk = new RevWalk(repo)) {
                 RevCommit start = walk.parseCommit(head);
                 walk.markStart(start);
-                int limit = windowSize + 1;
                 for (RevCommit commit : walk) {
-                    newestFirst.add(commit);
-                    if (newestFirst.size() >= limit) {
+                    int parentCount = mode == HistoryMode.FIRST_PARENT
+                            ? Math.min(1, commit.getParentCount())
+                            : commit.getParentCount();
+                    for (int parentIndex = 0; parentIndex < parentCount; parentIndex++) {
+                        newestFirst.add(CommitPair.analyzed(
+                                commit.getParent(parentIndex).getName(), commit.getName(), List.of()));
+                        if (newestFirst.size() >= windowSize) {
+                            break;
+                        }
+                    }
+                    if (newestFirst.size() >= windowSize) {
                         break;
                     }
                 }
             }
 
-            List<RevCommit> oldestFirst = new ArrayList<>(newestFirst);
-            Collections.reverse(oldestFirst);
-
-            List<CommitPair> pairs = new ArrayList<>();
-            for (int i = 0; i < oldestFirst.size() - 1; i++) {
-                String base = oldestFirst.get(i).getName();
-                String headSha = oldestFirst.get(i + 1).getName();
-                pairs.add(CommitPair.analyzed(base, headSha, List.of()));
-            }
-            return pairs;
+            java.util.Collections.reverse(newestFirst);
+            return newestFirst;
         } catch (Exception e) {
             throw new IllegalStateException("failed to resolve commit window for " + repoPath, e);
         }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/HistoryMode.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/HistoryMode.java
@@ -1,10 +1,20 @@
 package io.github.baokhang83.blastradius.validator.git;
 
+import java.util.Locale;
+
 /** Defines which direct parent edges a historical validator replay includes. */
 public enum HistoryMode {
     /** Replay every direct parent edge for commits reachable from {@code HEAD}. */
     ALL_PARENTS,
 
     /** Replay only each reachable commit's first parent edge. */
-    FIRST_PARENT
+    FIRST_PARENT;
+
+    /** Parses the stable kebab-case CLI spelling as well as the enum spelling. */
+    public static HistoryMode fromCliValue(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("history mode must not be null");
+        }
+        return valueOf(value.trim().toUpperCase(Locale.ROOT).replace('-', '_'));
+    }
 }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/HistoryMode.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/HistoryMode.java
@@ -1,0 +1,10 @@
+package io.github.baokhang83.blastradius.validator.git;
+
+/** Defines which direct parent edges a historical validator replay includes. */
+public enum HistoryMode {
+    /** Replay every direct parent edge for commits reachable from {@code HEAD}. */
+    ALL_PARENTS,
+
+    /** Replay only each reachable commit's first parent edge. */
+    FIRST_PARENT
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/report/AnalysisReport.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/report/AnalysisReport.java
@@ -1,6 +1,7 @@
 package io.github.baokhang83.blastradius.validator.report;
 
 import io.github.baokhang83.blastradius.validator.git.CommitPair;
+import io.github.baokhang83.blastradius.validator.git.HistoryMode;
 import io.github.baokhang83.blastradius.validator.verdict.FlakyFailure;
 import io.github.baokhang83.blastradius.validator.verdict.Verdict;
 import io.github.baokhang83.blastradius.validator.verdict.WouldMissCase;
@@ -16,8 +17,29 @@ import java.util.List;
  */
 public record AnalysisReport(
         Verdict verdict,
+        HistoryMode historyMode,
         List<CommitPair> analyzedCommitPairs,
         List<CommitPair> excludedCommitPairs,
+        FailureCoverage failureCoverage,
         List<WouldMissCase> wouldMissCases,
         List<FlakyFailure> flakyFailures,
-        SavingsSummary savingsSummary) {}
+        SavingsSummary savingsSummary) {
+
+    /** Compatibility constructor for callers that do not yet supply the newly-visible fields. */
+    public AnalysisReport(
+            Verdict verdict,
+            List<CommitPair> analyzedCommitPairs,
+            List<CommitPair> excludedCommitPairs,
+            List<WouldMissCase> wouldMissCases,
+            List<FlakyFailure> flakyFailures,
+            SavingsSummary savingsSummary) {
+        this(verdict, HistoryMode.ALL_PARENTS, analyzedCommitPairs, excludedCommitPairs,
+                legacyFailureCoverage(wouldMissCases), wouldMissCases, flakyFailures, savingsSummary);
+    }
+
+    private static FailureCoverage legacyFailureCoverage(List<WouldMissCase> wouldMissCases) {
+        int misses = wouldMissCases.size();
+        int pairs = (int) wouldMissCases.stream().map(WouldMissCase::commitPair).distinct().count();
+        return new FailureCoverage(pairs, misses, 0, misses);
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/report/FailureCoverage.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/report/FailureCoverage.java
@@ -1,0 +1,36 @@
+package io.github.baokhang83.blastradius.validator.report;
+
+/** Aggregate coverage of newly confirmed test failures observed during historical replay. */
+public record FailureCoverage(
+        int pairsWithNewlyConfirmedFailures,
+        int newlyConfirmedFailingTests,
+        int selectedNewlyConfirmedFailures,
+        int skippedNewlyConfirmedFailures) {
+
+    public FailureCoverage {
+        if (pairsWithNewlyConfirmedFailures < 0 || newlyConfirmedFailingTests < 0
+                || selectedNewlyConfirmedFailures < 0 || skippedNewlyConfirmedFailures < 0) {
+            throw new IllegalArgumentException("failure coverage counts must not be negative");
+        }
+        if (selectedNewlyConfirmedFailures + skippedNewlyConfirmedFailures != newlyConfirmedFailingTests) {
+            throw new IllegalArgumentException("selected and skipped failures must sum to newly confirmed failures");
+        }
+        if (pairsWithNewlyConfirmedFailures > newlyConfirmedFailingTests) {
+            throw new IllegalArgumentException("failure-bearing pairs cannot exceed newly confirmed failures");
+        }
+    }
+
+    /** No newly confirmed failures were observed. */
+    public static FailureCoverage empty() {
+        return new FailureCoverage(0, 0, 0, 0);
+    }
+
+    /** Combines disjoint per-pair coverage results into a window-wide total. */
+    public FailureCoverage plus(FailureCoverage other) {
+        return new FailureCoverage(
+                pairsWithNewlyConfirmedFailures + other.pairsWithNewlyConfirmedFailures,
+                newlyConfirmedFailingTests + other.newlyConfirmedFailingTests,
+                selectedNewlyConfirmedFailures + other.selectedNewlyConfirmedFailures,
+                skippedNewlyConfirmedFailures + other.skippedNewlyConfirmedFailures);
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/report/TextSummaryRenderer.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/report/TextSummaryRenderer.java
@@ -14,12 +14,23 @@ public final class TextSummaryRenderer {
     public String render(AnalysisReport report) {
         StringBuilder sb = new StringBuilder();
         sb.append("Verdict: ").append(report.verdict()).append('\n');
+        sb.append("History mode: ").append(report.historyMode()).append('\n');
         sb.append("Analyzed: ").append(report.analyzedCommitPairs().size()).append(" commit pair(s)");
         if (!report.excludedCommitPairs().isEmpty()) {
             sb.append(" (").append(report.excludedCommitPairs().size())
                     .append(" excluded — see report for reasons)");
         }
         sb.append('\n');
+        FailureCoverage coverage = report.failureCoverage();
+        sb.append("Failure coverage:\n");
+        sb.append("  - Pairs with newly confirmed failures: ")
+                .append(coverage.pairsWithNewlyConfirmedFailures()).append('\n');
+        sb.append("  - Newly confirmed failing tests: ")
+                .append(coverage.newlyConfirmedFailingTests()).append('\n');
+        sb.append("  - Newly confirmed failures selected: ")
+                .append(coverage.selectedNewlyConfirmedFailures()).append('\n');
+        sb.append("  - Newly confirmed failures skipped: ")
+                .append(coverage.skippedNewlyConfirmedFailures()).append('\n');
         sb.append("Would-miss cases: ").append(report.wouldMissCases().size()).append('\n');
 
         for (WouldMissCase miss : report.wouldMissCases()) {
@@ -40,9 +51,10 @@ public final class TextSummaryRenderer {
         sb.append("  - module-scoped fallback: ").append(savings.moduleScopedFallbackSelections()).append('\n');
         sb.append("  - new-or-modified: ").append(savings.newOrModifiedTestSelections()).append('\n');
 
+        sb.append("Excluded pairs: ").append(report.excludedCommitPairs().size()).append('\n');
+        sb.append("Flaky failures observed: ").append(report.flakyFailures().size())
+                .append(" (excluded from verdict)\n");
         if (!report.flakyFailures().isEmpty()) {
-            sb.append("Flaky failures observed: ").append(report.flakyFailures().size())
-                    .append(" (excluded from verdict)\n");
             for (FlakyFailure flaky : report.flakyFailures()) {
                 sb.append("  - commit ").append(flaky.commitPair().baseCommit())
                         .append("..").append(flaky.commitPair().headCommit())

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/verdict/FailureComparison.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/verdict/FailureComparison.java
@@ -1,0 +1,18 @@
+package io.github.baokhang83.blastradius.validator.verdict;
+
+import io.github.baokhang83.blastradius.validator.report.FailureCoverage;
+import java.util.List;
+import java.util.Objects;
+
+/** The individual misses and aggregate coverage produced for one replayed commit edge. */
+public record FailureComparison(List<WouldMissCase> wouldMissCases, FailureCoverage coverage) {
+
+    public FailureComparison {
+        Objects.requireNonNull(wouldMissCases, "wouldMissCases");
+        Objects.requireNonNull(coverage, "coverage");
+        wouldMissCases = List.copyOf(wouldMissCases);
+        if (wouldMissCases.size() != coverage.skippedNewlyConfirmedFailures()) {
+            throw new IllegalArgumentException("would-miss cases must equal skipped newly confirmed failures");
+        }
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/verdict/WouldMissComparator.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/verdict/WouldMissComparator.java
@@ -4,6 +4,7 @@ import io.github.baokhang83.blastradius.validator.build.GroundTruthResult;
 import io.github.baokhang83.blastradius.validator.build.Outcome;
 import io.github.baokhang83.blastradius.core.git.ChangedFile;
 import io.github.baokhang83.blastradius.validator.git.CommitPair;
+import io.github.baokhang83.blastradius.validator.report.FailureCoverage;
 import io.github.baokhang83.blastradius.core.selection.SelectionDecision;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import java.util.ArrayList;
@@ -31,7 +32,7 @@ public final class WouldMissComparator {
      *                        Selection had nothing to catch: the failure predates the
      *                        diff, so no dependency edge could have flagged it.
      */
-    public List<WouldMissCase> compare(
+    public FailureComparison compare(
             CommitPair pair, List<SelectionDecision> decisions, List<GroundTruthResult> groundTruth,
             List<GroundTruthResult> baseGroundTruth) {
         Map<TestIdentity, SelectionDecision> decisionByTest =
@@ -47,6 +48,8 @@ public final class WouldMissComparator {
                 .toList();
 
         List<WouldMissCase> misses = new ArrayList<>();
+        int newlyConfirmedFailures = 0;
+        int selectedNewlyConfirmedFailures = 0;
         for (GroundTruthResult result : groundTruth) {
             if (result.outcome() != Outcome.CONFIRMED_FAILED) {
                 continue;
@@ -54,13 +57,19 @@ public final class WouldMissComparator {
             if (preExistingFailures.contains(result.test())) {
                 continue;
             }
+            newlyConfirmedFailures++;
             SelectionDecision decision = decisionByTest.get(result.test());
             if (decision != null && decision.selected()) {
+                selectedNewlyConfirmedFailures++;
                 continue;
             }
             String reason = decision == null ? "no selection decision recorded" : decision.reason().name();
             misses.add(new WouldMissCase(pair, result.test(), changedClasses, reason));
         }
-        return misses;
+        return new FailureComparison(misses, new FailureCoverage(
+                newlyConfirmedFailures == 0 ? 0 : 1,
+                newlyConfirmedFailures,
+                selectedNewlyConfirmedFailures,
+                misses.size()));
     }
 }

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/EndToEndVerdictIntegrationTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/EndToEndVerdictIntegrationTest.java
@@ -128,6 +128,11 @@ class EndToEndVerdictIntegrationTest {
         assertEquals(1, exitCode, "expected FAIL verdict (exit code 1)");
         JsonNode report = new ObjectMapper().readTree(reportFile.toFile());
         assertEquals("FAIL", report.get("verdict").asText());
+        assertEquals("ALL_PARENTS", report.get("historyMode").asText());
+        assertEquals(1, report.get("failureCoverage").get("pairsWithNewlyConfirmedFailures").asInt());
+        assertEquals(1, report.get("failureCoverage").get("newlyConfirmedFailingTests").asInt());
+        assertEquals(0, report.get("failureCoverage").get("selectedNewlyConfirmedFailures").asInt());
+        assertEquals(1, report.get("failureCoverage").get("skippedNewlyConfirmedFailures").asInt());
         assertEquals(1, report.get("wouldMissCases").size());
         assertEquals("com.example.GapTest", report.get("wouldMissCases").get(0).get("test").get("className").asText());
     }

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/cli/RunConfigTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/cli/RunConfigTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.github.baokhang83.blastradius.validator.git.HistoryMode;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -23,6 +24,7 @@ class RunConfigTest {
         assertEquals(repo, config.projectPath());
         assertEquals(50, config.commitWindowSize());
         assertEquals(reportOut, config.reportOutputPath());
+        assertEquals(HistoryMode.ALL_PARENTS, config.historyMode());
     }
 
     @Test

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/git/CommitWindowResolverTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/git/CommitWindowResolverTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
 import java.nio.file.Path;
+import java.util.Set;
 import java.util.List;
+import org.eclipse.jgit.api.Git;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -54,6 +56,51 @@ class CommitWindowResolverTest {
         List<CommitPair> window = resolver.resolveWindow(tempDir, 5);
 
         assertTrue(window.isEmpty());
+    }
+
+    @Test
+    void defaultModeReplaysEveryDirectParentEdgeOfAReachableMerge(@TempDir Path tempDir) throws Exception {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(tempDir);
+        fixture.commit("initial");
+        Git git = fixture.git();
+
+        git.checkout().setCreateBranch(true).setName("feature").call();
+        fixture.writeResource("feature.txt", "feature");
+        String featureParent = fixture.commit("feature work");
+
+        git.checkout().setName("main").call();
+        fixture.writeResource("main.txt", "main");
+        String firstParent = fixture.commit("main work");
+
+        git.merge().include(git.getRepository().resolve(featureParent)).call();
+        String merge = git.getRepository().resolve("HEAD").getName();
+
+        List<CommitPair> window = resolver.resolveWindow(tempDir, 2);
+
+        assertEquals(Set.of(new PairKey(firstParent, merge), new PairKey(featureParent, merge)),
+                window.stream().map(CommitWindowResolverTest::keyOf).collect(java.util.stream.Collectors.toSet()));
+    }
+
+    @Test
+    void firstParentModeReplaysOnlyTheMainlineEdgeOfAReachableMerge(@TempDir Path tempDir) throws Exception {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(tempDir);
+        fixture.commit("initial");
+        Git git = fixture.git();
+
+        git.checkout().setCreateBranch(true).setName("feature").call();
+        fixture.writeResource("feature.txt", "feature");
+        String featureParent = fixture.commit("feature work");
+
+        git.checkout().setName("main").call();
+        fixture.writeResource("main.txt", "main");
+        String firstParent = fixture.commit("main work");
+
+        git.merge().include(git.getRepository().resolve(featureParent)).call();
+        String merge = git.getRepository().resolve("HEAD").getName();
+
+        List<CommitPair> window = resolver.resolveWindow(tempDir, 1, HistoryMode.FIRST_PARENT);
+
+        assertEquals(List.of(new PairKey(firstParent, merge)), window.stream().map(CommitWindowResolverTest::keyOf).toList());
     }
 
     private record PairKey(String base, String head) {}

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/git/HistoryModeTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/git/HistoryModeTest.java
@@ -1,0 +1,20 @@
+package io.github.baokhang83.blastradius.validator.git;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class HistoryModeTest {
+
+    @Test
+    void parsesCliValuesCaseInsensitively() {
+        assertEquals(HistoryMode.ALL_PARENTS, HistoryMode.fromCliValue("all-parents"));
+        assertEquals(HistoryMode.FIRST_PARENT, HistoryMode.fromCliValue("FIRST_PARENT"));
+    }
+
+    @Test
+    void rejectsUnknownCliValues() {
+        assertThrows(IllegalArgumentException.class, () -> HistoryMode.fromCliValue("adjacent"));
+    }
+}

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/report/AnalysisReportContractTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/report/AnalysisReportContractTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.baokhang83.blastradius.validator.git.CommitPair;
+import io.github.baokhang83.blastradius.validator.git.HistoryMode;
 import io.github.baokhang83.blastradius.core.selection.SelectionDecision;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import io.github.baokhang83.blastradius.validator.verdict.Verdict;
@@ -84,6 +85,24 @@ class AnalysisReportContractTest {
         AnalysisReport parsed = roundTrip(original);
 
         assertEquals(original, parsed);
+    }
+
+    @Test
+    void reportCarriesTheHistoryModeAndFailureCoverageDenominator() throws Exception {
+        AnalysisReport report = new AnalysisReport(
+                Verdict.PASS,
+                HistoryMode.FIRST_PARENT,
+                List.of(),
+                List.of(),
+                new FailureCoverage(2, 3, 3, 0),
+                List.of(),
+                List.of(),
+                aggregator.aggregate(List.of()));
+
+        AnalysisReport parsed = roundTrip(report);
+
+        assertEquals(HistoryMode.FIRST_PARENT, parsed.historyMode());
+        assertEquals(new FailureCoverage(2, 3, 3, 0), parsed.failureCoverage());
     }
 
     private AnalysisReport roundTrip(AnalysisReport report) throws Exception {

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/report/TextSummaryRendererTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/report/TextSummaryRendererTest.java
@@ -3,6 +3,7 @@ package io.github.baokhang83.blastradius.validator.report;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.baokhang83.blastradius.validator.git.CommitPair;
+import io.github.baokhang83.blastradius.validator.git.HistoryMode;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import io.github.baokhang83.blastradius.validator.verdict.Verdict;
 import io.github.baokhang83.blastradius.validator.verdict.WouldMissCase;
@@ -63,5 +64,26 @@ class TextSummaryRendererTest {
         assertTrue(text.contains("com.example.BTest#b"));
         assertTrue(text.contains("com.example.CTest#c"));
         assertTrue(text.contains("Would-miss cases: 3"));
+    }
+
+    @Test
+    void rendersReplayModeAndFailureCoverageBeforeWouldMissDetails() {
+        AnalysisReport report = new AnalysisReport(
+                Verdict.PASS,
+                HistoryMode.ALL_PARENTS,
+                List.of(),
+                List.of(),
+                new FailureCoverage(2, 3, 2, 1),
+                List.of(),
+                List.of(),
+                new SavingsSummary(3, 2, 1.0 / 3.0, 1, 0, 1, 0));
+
+        String text = renderer.render(report);
+
+        assertTrue(text.contains("History mode: ALL_PARENTS"));
+        assertTrue(text.contains("Pairs with newly confirmed failures: 2"));
+        assertTrue(text.contains("Newly confirmed failing tests: 3"));
+        assertTrue(text.contains("Newly confirmed failures selected: 2"));
+        assertTrue(text.contains("Newly confirmed failures skipped: 1"));
     }
 }

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/verdict/WouldMissComparatorTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/verdict/WouldMissComparatorTest.java
@@ -8,6 +8,7 @@ import io.github.baokhang83.blastradius.validator.build.Outcome;
 import io.github.baokhang83.blastradius.core.git.ChangedFile;
 import io.github.baokhang83.blastradius.validator.git.CommitPair;
 import io.github.baokhang83.blastradius.core.git.FileKind;
+import io.github.baokhang83.blastradius.validator.report.FailureCoverage;
 import io.github.baokhang83.blastradius.core.selection.SelectionDecision;
 import io.github.baokhang83.blastradius.core.selection.SelectionReason;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
@@ -26,10 +27,10 @@ class WouldMissComparatorTest {
         List<SelectionDecision> decisions = List.of(SelectionDecision.noMatch(FOO_TEST));
         List<GroundTruthResult> groundTruth = List.of(new GroundTruthResult(FOO_TEST, Outcome.CONFIRMED_FAILED));
 
-        List<WouldMissCase> misses = comparator.compare(pair, decisions, groundTruth, List.of());
+        FailureComparison comparison = comparator.compare(pair, decisions, groundTruth, List.of());
 
-        assertEquals(1, misses.size());
-        WouldMissCase miss = misses.get(0);
+        assertEquals(new FailureCoverage(1, 1, 0, 1), comparison.coverage());
+        WouldMissCase miss = comparison.wouldMissCases().get(0);
         assertEquals(FOO_TEST, miss.test());
         assertEquals(pair, miss.commitPair());
         assertTrue(miss.changedClasses().contains("com.example.Foo"));
@@ -42,9 +43,10 @@ class WouldMissComparatorTest {
         List<SelectionDecision> decisions = List.of(SelectionDecision.dependencyMatch(FOO_TEST, "com.example.Foo"));
         List<GroundTruthResult> groundTruth = List.of(new GroundTruthResult(FOO_TEST, Outcome.CONFIRMED_FAILED));
 
-        List<WouldMissCase> misses = comparator.compare(pair, decisions, groundTruth, List.of());
+        FailureComparison comparison = comparator.compare(pair, decisions, groundTruth, List.of());
 
-        assertEquals(0, misses.size());
+        assertEquals(new FailureCoverage(1, 1, 1, 0), comparison.coverage());
+        assertTrue(comparison.wouldMissCases().isEmpty());
     }
 
     @Test
@@ -53,9 +55,10 @@ class WouldMissComparatorTest {
         List<SelectionDecision> decisions = List.of(SelectionDecision.noMatch(FOO_TEST));
         List<GroundTruthResult> groundTruth = List.of(new GroundTruthResult(FOO_TEST, Outcome.PASSED));
 
-        List<WouldMissCase> misses = comparator.compare(pair, decisions, groundTruth, List.of());
+        FailureComparison comparison = comparator.compare(pair, decisions, groundTruth, List.of());
 
-        assertEquals(0, misses.size());
+        assertEquals(FailureCoverage.empty(), comparison.coverage());
+        assertTrue(comparison.wouldMissCases().isEmpty());
     }
 
     @Test
@@ -64,9 +67,10 @@ class WouldMissComparatorTest {
         List<SelectionDecision> decisions = List.of(SelectionDecision.noMatch(FOO_TEST));
         List<GroundTruthResult> groundTruth = List.of(new GroundTruthResult(FOO_TEST, Outcome.FLAKY));
 
-        List<WouldMissCase> misses = comparator.compare(pair, decisions, groundTruth, List.of());
+        FailureComparison comparison = comparator.compare(pair, decisions, groundTruth, List.of());
 
-        assertEquals(0, misses.size());
+        assertEquals(FailureCoverage.empty(), comparison.coverage());
+        assertTrue(comparison.wouldMissCases().isEmpty());
     }
 
     @Test
@@ -74,9 +78,10 @@ class WouldMissComparatorTest {
         CommitPair pair = CommitPair.analyzed("base", "head", List.of());
         List<GroundTruthResult> groundTruth = List.of(new GroundTruthResult(FOO_TEST, Outcome.CONFIRMED_FAILED));
 
-        List<WouldMissCase> misses = comparator.compare(pair, List.of(), groundTruth, List.of());
+        FailureComparison comparison = comparator.compare(pair, List.of(), groundTruth, List.of());
 
-        assertEquals(1, misses.size());
+        assertEquals(new FailureCoverage(1, 1, 0, 1), comparison.coverage());
+        assertEquals(1, comparison.wouldMissCases().size());
     }
 
     @Test
@@ -90,9 +95,10 @@ class WouldMissComparatorTest {
         List<GroundTruthResult> groundTruth = List.of(new GroundTruthResult(FOO_TEST, Outcome.CONFIRMED_FAILED));
         List<GroundTruthResult> baseGroundTruth = List.of(new GroundTruthResult(FOO_TEST, Outcome.CONFIRMED_FAILED));
 
-        List<WouldMissCase> misses = comparator.compare(pair, decisions, groundTruth, baseGroundTruth);
+        FailureComparison comparison = comparator.compare(pair, decisions, groundTruth, baseGroundTruth);
 
-        assertEquals(0, misses.size());
+        assertEquals(FailureCoverage.empty(), comparison.coverage());
+        assertTrue(comparison.wouldMissCases().isEmpty());
     }
 
     @Test
@@ -105,8 +111,26 @@ class WouldMissComparatorTest {
         List<GroundTruthResult> groundTruth = List.of(new GroundTruthResult(FOO_TEST, Outcome.CONFIRMED_FAILED));
         List<GroundTruthResult> baseGroundTruth = List.of(new GroundTruthResult(FOO_TEST, Outcome.FLAKY));
 
-        List<WouldMissCase> misses = comparator.compare(pair, decisions, groundTruth, baseGroundTruth);
+        FailureComparison comparison = comparator.compare(pair, decisions, groundTruth, baseGroundTruth);
 
-        assertEquals(1, misses.size());
+        assertEquals(new FailureCoverage(1, 1, 0, 1), comparison.coverage());
+        assertEquals(1, comparison.wouldMissCases().size());
+    }
+
+    @Test
+    void coverageCountsSelectedAndSkippedNewFailuresWithinOnePair() {
+        TestIdentity selected = new TestIdentity("com.example.SelectedTest", "checksSelected");
+        CommitPair pair = CommitPair.analyzed("base", "head", List.of());
+        List<SelectionDecision> decisions = List.of(
+                SelectionDecision.dependencyMatch(selected, "com.example.Shared"),
+                SelectionDecision.noMatch(FOO_TEST));
+        List<GroundTruthResult> groundTruth = List.of(
+                new GroundTruthResult(selected, Outcome.CONFIRMED_FAILED),
+                new GroundTruthResult(FOO_TEST, Outcome.CONFIRMED_FAILED));
+
+        FailureComparison comparison = comparator.compare(pair, decisions, groundTruth, List.of());
+
+        assertEquals(new FailureCoverage(1, 2, 1, 1), comparison.coverage());
+        assertEquals(1, comparison.wouldMissCases().size());
     }
 }

--- a/docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/design.md
+++ b/docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/design.md
@@ -1,0 +1,155 @@
+# Design: Replay real parent-child history edges and report failure-bearing coverage
+
+FluencyLoop Stage 2 for [issue #186](https://github.com/baokhang83/blastradius/issues/186).
+
+## Class diagram
+
+```mermaid
+classDiagram
+    class RunConfig {
+        +HistoryMode historyMode
+        +int commitWindowSize
+    }
+    class HistoryMode {
+        <<enumeration>>
+        ALL_PARENTS
+        FIRST_PARENT
+    }
+    class CommitWindowResolver {
+        +resolveWindow(repoPath, windowSize, historyMode) List~CommitPair~
+    }
+    class CommitPair {
+        +String baseCommit
+        +String headCommit
+        +List~ChangedFile~ changedFiles
+    }
+    class RunCommand {
+        +analyzeWindow() AnalysisReport
+    }
+    class WouldMissComparator {
+        +compare() FailureComparison
+    }
+    class FailureComparison {
+        +List~WouldMissCase~ wouldMissCases
+        +FailureCoverage coverage
+    }
+    class FailureCoverage {
+        +int pairsWithNewlyConfirmedFailures
+        +int newlyConfirmedFailingTests
+        +int selectedNewlyConfirmedFailures
+        +int skippedNewlyConfirmedFailures
+    }
+    class AnalysisReport {
+        +HistoryMode historyMode
+        +List~CommitPair~ analyzedCommitPairs
+        +List~CommitPair~ excludedCommitPairs
+        +FailureCoverage failureCoverage
+        +List~WouldMissCase~ wouldMissCases
+        +List~FlakyFailure~ flakyFailures
+    }
+    class TextSummaryRenderer {
+        +render(report) String
+    }
+
+    RunConfig --> HistoryMode
+    CommitWindowResolver --> HistoryMode
+    CommitWindowResolver --> CommitPair
+    RunCommand --> CommitWindowResolver
+    RunCommand --> WouldMissComparator
+    WouldMissComparator --> FailureComparison
+    FailureComparison --> FailureCoverage
+    FailureComparison --> WouldMissCase
+    RunCommand --> AnalysisReport
+    AnalysisReport --> FailureCoverage
+    TextSummaryRenderer --> AnalysisReport
+```
+
+## Sequence: resolve, replay, and account for a real edge
+
+```mermaid
+sequenceDiagram
+    participant Operator
+    participant CLI as RunCommand
+    participant Resolver as CommitWindowResolver
+    participant Git as Reachable Git graph
+    participant Build as Build cache
+    participant Compare as WouldMissComparator
+    participant Report as AnalysisReport
+
+    Operator->>CLI: run with history mode and edge window
+    CLI->>Resolver: resolveWindow(project, size, mode)
+    Resolver->>Git: walk commits reachable from HEAD
+    Git-->>Resolver: each child with its direct parent edges
+    Resolver-->>CLI: oldest to newest direct parent child pairs
+    loop each edge
+        CLI->>Build: load base tracking build and head ground truth
+        Build-->>CLI: dependency record and confirmed outcomes
+        CLI->>Compare: compare new confirmed failures to selections
+        Compare-->>CLI: miss cases and coverage counts
+    end
+    CLI->>Report: write pairs, coverage, misses, flakes, exclusions
+    Report-->>Operator: verdict with visible failure denominator
+```
+
+## Design
+
+### Direct graph edges, not traversal adjacency
+
+`CommitWindowResolver` will keep walking all commits reachable from `HEAD`, including commits
+preserved by merged branches. For every encountered child commit, it will emit its direct
+parent-to-child edge or edges instead of pairing neighbouring entries in `RevWalk` order.
+Every reported pair will therefore satisfy `baseCommit` is a Git parent of `headCommit`.
+
+`HistoryMode.ALL_PARENTS` is the default. It includes an edge from every direct parent of each
+reachable child, retaining broad merged-history coverage. `HistoryMode.FIRST_PARENT` is an
+explicit narrower mode for operators who want mainline-only replay. The edge window limits the
+number of emitted edges, not commits. The resolver returns the selected edges in a
+parent-before-child order for intelligible progress output. Duplicate commit builds remain cheap
+because `CommitBuildService` already keys and caches builds by commit plus agent attachment.
+
+Rejected: continue pairing adjacent `RevWalk` entries. That is compact but can compare unrelated
+commits in non-linear history, so it does not simulate an actual change.
+
+Rejected: first-parent-only as the sole mode. It is easy to explain but discards useful
+failure-bearing commits that survive in merged branch history, contrary to the issue goal.
+
+### Failure-bearing coverage is a first-class report result
+
+`WouldMissComparator` already distinguishes a newly confirmed head failure from a failure that
+was already confirmed on the base. It will return a `FailureComparison` rather than only a list
+of misses. The comparison produces both the existing individual `WouldMissCase` records and a
+`FailureCoverage` aggregate:
+
+- pairs with one or more newly confirmed failures
+- newly confirmed failing tests
+- newly confirmed failures selected
+- newly confirmed failures skipped
+
+The skipped count must equal the number of would-miss cases. A test that is flaky on confirmation
+does not enter this denominator, and a pair whose build fails before test reports exist remains
+excluded because test selection could not have influenced that failure. Exclusions and flaky
+failures remain visible in the JSON report and become explicit counts in the text summary.
+
+Rejected: infer the denominator from the would-miss list. A zero-sized miss list cannot say
+whether selection caught every observed failure or whether no new confirmed failure occurred.
+
+### Report compatibility and evidence wording
+
+`AnalysisReport` will include the history mode and `FailureCoverage`. The JSON contract test will
+lock down the new fields, and the text renderer will print the coverage block before individual
+would-miss cases. README wording will describe old adjacency-based analyses as superseded once
+the existing projects are rerun with this edge semantics; it must not present a zero miss count
+without its observed-failure denominator.
+
+## Constitution check
+
+- **I. Test-Driven Development:** resolver and comparator/report tests are written red before
+  production changes, including a merge graph that proves every edge is a direct parent edge.
+- **II. Clean Code and Simplicity:** the existing resolver, comparator, and report objects gain
+  small concrete values instead of a new validation framework.
+- **III. Safety Over Speed:** real edges and explicit failure denominators make evidence more
+  auditable, while pre-test build failures remain honestly excluded.
+- **IV. Deterministic Core Before ML:** graph traversal, edge selection, and counting are fully
+  deterministic.
+- **V. Explainability:** report consumers can see the replay mode, denominator, misses, flakes,
+  and exclusions rather than infer them.

--- a/docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/align-edge-terminology-in-public-validator-types.md
+++ b/docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/align-edge-terminology-in-public-validator-types.md
@@ -1,0 +1,10 @@
+# Session: align edge terminology in public validator types
+
+- **intent:** align edge terminology in public validator types
+- **started:** 2026-08-01
+
+## Knowledge transfer
+
+- **Public validator terminology:** `commitWindowSize` and `CommitPair` now describe direct
+  parent-child history edges. The `--commits` flag is retained for compatibility, but its count
+  is explicitly an edge budget in the current replay model. · status: documented

--- a/docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/mark-adjacency-based-analyses-superseded.md
+++ b/docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/mark-adjacency-based-analyses-superseded.md
@@ -1,0 +1,20 @@
+# Session: mark adjacency-based analyses superseded
+
+- **intent:** mark adjacency-based analyses superseded
+- **started:** 2026-08-01
+
+## Knowledge transfer
+
+- **Historical validation table:** records throughput evidence but formerly used `RevWalk`
+  adjacency, so its pairs are not guaranteed to be real changes. Keeping the figures labelled as
+  superseded preserves transparency without claiming they establish selection soundness. New
+  reports carry both replay mode and the observed-failure denominator. · status: documented
+
+## Decision: retain but supersede adjacency-based analysis results
+
+- **where:** `README historical validation section`
+- **why:** past savings measurements remain useful context but cannot support soundness claims without real edges and an observed-failure denominator
+- **alternative:** Delete the results or leave them presented as validation evidence — rejected: deletion loses provenance and the old wording overclaims what the runs establish
+- **design:** ../design.md#report-compatibility-and-evidence-wording
+- **constitution:** §V
+- **trust:** ✓ verified

--- a/docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/measure-newly-confirmed-failure-coverage-per-edge.md
+++ b/docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/measure-newly-confirmed-failure-coverage-per-edge.md
@@ -1,0 +1,23 @@
+# Session: measure newly confirmed failure coverage per edge
+
+- **intent:** measure newly confirmed failure coverage per edge
+- **started:** 2026-08-01
+
+## Knowledge transfer
+
+- **FailureCoverage:** records the observed, newly confirmed failure denominator and partitions
+  it into selected and skipped tests. Its constructor enforces non-negative values and the
+  selected-plus-skipped invariant, so a report cannot claim a denominator inconsistent with the
+  individual miss evidence. · status: documented
+- **FailureComparison:** is the comparator's per-edge result. It couples `WouldMissCase` detail
+  to the aggregate coverage and verifies that every skipped failure has an individual case. Base
+  failures and flaky head outcomes do not enter the new-failure denominator. · status: documented
+
+## Decision: couple failure coverage to comparator evidence
+
+- **where:** `WouldMissComparator, FailureComparison, and FailureCoverage`
+- **why:** the report needs a visible observed-failure denominator that cannot drift from the individual skipped failures
+- **alternative:** Infer totals from the would-miss list or keep independent counters — rejected: zero misses cannot distinguish full coverage from no observed failures and detached counters can disagree
+- **design:** ../design.md#failure-bearing-coverage-is-a-first-class-report-result
+- **constitution:** §III
+- **trust:** ✓ verified

--- a/docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/model-reachable-history-as-direct-parent-child-edges.md
+++ b/docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/model-reachable-history-as-direct-parent-child-edges.md
@@ -1,0 +1,23 @@
+# Session: model reachable history as direct parent-child edges
+
+- **intent:** model reachable history as direct parent-child edges
+- **started:** 2026-08-01
+
+## Knowledge transfer
+
+- **CommitWindowResolver:** walks the commits reachable from `HEAD`, but now turns each visited
+  child into one or more actual parent-to-child `CommitPair` values. The edge budget is consumed
+  by emitted edges, so a merge can occupy more than one slot. This prevents a `RevWalk` ordering
+  detail from being mistaken for a repository transition. · status: documented
+- **HistoryMode:** makes the graph-coverage policy explicit. `ALL_PARENTS` preserves reachable
+  merged-branch evidence and is the default; `FIRST_PARENT` remains available when an operator
+  intentionally wants mainline-only replay. · status: documented
+
+## Decision: replay direct parent edges with all parents by default
+
+- **where:** `CommitWindowResolver and HistoryMode`
+- **why:** each reported pair must be a real Git transition while retained merged-branch commits still contribute evidence
+- **alternative:** Pair adjacent RevWalk entries or make first-parent the only mode — rejected: adjacency can fabricate a transition and first-parent-only discards reachable branch evidence
+- **design:** ../design.md#direct-graph-edges-not-traversal-adjacency
+- **constitution:** §III
+- **trust:** ✓ verified

--- a/docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/surface-replay-mode-and-failure-denominator-in-reports.md
+++ b/docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/surface-replay-mode-and-failure-denominator-in-reports.md
@@ -1,0 +1,23 @@
+# Session: surface replay mode and failure denominator in reports
+
+- **intent:** surface replay mode and failure denominator in reports
+- **started:** 2026-08-01
+
+## Knowledge transfer
+
+- **RunConfig and Main:** accept `--history-mode all-parents|first-parent`, defaulting to
+  `ALL_PARENTS`, and carry the enum into the resolver. The enum parser accepts either kebab-case
+  CLI spelling or enum spelling, while rejecting an unrecognised mode. · status: documented
+- **AnalysisReport and TextSummaryRenderer:** serialize the replay mode and print a failure
+  coverage block before individual would-miss detail. Excluded pairs and flaky failures are
+  explicit summary counts, so zero misses cannot hide an empty observed-failure denominator.
+  · status: documented
+
+## Decision: serialize replay policy and observed failure coverage
+
+- **where:** `RunConfig, Main, AnalysisReport, RunCommand, and TextSummaryRenderer`
+- **why:** a result is auditable only when its direct-edge mode and observed failure denominator travel with the verdict
+- **alternative:** Infer replay semantics from a command line or show only would-miss cases — rejected: omitted mode and denominator make a zero-miss result ambiguous
+- **design:** ../design.md#report-compatibility-and-evidence-wording
+- **constitution:** §V
+- **trust:** ✓ verified


### PR DESCRIPTION
Closes #186

## Summary

- replay only real direct Git parent-to-child edges, with `ALL_PARENTS` as the default and `FIRST_PARENT` as an explicit opt-in
- expose the replay mode and the observed newly-confirmed-failure denominator in JSON and text reports
- retain old selection-savings data while marking adjacency-based analyses superseded for soundness claims

## Key decisions

- `CommitWindowResolver` emits direct graph edges rather than traversal neighbours, preserving merged-branch coverage without fabricating a change.
- `FailureCoverage` enforces that selected plus skipped newly confirmed failures equal the observed denominator, and that skipped failures equal individual would-miss cases.
- Reports carry their replay mode so reviewers can interpret the evidence without reconstructing CLI inputs.

## Validation

- `JAVA_HOME=/opt/homebrew/Cellar/openjdk/25.0.1/libexec/openjdk.jdk/Contents/Home mvn -B --no-transfer-progress clean verify`
- 133 generated Surefire/Failsafe reports inspected with no failures or errors

## Notes

- Existing published analyses are explicitly marked superseded for soundness claims pending reruns with direct-edge semantics and the new denominator.
