### PR TITLE
validator: add mutation-based soundness validation

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "replay-real-parent-child-history-edges-and-report-failure-be",
-  "branch": "feature/replay-real-parent-child-history-edges-and-report-failure-be",
-  "stage": "build",
-  "last_session": "docs/fluencyloop/features/replay-real-parent-child-history-edges-and-report-failure-be/sessions/align-edge-terminology-in-public-validator-types.md",
+  "feature": "add-opt-in-bounded-mutation-based-validator-soundness-valida",
+  "branch": "feature/add-opt-in-bounded-mutation-based-validator-soundness-valida",
+  "stage": "design",
+  "last_session": "",
   "base_ref": "main",
   "updated": "2026-08-01"
 }

--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
   "feature": "add-opt-in-bounded-mutation-based-validator-soundness-valida",
   "branch": "feature/add-opt-in-bounded-mutation-based-validator-soundness-valida",
-  "stage": "design",
-  "last_session": "",
+  "stage": "build",
+  "last_session": "docs/fluencyloop/features/add-opt-in-bounded-mutation-based-validator-soundness-valida/sessions/run-bounded-mutation-experiments-and-report-confirmed-misses.md",
   "base_ref": "main",
   "updated": "2026-08-01"
 }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,30 @@ These historical windows are not a universal guarantee. Current validator report
 zero would-miss cases without that denominator are not a soundness result. Full suites remain the
 recommended daily safety net.
 
+## Controlled mutation validation
+
+Historical replay can contain few newly confirmed failures. The validator also offers an opt-in,
+bounded mutation mode that creates one synthetic, compiling child commit in a disposable clone,
+runs the full suite, and checks that every test which demonstrably kills the mutation was selected
+for that real `B → M` edge. It never changes the project working tree you point it at.
+
+```sh
+java -jar blastradius-validator/target/blastradius-validator-0.3.2.jar mutate \
+  --project-path ../your-maven-project \
+  --report-out mutation-report.json \
+  --summary-out mutation-summary.txt \
+  --max-classes 10 \
+  --max-mutations 10 \
+  --mutation-time-limit-minutes 60
+```
+
+The first deterministic corpus inverts boolean literals and equality or relational operators in
+`src/main/java`. A killing test must pass on the baseline, fail on the mutant, and remain failed
+on confirmation. Unbuildable mutants, baseline failures, and flakes are reported separately and
+do not become soundness failures. This is sampled fault evidence, not a claim that all real
+changes or every possible defect are covered. Use the optional `--mutation-class <FQCN>` only
+when you want to focus the bounded run on one production class.
+
 ## How it works
 
 1. **Track.** On a build of your base branch, a `java.lang.instrument` agent watches every

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ java -jar blastradius-validator/target/blastradius-validator-0.3.2.jar mutate \
   --project-path ../your-maven-project \
   --report-out mutation-report.json \
   --summary-out mutation-summary.txt \
-  --max-classes 10 \
+  --max-mutation-classes 10 \
   --max-mutations 10 \
   --mutation-time-limit-minutes 60
 ```

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/Main.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/Main.java
@@ -92,7 +92,7 @@ public final class Main {
         Path reportOut = null;
         Path summaryOut = null;
         String classFilter = null;
-        int maxClasses = MutationConfig.DEFAULT_MAX_CLASSES;
+        int maxMutationClasses = MutationConfig.DEFAULT_MAX_CLASSES;
         int maxMutations = MutationConfig.DEFAULT_MAX_MUTATIONS;
         long timeLimitMinutes = MutationConfig.DEFAULT_TIME_LIMIT_MINUTES;
         Integer mavenThreads = null;
@@ -104,7 +104,7 @@ public final class Main {
                 case "--report-out" -> reportOut = Path.of(args[++i]);
                 case "--summary-out" -> summaryOut = Path.of(args[++i]);
                 case "--mutation-class" -> classFilter = args[++i];
-                case "--max-classes" -> maxClasses = Integer.parseInt(args[++i]);
+                case "--max-mutation-classes" -> maxMutationClasses = Integer.parseInt(args[++i]);
                 case "--max-mutations" -> maxMutations = Integer.parseInt(args[++i]);
                 case "--mutation-time-limit-minutes" -> timeLimitMinutes = Long.parseLong(args[++i]);
                 case "--maven-threads" -> mavenThreads = Integer.parseInt(args[++i]);
@@ -123,7 +123,7 @@ public final class Main {
             return;
         }
         try {
-            MutationConfig config = new MutationConfig(projectPath, reportOut, classFilter, maxClasses, maxMutations,
+            MutationConfig config = new MutationConfig(projectPath, reportOut, classFilter, maxMutationClasses, maxMutations,
                     timeLimitMinutes, mavenThreads, buildTimeoutMinutes, skipBuildExtras);
             int exitCode = new MutationCommand().run(config);
             printMutationSummary(reportOut, summaryOut, exitCode);
@@ -175,7 +175,7 @@ public final class Main {
                 + "[--build-concurrency <K>] [--build-timeout-minutes <M>] [--skip-build-extras] "
                 + "[--history-mode <all-parents|first-parent>]\n"
                 + "   or: mutate --project-path <path> --report-out <path> [--summary-out <path>] "
-                + "[--mutation-class <FQCN>] [--max-classes <N>] [--max-mutations <N>] "
+                + "[--mutation-class <FQCN>] [--max-mutation-classes <N>] [--max-mutations <N>] "
                 + "[--mutation-time-limit-minutes <M>] [--maven-threads <N>] "
                 + "[--build-timeout-minutes <M>] [--skip-build-extras]");
     }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/Main.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/Main.java
@@ -2,6 +2,10 @@ package io.github.baokhang83.blastradius.validator.cli;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.baokhang83.blastradius.validator.git.HistoryMode;
+import io.github.baokhang83.blastradius.validator.mutation.MutationCommand;
+import io.github.baokhang83.blastradius.validator.mutation.MutationConfig;
+import io.github.baokhang83.blastradius.validator.mutation.MutationReport;
+import io.github.baokhang83.blastradius.validator.mutation.MutationTextSummaryRenderer;
 import io.github.baokhang83.blastradius.validator.report.AnalysisReport;
 import io.github.baokhang83.blastradius.validator.report.TextSummaryRenderer;
 import java.io.IOException;
@@ -17,14 +21,22 @@ import java.nio.file.Path;
 public final class Main {
 
     public static void main(String[] args) {
-        if (args.length == 0 || !"run".equals(args[0])) {
-            System.err.println("usage: run --project-path <path> --commits <N> --report-out <path> "
-                    + "[--summary-out <path>] [--maven-threads <N>] [--fast-ground-truth] "
-                    + "[--build-concurrency <K>] [--build-timeout-minutes <M>] [--skip-build-extras] "
-                    + "[--history-mode <all-parents|first-parent>]");
+        if (args.length == 0) {
+            usage();
             System.exit(2);
             return;
         }
+        switch (args[0]) {
+            case "run" -> runHistory(args);
+            case "mutate" -> runMutations(args);
+            default -> {
+                usage();
+                System.exit(2);
+            }
+        }
+    }
+
+    private static void runHistory(String[] args) {
 
         Path projectPath = null;
         Integer commits = null;
@@ -75,6 +87,53 @@ public final class Main {
         }
     }
 
+    private static void runMutations(String[] args) {
+        Path projectPath = null;
+        Path reportOut = null;
+        Path summaryOut = null;
+        String classFilter = null;
+        int maxClasses = MutationConfig.DEFAULT_MAX_CLASSES;
+        int maxMutations = MutationConfig.DEFAULT_MAX_MUTATIONS;
+        long timeLimitMinutes = MutationConfig.DEFAULT_TIME_LIMIT_MINUTES;
+        Integer mavenThreads = null;
+        long buildTimeoutMinutes = MutationConfig.DEFAULT_BUILD_TIMEOUT_MINUTES;
+        boolean skipBuildExtras = false;
+        for (int i = 1; i < args.length; i++) {
+            switch (args[i]) {
+                case "--project-path" -> projectPath = Path.of(args[++i]);
+                case "--report-out" -> reportOut = Path.of(args[++i]);
+                case "--summary-out" -> summaryOut = Path.of(args[++i]);
+                case "--mutation-class" -> classFilter = args[++i];
+                case "--max-classes" -> maxClasses = Integer.parseInt(args[++i]);
+                case "--max-mutations" -> maxMutations = Integer.parseInt(args[++i]);
+                case "--mutation-time-limit-minutes" -> timeLimitMinutes = Long.parseLong(args[++i]);
+                case "--maven-threads" -> mavenThreads = Integer.parseInt(args[++i]);
+                case "--build-timeout-minutes" -> buildTimeoutMinutes = Long.parseLong(args[++i]);
+                case "--skip-build-extras" -> skipBuildExtras = true;
+                default -> {
+                    System.err.println("unknown argument: " + args[i]);
+                    System.exit(2);
+                    return;
+                }
+            }
+        }
+        if (projectPath == null || reportOut == null) {
+            System.err.println("missing required argument(s): --project-path and --report-out are required");
+            System.exit(2);
+            return;
+        }
+        try {
+            MutationConfig config = new MutationConfig(projectPath, reportOut, classFilter, maxClasses, maxMutations,
+                    timeLimitMinutes, mavenThreads, buildTimeoutMinutes, skipBuildExtras);
+            int exitCode = new MutationCommand().run(config);
+            printMutationSummary(reportOut, summaryOut, exitCode);
+            System.exit(exitCode);
+        } catch (IllegalArgumentException e) {
+            System.err.println("invalid configuration: " + e.getMessage());
+            System.exit(2);
+        }
+    }
+
     /** Renders the just-written report as text — to stdout by default, or {@code --summary-out}. */
     private static void printSummary(Path reportOut, Path summaryOut, int exitCode) {
         if (exitCode == 2) {
@@ -91,5 +150,33 @@ public final class Main {
         } catch (IOException e) {
             System.err.println("warning: could not render text summary: " + e.getMessage());
         }
+    }
+
+    private static void printMutationSummary(Path reportOut, Path summaryOut, int exitCode) {
+        if (exitCode == 2) {
+            return;
+        }
+        try {
+            MutationReport report = new ObjectMapper().readValue(reportOut.toFile(), MutationReport.class);
+            String text = new MutationTextSummaryRenderer().render(report);
+            if (summaryOut != null) {
+                Files.writeString(summaryOut, text);
+            } else {
+                System.out.print(text);
+            }
+        } catch (IOException e) {
+            System.err.println("warning: could not render mutation text summary: " + e.getMessage());
+        }
+    }
+
+    private static void usage() {
+        System.err.println("usage: run --project-path <path> --commits <N> --report-out <path> "
+                + "[--summary-out <path>] [--maven-threads <N>] [--fast-ground-truth] "
+                + "[--build-concurrency <K>] [--build-timeout-minutes <M>] [--skip-build-extras] "
+                + "[--history-mode <all-parents|first-parent>]\n"
+                + "   or: mutate --project-path <path> --report-out <path> [--summary-out <path>] "
+                + "[--mutation-class <FQCN>] [--max-classes <N>] [--max-mutations <N>] "
+                + "[--mutation-time-limit-minutes <M>] [--maven-threads <N>] "
+                + "[--build-timeout-minutes <M>] [--skip-build-extras]");
     }
 }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
@@ -12,7 +12,6 @@ import io.github.baokhang83.blastradius.validator.build.GroundTruthResolver;
 import io.github.baokhang83.blastradius.validator.build.GroundTruthResult;
 import io.github.baokhang83.blastradius.validator.build.JdkMismatchDetector;
 import io.github.baokhang83.blastradius.validator.build.MavenBuildRunner;
-import io.github.baokhang83.blastradius.validator.build.Outcome;
 import io.github.baokhang83.blastradius.core.git.ChangedFile;
 import io.github.baokhang83.blastradius.core.git.ChangedFileClassifier;
 import io.github.baokhang83.blastradius.core.reactor.ReactorModuleGraph;
@@ -22,6 +21,8 @@ import io.github.baokhang83.blastradius.core.reactor.TestModuleIndex;
 import io.github.baokhang83.blastradius.validator.git.CommitCheckout;
 import io.github.baokhang83.blastradius.validator.git.CommitPair;
 import io.github.baokhang83.blastradius.validator.git.CommitWindowResolver;
+import io.github.baokhang83.blastradius.validator.selection.PairSelectionAnalyzer;
+import io.github.baokhang83.blastradius.validator.selection.PairSelectionResult;
 import io.github.baokhang83.blastradius.validator.report.FailureCoverage;
 import io.github.baokhang83.blastradius.validator.git.PairStatus;
 import io.github.baokhang83.blastradius.validator.report.AnalysisReport;
@@ -29,18 +30,13 @@ import io.github.baokhang83.blastradius.validator.report.ReportWriter;
 import io.github.baokhang83.blastradius.validator.report.SavingsSummary;
 import io.github.baokhang83.blastradius.validator.report.SavingsSummaryAggregator;
 import io.github.baokhang83.blastradius.core.selection.FallbackSelector;
-import io.github.baokhang83.blastradius.core.selection.NewOrModifiedTestSelector;
 import io.github.baokhang83.blastradius.core.selection.SelectionDecision;
-import io.github.baokhang83.blastradius.core.selection.SelectionEngine;
 import io.github.baokhang83.blastradius.core.tracking.DependencyRecordReader;
 import io.github.baokhang83.blastradius.core.tracking.DependencyRecordSet;
-import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import io.github.baokhang83.blastradius.validator.verdict.FlakyFailure;
-import io.github.baokhang83.blastradius.validator.verdict.FailureComparison;
 import io.github.baokhang83.blastradius.validator.verdict.Verdict;
 import io.github.baokhang83.blastradius.validator.verdict.VerdictCalculator;
 import io.github.baokhang83.blastradius.validator.verdict.WouldMissCase;
-import io.github.baokhang83.blastradius.validator.verdict.WouldMissComparator;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
@@ -50,10 +46,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.stream.Collectors;
 
 /**
  * Wires the full pipeline together: for each commit pair in the resolved window, checks
@@ -73,11 +67,9 @@ public final class RunCommand {
     private final ChangedFileClassifier changedFileClassifier = new ChangedFileClassifier();
     private final ReactorModuleGraphBuilder reactorModuleGraphBuilder = new ReactorModuleGraphBuilder();
     private final FallbackSelector fallbackSelector = new FallbackSelector();
-    private final SelectionEngine selectionEngine = new SelectionEngine();
-    private final NewOrModifiedTestSelector newOrModifiedTestSelector = new NewOrModifiedTestSelector();
-    private final WouldMissComparator wouldMissComparator = new WouldMissComparator();
     private final VerdictCalculator verdictCalculator = new VerdictCalculator();
     private final SavingsSummaryAggregator savingsSummaryAggregator = new SavingsSummaryAggregator();
+    private final PairSelectionAnalyzer pairSelectionAnalyzer = new PairSelectionAnalyzer();
     private final ReportWriter reportWriter = new ReportWriter();
     private final BuildFailureDetector buildFailureDetector = new BuildFailureDetector();
     private final JdkMismatchDetector jdkMismatchDetector = new JdkMismatchDetector();
@@ -274,33 +266,9 @@ public final class RunCommand {
         List<GroundTruthResult> baseGroundTruth = base.groundTruth();
         List<GroundTruthResult> groundTruth = head.groundTruth();
 
-        Map<TestIdentity, Map<String, String>> baseRecord = baseRecordSet.tests();
-        // Keyed by baselineKey(), not the raw tracked identity, so a ground-truth lookup
-        // (which may carry a parameterized-test's Surefire-style invocation suffix) can
-        // still find the baseline the tracking agent recorded under the plain method
-        // name. See TestIdentity#baselineKey for why the two pipelines disagree here.
-        Map<TestIdentity, Set<String>> testDependencies = baseRecord.entrySet().stream()
-                .collect(Collectors.toMap(
-                        e -> e.getKey().baselineKey(),
-                        e -> e.getValue().keySet(),
-                        (a, b) -> {
-                            Set<String> union = new java.util.HashSet<>(a);
-                            union.addAll(b);
-                            return union;
-                        }));
-
         // Changed files, classified, against the real target repo's git history.
         List<ChangedFile> changedFiles =
                 changedFileClassifier.classify(targetRepo, pair.baseCommit(), pair.headCommit());
-        Set<String> changedClassNames = changedFiles.stream()
-                .flatMap(file -> file.candidateClassNames().stream())
-                .collect(Collectors.toUnmodifiableSet());
-
-        Set<TestIdentity> allTests = groundTruth.stream().map(GroundTruthResult::test).collect(Collectors.toSet());
-        Set<TestIdentity> newOrModifiedTests = allTests.stream()
-                .filter(test -> newOrModifiedTestSelector.appliesTo(
-                        test, !testDependencies.containsKey(test.baselineKey()), changedClassNames))
-                .collect(Collectors.toSet());
 
         // Reactor scope for the NON_SOURCE fallback: built from the HEAD tree so module layout
         // and inter-module edges reflect the commit selection runs against. Phase 1's concurrent
@@ -318,19 +286,11 @@ public final class RunCommand {
                     pair.headCommit(), sha -> buildReactorScope(scopeCheckout.checkoutCommit(sha)));
         }
 
-        List<SelectionDecision> decisions = selectionEngine.selectAll(
-                allTests, testDependencies, newOrModifiedTests, changedFiles,
-                baseRecordSet.ambientDependencies(), reactorScope);
-
         CommitPair enrichedPair = CommitPair.analyzed(pair.baseCommit(), pair.headCommit(), changedFiles);
-        FailureComparison comparison = wouldMissComparator.compare(
-                enrichedPair, decisions, groundTruth, baseGroundTruth);
-        List<FlakyFailure> flakyFailures = groundTruth.stream()
-                .filter(r -> r.outcome() == Outcome.FLAKY)
-                .map(r -> new FlakyFailure(enrichedPair, r.test()))
-                .toList();
-
-        return new PairAnalysis(enrichedPair, comparison.wouldMissCases(), comparison.coverage(), decisions, flakyFailures);
+        PairSelectionResult result = pairSelectionAnalyzer.analyze(
+                enrichedPair, baseRecordSet, baseGroundTruth, groundTruth, reactorScope);
+        return new PairAnalysis(enrichedPair, result.failureComparison().wouldMissCases(),
+                result.failureComparison().coverage(), result.decisions(), result.flakyFailures());
     }
 
     /**
@@ -338,7 +298,7 @@ public final class RunCommand {
      * the {@link CheckoutPool} has already handed the caller. Checks out {@code sha} on that
      * clone (which wipes {@code target/} — §VII) and runs the suite through
      * {@link GroundTruthResolver} so a test already broken at this commit is confirmed and
-     * recorded, which {@link WouldMissComparator} needs to avoid flagging a pre-existing
+     * recorded, which the shared pair-selection analysis needs to avoid flagging a pre-existing
      * failure as a miss.
      *
      * <p>When {@code agentAttached} is true the tracking agent records each test's

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/CommitCheckout.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/git/CommitCheckout.java
@@ -8,6 +8,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Comparator;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.PersonIdent;
 
 /**
  * Materializes historical commits of a target project into an isolated scratch working
@@ -72,6 +73,31 @@ public final class CommitCheckout implements AutoCloseable {
             return scratchDir;
         } catch (Exception e) {
             throw new IllegalStateException("failed to checkout commit " + commitSha, e);
+        }
+    }
+
+    /** Returns the disposable clone's worktree, never the caller's target repository. */
+    public Path workTree() {
+        return scratchDir;
+    }
+
+    /**
+     * Writes one tracked file in this disposable clone and commits it on its current detached
+     * HEAD. The returned SHA therefore names a real Git child of the commit most recently passed
+     * to {@link #checkoutCommit(String)}.
+     */
+    public String commitFile(Path relativePath, String contents, String message) {
+        Path normalized = relativePath.normalize();
+        if (normalized.isAbsolute() || normalized.startsWith("..")) {
+            throw new IllegalArgumentException("path must stay inside the scratch clone: " + relativePath);
+        }
+        try {
+            Files.writeString(scratchDir.resolve(normalized), contents);
+            scratchGit.add().addFilepattern(normalized.toString().replace('\\', '/')).call();
+            PersonIdent identity = new PersonIdent("Blastradius Validator", "validator@blastradius.invalid");
+            return scratchGit.commit().setMessage(message).setAuthor(identity).setCommitter(identity).call().getId().name();
+        } catch (Exception e) {
+            throw new IllegalStateException("failed to commit synthetic change to " + relativePath, e);
         }
     }
 

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCandidate.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCandidate.java
@@ -1,0 +1,37 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+import java.util.Objects;
+
+/** One deterministic, single-token source replacement in a production Java class. */
+public record MutationCandidate(
+        String sourcePath,
+        String className,
+        MutationOperator operator,
+        int offset,
+        String original,
+        String replacement) {
+
+    public MutationCandidate {
+        Objects.requireNonNull(sourcePath, "sourcePath");
+        Objects.requireNonNull(className, "className");
+        Objects.requireNonNull(operator, "operator");
+        Objects.requireNonNull(original, "original");
+        Objects.requireNonNull(replacement, "replacement");
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset must not be negative: " + offset);
+        }
+        if (original.isEmpty() || replacement.isEmpty()) {
+            throw new IllegalArgumentException("mutation tokens must not be empty");
+        }
+    }
+
+    /** Applies this candidate only when its source still contains the recorded token. */
+    public String applyTo(String source) {
+        Objects.requireNonNull(source, "source");
+        int end = offset + original.length();
+        if (end > source.length() || !source.regionMatches(offset, original, 0, original.length())) {
+            throw new IllegalArgumentException("source no longer matches mutation candidate at offset " + offset);
+        }
+        return source.substring(0, offset) + replacement + source.substring(end);
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCandidateGenerator.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCandidateGenerator.java
@@ -1,0 +1,194 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * Enumerates the first, deliberately narrow mutation corpus from {@code src/main/java}.
+ * Comments, string literals, character literals, and text blocks are skipped so candidates
+ * describe executable Java tokens rather than explanatory text.
+ */
+public final class MutationCandidateGenerator {
+
+    private static final Path PRODUCTION_SOURCES = Path.of("src", "main", "java");
+
+    /**
+     * @param projectRoot Maven project root containing production Java sources
+     * @param classFilter exact fully-qualified class name to include, or {@code null} for all
+     * @param maxMutations upper bound after deterministic ordering
+     */
+    public List<MutationCandidate> generate(Path projectRoot, String classFilter, int maxMutations) {
+        return generate(projectRoot, classFilter, Integer.MAX_VALUE, maxMutations);
+    }
+
+    /** Like {@link #generate(Path, String, int)}, with a bound on production classes visited. */
+    public List<MutationCandidate> generate(Path projectRoot, String classFilter, int maxClasses, int maxMutations) {
+        Objects.requireNonNull(projectRoot, "projectRoot");
+        if (maxClasses < 1) {
+            throw new IllegalArgumentException("maxClasses must be positive, got: " + maxClasses);
+        }
+        if (maxMutations < 1) {
+            throw new IllegalArgumentException("maxMutations must be positive, got: " + maxMutations);
+        }
+        Path sourceRoot = projectRoot.resolve(PRODUCTION_SOURCES);
+        if (Files.notExists(sourceRoot)) {
+            return List.of();
+        }
+        try (Stream<Path> paths = Files.walk(sourceRoot)) {
+            return paths.filter(path -> path.toString().endsWith(".java"))
+                    .sorted()
+                    .filter(path -> classFilter == null || classFilter.equals(className(sourceRoot, path)))
+                    .limit(maxClasses)
+                    .flatMap(path -> candidatesIn(sourceRoot, path, classFilter).stream())
+                    .sorted(Comparator.comparing(MutationCandidate::sourcePath)
+                            .thenComparingInt(MutationCandidate::offset))
+                    .limit(maxMutations)
+                    .toList();
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to enumerate production Java sources under " + sourceRoot, e);
+        }
+    }
+
+    private static List<MutationCandidate> candidatesIn(Path sourceRoot, Path sourceFile, String classFilter) {
+        String sourcePath = PRODUCTION_SOURCES.resolve(sourceRoot.relativize(sourceFile)).toString()
+                .replace(sourceFile.getFileSystem().getSeparator(), "/");
+        String className = className(sourceRoot, sourceFile);
+        if (classFilter != null && !classFilter.equals(className)) {
+            return List.of();
+        }
+        try {
+            return scan(sourcePath, className, Files.readString(sourceFile));
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to read " + sourceFile, e);
+        }
+    }
+
+    private static String className(Path sourceRoot, Path sourceFile) {
+        return sourceRoot.relativize(sourceFile).toString()
+                .replace(sourceFile.getFileSystem().getSeparator(), ".")
+                .replaceFirst("\\.java$", "");
+    }
+
+    private static List<MutationCandidate> scan(String sourcePath, String className, String source) {
+        List<MutationCandidate> candidates = new ArrayList<>();
+        ScanState state = ScanState.CODE;
+        for (int index = 0; index < source.length(); index++) {
+            char current = source.charAt(index);
+            char next = index + 1 < source.length() ? source.charAt(index + 1) : '\0';
+            if (state == ScanState.LINE_COMMENT) {
+                if (current == '\n' || current == '\r') {
+                    state = ScanState.CODE;
+                }
+                continue;
+            }
+            if (state == ScanState.BLOCK_COMMENT) {
+                if (current == '*' && next == '/') {
+                    state = ScanState.CODE;
+                    index++;
+                }
+                continue;
+            }
+            if (state == ScanState.STRING || state == ScanState.CHARACTER) {
+                if (current == '\\') {
+                    index++;
+                } else if ((state == ScanState.STRING && current == '"')
+                        || (state == ScanState.CHARACTER && current == '\'')) {
+                    state = ScanState.CODE;
+                }
+                continue;
+            }
+            if (state == ScanState.TEXT_BLOCK) {
+                if (startsWith(source, index, "\"\"\"")) {
+                    state = ScanState.CODE;
+                    index += 2;
+                }
+                continue;
+            }
+            if (current == '/' && next == '/') {
+                state = ScanState.LINE_COMMENT;
+                index++;
+                continue;
+            }
+            if (current == '/' && next == '*') {
+                state = ScanState.BLOCK_COMMENT;
+                index++;
+                continue;
+            }
+            if (startsWith(source, index, "\"\"\"")) {
+                state = ScanState.TEXT_BLOCK;
+                index += 2;
+                continue;
+            }
+            if (current == '"') {
+                state = ScanState.STRING;
+                continue;
+            }
+            if (current == '\'') {
+                state = ScanState.CHARACTER;
+                continue;
+            }
+            if (isWordAt(source, index, "true")) {
+                candidates.add(candidate(sourcePath, className, MutationOperator.BOOLEAN_LITERAL, index, "true", "false"));
+                index += "true".length() - 1;
+                continue;
+            }
+            if (isWordAt(source, index, "false")) {
+                candidates.add(candidate(sourcePath, className, MutationOperator.BOOLEAN_LITERAL, index, "false", "true"));
+                index += "false".length() - 1;
+                continue;
+            }
+            if (startsWith(source, index, "==")) {
+                candidates.add(candidate(sourcePath, className, MutationOperator.EQUALITY_OPERATOR, index, "==", "!="));
+                index++;
+                continue;
+            }
+            if (startsWith(source, index, "!=")) {
+                candidates.add(candidate(sourcePath, className, MutationOperator.EQUALITY_OPERATOR, index, "!=", "=="));
+                index++;
+                continue;
+            }
+            if (startsWith(source, index, ">=")) {
+                candidates.add(candidate(sourcePath, className, MutationOperator.RELATIONAL_OPERATOR, index, ">=", "<"));
+                index++;
+                continue;
+            }
+            if (startsWith(source, index, "<=")) {
+                candidates.add(candidate(sourcePath, className, MutationOperator.RELATIONAL_OPERATOR, index, "<=", ">"));
+                index++;
+            }
+        }
+        return candidates;
+    }
+
+    private static MutationCandidate candidate(
+            String sourcePath, String className, MutationOperator operator, int offset, String original, String replacement) {
+        return new MutationCandidate(sourcePath, className, operator, offset, original, replacement);
+    }
+
+    private static boolean startsWith(String source, int offset, String token) {
+        return source.regionMatches(offset, token, 0, token.length());
+    }
+
+    private static boolean isWordAt(String source, int offset, String word) {
+        int end = offset + word.length();
+        return startsWith(source, offset, word)
+                && (offset == 0 || !Character.isJavaIdentifierPart(source.charAt(offset - 1)))
+                && (end == source.length() || !Character.isJavaIdentifierPart(source.charAt(end)));
+    }
+
+    private enum ScanState {
+        CODE,
+        LINE_COMMENT,
+        BLOCK_COMMENT,
+        STRING,
+        CHARACTER,
+        TEXT_BLOCK
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCandidateGenerator.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCandidateGenerator.java
@@ -29,10 +29,12 @@ public final class MutationCandidateGenerator {
     }
 
     /** Like {@link #generate(Path, String, int)}, with a bound on production classes visited. */
-    public List<MutationCandidate> generate(Path projectRoot, String classFilter, int maxClasses, int maxMutations) {
+    public List<MutationCandidate> generate(
+            Path projectRoot, String classFilter, int maxMutationClasses, int maxMutations) {
         Objects.requireNonNull(projectRoot, "projectRoot");
-        if (maxClasses < 1) {
-            throw new IllegalArgumentException("maxClasses must be positive, got: " + maxClasses);
+        if (maxMutationClasses < 1) {
+            throw new IllegalArgumentException(
+                    "maxMutationClasses must be positive, got: " + maxMutationClasses);
         }
         if (maxMutations < 1) {
             throw new IllegalArgumentException("maxMutations must be positive, got: " + maxMutations);
@@ -45,7 +47,7 @@ public final class MutationCandidateGenerator {
             return paths.filter(path -> path.toString().endsWith(".java"))
                     .sorted()
                     .filter(path -> classFilter == null || classFilter.equals(className(sourceRoot, path)))
-                    .limit(maxClasses)
+                    .limit(maxMutationClasses)
                     .flatMap(path -> candidatesIn(sourceRoot, path, classFilter).stream())
                     .sorted(Comparator.comparing(MutationCandidate::sourcePath)
                             .thenComparingInt(MutationCandidate::offset))

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCommand.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCommand.java
@@ -1,0 +1,187 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+import io.github.baokhang83.blastradius.core.git.ChangedFile;
+import io.github.baokhang83.blastradius.core.git.ChangedFileClassifier;
+import io.github.baokhang83.blastradius.core.reactor.ReactorModuleGraph;
+import io.github.baokhang83.blastradius.core.reactor.ReactorModuleGraphBuilder;
+import io.github.baokhang83.blastradius.core.reactor.ReactorScope;
+import io.github.baokhang83.blastradius.core.reactor.TestModuleIndex;
+import io.github.baokhang83.blastradius.core.selection.FallbackSelector;
+import io.github.baokhang83.blastradius.core.selection.SelectionDecision;
+import io.github.baokhang83.blastradius.core.tracking.DependencyRecordReader;
+import io.github.baokhang83.blastradius.core.tracking.DependencyRecordSet;
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import io.github.baokhang83.blastradius.validator.build.BuildFailureDetector;
+import io.github.baokhang83.blastradius.validator.build.GroundTruthResolution;
+import io.github.baokhang83.blastradius.validator.build.GroundTruthResolver;
+import io.github.baokhang83.blastradius.validator.build.GroundTruthResult;
+import io.github.baokhang83.blastradius.validator.build.JdkMismatchDetector;
+import io.github.baokhang83.blastradius.validator.build.MavenBuildRunner;
+import io.github.baokhang83.blastradius.validator.build.Outcome;
+import io.github.baokhang83.blastradius.validator.git.CommitPair;
+import io.github.baokhang83.blastradius.validator.report.ReportWriter;
+import io.github.baokhang83.blastradius.validator.selection.PairSelectionAnalyzer;
+import io.github.baokhang83.blastradius.validator.selection.PairSelectionResult;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.jgit.api.Git;
+
+/** Runs bounded, opt-in mutation soundness validation against an isolated target clone. */
+public final class MutationCommand {
+
+    private final MutationCandidateGenerator candidateGenerator = new MutationCandidateGenerator();
+    private final ChangedFileClassifier changedFileClassifier = new ChangedFileClassifier();
+    private final FallbackSelector fallbackSelector = new FallbackSelector();
+    private final ReactorModuleGraphBuilder reactorModuleGraphBuilder = new ReactorModuleGraphBuilder();
+    private final PairSelectionAnalyzer pairSelectionAnalyzer = new PairSelectionAnalyzer();
+    private final BuildFailureDetector buildFailureDetector = new BuildFailureDetector();
+    private final ReportWriter reportWriter = new ReportWriter();
+
+    public int run(MutationConfig config) {
+        return run(config, locateOwnJar());
+    }
+
+    public int run(MutationConfig config, Path agentJar) {
+        Path scratchParent = null;
+        Path dependencyOutput = null;
+        try {
+            new JdkMismatchDetector().detect(config.projectPath()).ifPresent(System.err::println);
+            scratchParent = Files.createTempDirectory("blastradius-mutations-");
+            MavenBuildRunner buildRunner = new MavenBuildRunner(
+                    config.mavenParallelThreads(), config.buildTimeoutMinutes(), false, config.skipBuildExtras());
+            GroundTruthResolver groundTruthResolver = new GroundTruthResolver(buildRunner);
+            try (SyntheticMutationCheckout checkout =
+                    SyntheticMutationCheckout.forTargetProject(config.projectPath(), scratchParent)) {
+                String baselineSha = head(checkout.workTree());
+                Path baselineTree = checkout.checkoutBaseline(baselineSha);
+                List<MutationCandidate> candidates = candidateGenerator.generate(
+                        baselineTree, config.classFilter(), config.maxClasses(), config.maxMutations());
+                dependencyOutput = Files.createTempFile("blastradius-mutation-deps-", ".json");
+                GroundTruthResolution baselineResolution =
+                        groundTruthResolver.resolve(baselineTree, agentJar, dependencyOutput);
+                if (buildFailureDetector.isBuildFailure(baselineResolution.initialBuild(), baselineTree)) {
+                    System.err.println("blastradius-validator: baseline " + baselineSha + " failed to build");
+                    return 2;
+                }
+                DependencyRecordSet baselineDependencies = new DependencyRecordReader().readAll(dependencyOutput);
+                List<GroundTruthResult> baselineOutcomes = baselineResolution.results();
+                List<TestIdentity> baselineFailingTests = baselineOutcomes.stream()
+                        .filter(result -> result.outcome() == Outcome.CONFIRMED_FAILED)
+                        .map(GroundTruthResult::test)
+                        .toList();
+                long deadline = System.nanoTime() + Duration.ofMinutes(config.timeLimitMinutes()).toNanos();
+                List<MutationExperiment> experiments = new ArrayList<>();
+                int timeLimitSkipped = 0;
+                for (int index = 0; index < candidates.size(); index++) {
+                    if (System.nanoTime() >= deadline) {
+                        timeLimitSkipped = candidates.size() - index;
+                        break;
+                    }
+                    MutationCandidate candidate = candidates.get(index);
+                    checkout.checkoutBaseline(baselineSha);
+                    String mutantSha = checkout.commit(candidate);
+                    GroundTruthResolution mutantResolution = groundTruthResolver.resolve(checkout.workTree(), null, null);
+                    if (buildFailureDetector.isBuildFailure(mutantResolution.initialBuild(), checkout.workTree())) {
+                        experiments.add(new MutationExperiment(candidate, mutantSha, MutationStatus.UNBUILDABLE,
+                                "mutant failed to build (exit " + mutantResolution.initialBuild().exitCode() + ")",
+                                List.of(), List.of(), List.of(), List.of()));
+                        continue;
+                    }
+                    experiments.add(analyzeMutant(candidate, baselineSha, mutantSha, checkout.workTree(),
+                            baselineDependencies, baselineOutcomes, mutantResolution.results()));
+                }
+                MutationReport report = MutationReport.from(
+                        baselineSha, baselineFailingTests, experiments, candidates.size(), timeLimitSkipped);
+                reportWriter.write(config.reportOutputPath(), report);
+                return report.verdict() == io.github.baokhang83.blastradius.validator.verdict.Verdict.PASS ? 0 : 1;
+            }
+        } catch (Exception e) {
+            System.err.println("blastradius-validator: " + e.getMessage());
+            return 2;
+        } finally {
+            deleteFile(dependencyOutput);
+            deleteFile(scratchParent);
+        }
+    }
+
+    private MutationExperiment analyzeMutant(
+            MutationCandidate candidate,
+            String baselineSha,
+            String mutantSha,
+            Path mutantTree,
+            DependencyRecordSet baselineDependencies,
+            List<GroundTruthResult> baselineOutcomes,
+            List<GroundTruthResult> mutantOutcomes) {
+        List<ChangedFile> changedFiles = changedFileClassifier.classify(mutantTree, baselineSha, mutantSha);
+        ReactorScope scope = fallbackSelector.shouldFallback(changedFiles) ? buildReactorScope(mutantTree) : null;
+        CommitPair edge = CommitPair.analyzed(baselineSha, mutantSha, changedFiles);
+        PairSelectionResult selection = pairSelectionAnalyzer.analyze(
+                edge, baselineDependencies, baselineOutcomes, mutantOutcomes, scope);
+        Map<TestIdentity, Outcome> baselineByTest = new HashMap<>();
+        baselineOutcomes.forEach(result -> baselineByTest.put(result.test(), result.outcome()));
+        Map<TestIdentity, SelectionDecision> decisionByTest = new HashMap<>();
+        selection.decisions().forEach(decision -> decisionByTest.put(decision.test(), decision));
+        List<TestIdentity> killing = new ArrayList<>();
+        List<TestIdentity> selected = new ArrayList<>();
+        List<TestIdentity> skipped = new ArrayList<>();
+        for (GroundTruthResult result : mutantOutcomes) {
+            if (result.outcome() != Outcome.CONFIRMED_FAILED || baselineByTest.get(result.test()) != Outcome.PASSED) {
+                continue;
+            }
+            killing.add(result.test());
+            SelectionDecision decision = decisionByTest.get(result.test());
+            if (decision != null && decision.selected()) {
+                selected.add(result.test());
+            } else {
+                skipped.add(result.test());
+            }
+        }
+        List<TestIdentity> flaky = selection.flakyFailures().stream().map(flakyFailure -> flakyFailure.test()).toList();
+        return new MutationExperiment(candidate, mutantSha,
+                killing.isEmpty() ? MutationStatus.SURVIVED : MutationStatus.KILLED,
+                null, killing, selected, skipped, flaky);
+    }
+
+    private ReactorScope buildReactorScope(Path tree) {
+        try {
+            ReactorModuleGraph graph = reactorModuleGraphBuilder.fromRepoTree(tree);
+            return new ReactorScope(graph, TestModuleIndex.fromRepoTree(tree, graph));
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static String head(Path repository) {
+        try (Git git = Git.open(repository.toFile())) {
+            return git.getRepository().resolve("HEAD").name();
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to resolve target HEAD", e);
+        }
+    }
+
+    private static void deleteFile(Path path) {
+        if (path == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(path);
+        } catch (IOException ignored) {
+            // The cloned checkout owns all material state; this only removes its empty parent or a temp record.
+        }
+    }
+
+    private static Path locateOwnJar() {
+        try {
+            return Path.of(MutationCommand.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        } catch (Exception e) {
+            throw new IllegalStateException("could not locate this tool's own jar for -javaagent attachment", e);
+        }
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCommand.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCommand.java
@@ -62,7 +62,7 @@ public final class MutationCommand {
                 String baselineSha = head(checkout.workTree());
                 Path baselineTree = checkout.checkoutBaseline(baselineSha);
                 List<MutationCandidate> candidates = candidateGenerator.generate(
-                        baselineTree, config.classFilter(), config.maxClasses(), config.maxMutations());
+                        baselineTree, config.classFilter(), config.maxMutationClasses(), config.maxMutations());
                 dependencyOutput = Files.createTempFile("blastradius-mutation-deps-", ".json");
                 GroundTruthResolution baselineResolution =
                         groundTruthResolver.resolve(baselineTree, agentJar, dependencyOutput);

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationConfig.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationConfig.java
@@ -1,0 +1,45 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/** Operator-supplied bounds for one opt-in mutation soundness run. */
+public record MutationConfig(
+        Path projectPath,
+        Path reportOutputPath,
+        String classFilter,
+        int maxClasses,
+        int maxMutations,
+        long timeLimitMinutes,
+        Integer mavenParallelThreads,
+        long buildTimeoutMinutes,
+        boolean skipBuildExtras) {
+
+    public static final int DEFAULT_MAX_CLASSES = 10;
+    public static final int DEFAULT_MAX_MUTATIONS = 20;
+    public static final long DEFAULT_TIME_LIMIT_MINUTES = 60;
+    public static final long DEFAULT_BUILD_TIMEOUT_MINUTES = 5;
+
+    public MutationConfig(Path projectPath, Path reportOutputPath) {
+        this(projectPath, reportOutputPath, null, DEFAULT_MAX_CLASSES, DEFAULT_MAX_MUTATIONS,
+                DEFAULT_TIME_LIMIT_MINUTES, null, DEFAULT_BUILD_TIMEOUT_MINUTES, false);
+    }
+
+    public MutationConfig {
+        Objects.requireNonNull(projectPath, "projectPath");
+        Objects.requireNonNull(reportOutputPath, "reportOutputPath");
+        if (!Files.isDirectory(projectPath) || !Files.isDirectory(projectPath.resolve(".git"))) {
+            throw new IllegalArgumentException("projectPath must be a local git repository: " + projectPath);
+        }
+        if (Files.isDirectory(reportOutputPath)) {
+            throw new IllegalArgumentException("reportOutputPath must be a file path, not a directory: " + reportOutputPath);
+        }
+        if (maxClasses < 1 || maxMutations < 1 || timeLimitMinutes < 1 || buildTimeoutMinutes < 1) {
+            throw new IllegalArgumentException("mutation limits must be positive");
+        }
+        if (mavenParallelThreads != null && mavenParallelThreads < 1) {
+            throw new IllegalArgumentException("mavenParallelThreads must be positive");
+        }
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationConfig.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationConfig.java
@@ -9,7 +9,7 @@ public record MutationConfig(
         Path projectPath,
         Path reportOutputPath,
         String classFilter,
-        int maxClasses,
+        int maxMutationClasses,
         int maxMutations,
         long timeLimitMinutes,
         Integer mavenParallelThreads,
@@ -35,7 +35,7 @@ public record MutationConfig(
         if (Files.isDirectory(reportOutputPath)) {
             throw new IllegalArgumentException("reportOutputPath must be a file path, not a directory: " + reportOutputPath);
         }
-        if (maxClasses < 1 || maxMutations < 1 || timeLimitMinutes < 1 || buildTimeoutMinutes < 1) {
+        if (maxMutationClasses < 1 || maxMutations < 1 || timeLimitMinutes < 1 || buildTimeoutMinutes < 1) {
             throw new IllegalArgumentException("mutation limits must be positive");
         }
         if (mavenParallelThreads != null && mavenParallelThreads < 1) {

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCoverage.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCoverage.java
@@ -1,0 +1,28 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+/** The full denominator behind a bounded mutation-validation verdict. */
+public record MutationCoverage(
+        int generatedMutations,
+        int attemptedMutations,
+        int timeLimitSkippedMutations,
+        int unbuildableMutants,
+        int compilableMutants,
+        int baselineCleanMutants,
+        int testKilledMutants,
+        int mutationKillingTests,
+        int selectedKillingTests,
+        int skippedKillingTests,
+        int flakyMutantFailures) {
+
+    public MutationCoverage {
+        if (generatedMutations < 0 || attemptedMutations < 0 || timeLimitSkippedMutations < 0
+                || unbuildableMutants < 0 || compilableMutants < 0 || baselineCleanMutants < 0
+                || testKilledMutants < 0 || mutationKillingTests < 0 || selectedKillingTests < 0
+                || skippedKillingTests < 0 || flakyMutantFailures < 0) {
+            throw new IllegalArgumentException("mutation coverage counts must not be negative");
+        }
+        if (selectedKillingTests + skippedKillingTests != mutationKillingTests) {
+            throw new IllegalArgumentException("selected and skipped killing tests must sum to all killing tests");
+        }
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationExperiment.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationExperiment.java
@@ -1,0 +1,43 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import java.util.List;
+import java.util.Objects;
+
+/** The auditable outcome of one real synthetic baseline-to-mutant Git edge. */
+public record MutationExperiment(
+        MutationCandidate mutation,
+        String mutantCommit,
+        MutationStatus status,
+        String buildFailure,
+        List<TestIdentity> killingTests,
+        List<TestIdentity> selectedKillingTests,
+        List<TestIdentity> skippedKillingTests,
+        List<TestIdentity> flakyTests) {
+
+    public MutationExperiment {
+        Objects.requireNonNull(mutation, "mutation");
+        Objects.requireNonNull(mutantCommit, "mutantCommit");
+        Objects.requireNonNull(status, "status");
+        Objects.requireNonNull(killingTests, "killingTests");
+        Objects.requireNonNull(selectedKillingTests, "selectedKillingTests");
+        Objects.requireNonNull(skippedKillingTests, "skippedKillingTests");
+        Objects.requireNonNull(flakyTests, "flakyTests");
+        killingTests = List.copyOf(killingTests);
+        selectedKillingTests = List.copyOf(selectedKillingTests);
+        skippedKillingTests = List.copyOf(skippedKillingTests);
+        flakyTests = List.copyOf(flakyTests);
+        if (status == MutationStatus.UNBUILDABLE && (buildFailure == null || buildFailure.isBlank())) {
+            throw new IllegalArgumentException("unbuildable mutant needs a buildFailure");
+        }
+        if (status != MutationStatus.UNBUILDABLE && buildFailure != null) {
+            throw new IllegalArgumentException("buildFailure belongs only to an unbuildable mutant");
+        }
+        if (status == MutationStatus.KILLED && killingTests.isEmpty()) {
+            throw new IllegalArgumentException("a killed mutant needs a confirmed killing test");
+        }
+        if (selectedKillingTests.size() + skippedKillingTests.size() != killingTests.size()) {
+            throw new IllegalArgumentException("every killing test must be selected or skipped");
+        }
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationOperator.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationOperator.java
@@ -1,0 +1,8 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+/** The small, source-preserving set of mutations supported by the first validator corpus. */
+public enum MutationOperator {
+    BOOLEAN_LITERAL,
+    EQUALITY_OPERATOR,
+    RELATIONAL_OPERATOR
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationReport.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationReport.java
@@ -1,0 +1,45 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import io.github.baokhang83.blastradius.validator.verdict.Verdict;
+import java.util.List;
+import java.util.Objects;
+
+/** JSON source of truth for an opt-in mutation soundness run. */
+public record MutationReport(
+        Verdict verdict,
+        String baselineCommit,
+        List<TestIdentity> baselineFailingTests,
+        MutationCoverage coverage,
+        List<MutationExperiment> experiments) {
+
+    public MutationReport {
+        Objects.requireNonNull(verdict, "verdict");
+        Objects.requireNonNull(baselineCommit, "baselineCommit");
+        Objects.requireNonNull(baselineFailingTests, "baselineFailingTests");
+        Objects.requireNonNull(coverage, "coverage");
+        Objects.requireNonNull(experiments, "experiments");
+        baselineFailingTests = List.copyOf(baselineFailingTests);
+        experiments = List.copyOf(experiments);
+    }
+
+    public static MutationReport from(
+            String baselineCommit,
+            List<TestIdentity> baselineFailingTests,
+            List<MutationExperiment> experiments,
+            int generatedMutations,
+            int timeLimitSkippedMutations) {
+        int unbuildable = (int) experiments.stream().filter(e -> e.status() == MutationStatus.UNBUILDABLE).count();
+        int compilable = experiments.size() - unbuildable;
+        int killed = (int) experiments.stream().filter(e -> e.status() == MutationStatus.KILLED).count();
+        int killingTests = experiments.stream().mapToInt(e -> e.killingTests().size()).sum();
+        int selected = experiments.stream().mapToInt(e -> e.selectedKillingTests().size()).sum();
+        int skipped = experiments.stream().mapToInt(e -> e.skippedKillingTests().size()).sum();
+        int flaky = experiments.stream().mapToInt(e -> e.flakyTests().size()).sum();
+        MutationCoverage coverage = new MutationCoverage(
+                generatedMutations, experiments.size(), timeLimitSkippedMutations, unbuildable, compilable,
+                baselineFailingTests.isEmpty() ? compilable : 0, killed, killingTests, selected, skipped, flaky);
+        return new MutationReport(skipped == 0 ? Verdict.PASS : Verdict.FAIL, baselineCommit,
+                baselineFailingTests, coverage, experiments);
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationStatus.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationStatus.java
@@ -1,0 +1,8 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+/** The observed full-suite outcome of one synthetic mutant. */
+public enum MutationStatus {
+    KILLED,
+    SURVIVED,
+    UNBUILDABLE
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationTextSummaryRenderer.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationTextSummaryRenderer.java
@@ -1,0 +1,44 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+
+/** Human-readable rendering of the mutation JSON report, not a second source of truth. */
+public final class MutationTextSummaryRenderer {
+
+    public String render(MutationReport report) {
+        MutationCoverage coverage = report.coverage();
+        StringBuilder text = new StringBuilder("Verdict: ").append(report.verdict()).append('\n');
+        text.append("Baseline: ").append(report.baselineCommit()).append('\n');
+        text.append("Mutation coverage:\n");
+        text.append("  - generated: ").append(coverage.generatedMutations()).append('\n');
+        text.append("  - attempted: ").append(coverage.attemptedMutations()).append('\n');
+        text.append("  - skipped by time limit: ").append(coverage.timeLimitSkippedMutations()).append('\n');
+        text.append("  - unbuildable: ").append(coverage.unbuildableMutants()).append('\n');
+        text.append("  - compilable: ").append(coverage.compilableMutants()).append('\n');
+        text.append("  - baseline-clean: ").append(coverage.baselineCleanMutants()).append('\n');
+        text.append("  - test-killed: ").append(coverage.testKilledMutants()).append('\n');
+        text.append("  - killing tests: ").append(coverage.mutationKillingTests()).append('\n');
+        text.append("  - killing tests selected: ").append(coverage.selectedKillingTests()).append('\n');
+        text.append("  - killing tests skipped: ").append(coverage.skippedKillingTests()).append('\n');
+        text.append("  - flaky mutant failures: ").append(coverage.flakyMutantFailures()).append('\n');
+        text.append("Baseline failures: ").append(report.baselineFailingTests().size()).append('\n');
+        for (TestIdentity test : report.baselineFailingTests()) {
+            text.append("  - ").append(label(test)).append('\n');
+        }
+        for (MutationExperiment experiment : report.experiments()) {
+            text.append("Mutation ").append(experiment.mutantCommit()).append(" ")
+                    .append(experiment.mutation().className()).append(" ")
+                    .append(experiment.mutation().original()).append(" -> ")
+                    .append(experiment.mutation().replacement()).append(": ")
+                    .append(experiment.status()).append('\n');
+            for (TestIdentity test : experiment.skippedKillingTests()) {
+                text.append("  - skipped killing test: ").append(label(test)).append('\n');
+            }
+        }
+        return text.toString();
+    }
+
+    private static String label(TestIdentity test) {
+        return test.methodName() == null ? test.className() : test.className() + "#" + test.methodName();
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/SyntheticMutationCheckout.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/SyntheticMutationCheckout.java
@@ -1,0 +1,46 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+import io.github.baokhang83.blastradius.validator.git.CommitCheckout;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/** A disposable target-project clone that can turn one candidate into a real child commit. */
+public final class SyntheticMutationCheckout implements AutoCloseable {
+
+    private final CommitCheckout checkout;
+
+    private SyntheticMutationCheckout(CommitCheckout checkout) {
+        this.checkout = checkout;
+    }
+
+    public static SyntheticMutationCheckout forTargetProject(Path targetProject, Path scratchParent) {
+        return new SyntheticMutationCheckout(CommitCheckout.forTargetProject(targetProject, scratchParent));
+    }
+
+    public Path checkoutBaseline(String baselineSha) {
+        return checkout.checkoutCommit(baselineSha);
+    }
+
+    /** Applies {@code candidate} and commits the result as a direct child of the current baseline. */
+    public String commit(MutationCandidate candidate) {
+        Objects.requireNonNull(candidate, "candidate");
+        Path source = workTree().resolve(candidate.sourcePath());
+        try {
+            String mutated = candidate.applyTo(Files.readString(source));
+            return checkout.commitFile(Path.of(candidate.sourcePath()), mutated,
+                    "blastradius mutation: " + candidate.className() + " " + candidate.operator());
+        } catch (java.io.IOException e) {
+            throw new java.io.UncheckedIOException("failed to mutate " + candidate.sourcePath(), e);
+        }
+    }
+
+    public Path workTree() {
+        return checkout.workTree();
+    }
+
+    @Override
+    public void close() {
+        checkout.close();
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/report/ReportWriter.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/report/ReportWriter.java
@@ -6,12 +6,12 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
 
-/** Writes the {@link AnalysisReport} to disk as indented JSON (FR-010). */
+/** Writes a validator report to disk as indented JSON. */
 public final class ReportWriter {
 
     private final ObjectMapper mapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
 
-    public void write(Path outputFile, AnalysisReport report) {
+    public void write(Path outputFile, Object report) {
         try {
             mapper.writeValue(outputFile.toFile(), report);
         } catch (IOException e) {

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/selection/PairSelectionAnalyzer.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/selection/PairSelectionAnalyzer.java
@@ -1,0 +1,65 @@
+package io.github.baokhang83.blastradius.validator.selection;
+
+import io.github.baokhang83.blastradius.core.git.ChangedFile;
+import io.github.baokhang83.blastradius.core.reactor.ReactorScope;
+import io.github.baokhang83.blastradius.core.selection.NewOrModifiedTestSelector;
+import io.github.baokhang83.blastradius.core.selection.SelectionDecision;
+import io.github.baokhang83.blastradius.core.selection.SelectionEngine;
+import io.github.baokhang83.blastradius.core.tracking.DependencyRecordSet;
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import io.github.baokhang83.blastradius.validator.build.GroundTruthResult;
+import io.github.baokhang83.blastradius.validator.build.Outcome;
+import io.github.baokhang83.blastradius.validator.git.CommitPair;
+import io.github.baokhang83.blastradius.validator.verdict.FlakyFailure;
+import io.github.baokhang83.blastradius.validator.verdict.WouldMissComparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * The selection-and-comparison half of validator replay, shared by historical and synthetic
+ * mutation edges once both sides have established full-suite outcomes.
+ */
+public final class PairSelectionAnalyzer {
+
+    private final SelectionEngine selectionEngine = new SelectionEngine();
+    private final NewOrModifiedTestSelector newOrModifiedTestSelector = new NewOrModifiedTestSelector();
+    private final WouldMissComparator wouldMissComparator = new WouldMissComparator();
+
+    public PairSelectionResult analyze(
+            CommitPair edge,
+            DependencyRecordSet baselineDependencies,
+            List<GroundTruthResult> baselineOutcomes,
+            List<GroundTruthResult> headOutcomes,
+            ReactorScope reactorScope) {
+        Map<TestIdentity, Set<String>> testDependencies = baselineDependencies.tests().entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> entry.getKey().baselineKey(),
+                        entry -> entry.getValue().keySet(),
+                        (left, right) -> {
+                            Set<String> union = new java.util.HashSet<>(left);
+                            union.addAll(right);
+                            return union;
+                        }));
+        Set<String> changedClassNames = edge.changedFiles().stream()
+                .flatMap(file -> file.candidateClassNames().stream())
+                .collect(Collectors.toUnmodifiableSet());
+        Set<TestIdentity> allTests = headOutcomes.stream()
+                .map(GroundTruthResult::test)
+                .collect(Collectors.toSet());
+        Set<TestIdentity> newOrModifiedTests = allTests.stream()
+                .filter(test -> newOrModifiedTestSelector.appliesTo(
+                        test, !testDependencies.containsKey(test.baselineKey()), changedClassNames))
+                .collect(Collectors.toSet());
+        List<SelectionDecision> decisions = selectionEngine.selectAll(
+                allTests, testDependencies, newOrModifiedTests, edge.changedFiles(),
+                baselineDependencies.ambientDependencies(), reactorScope);
+        List<FlakyFailure> flakyFailures = headOutcomes.stream()
+                .filter(result -> result.outcome() == Outcome.FLAKY)
+                .map(result -> new FlakyFailure(edge, result.test()))
+                .toList();
+        return new PairSelectionResult(
+                decisions, wouldMissComparator.compare(edge, decisions, headOutcomes, baselineOutcomes), flakyFailures);
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/selection/PairSelectionResult.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/selection/PairSelectionResult.java
@@ -1,0 +1,20 @@
+package io.github.baokhang83.blastradius.validator.selection;
+
+import io.github.baokhang83.blastradius.core.selection.SelectionDecision;
+import io.github.baokhang83.blastradius.validator.verdict.FailureComparison;
+import io.github.baokhang83.blastradius.validator.verdict.FlakyFailure;
+import java.util.List;
+import java.util.Objects;
+
+/** Selection decisions and independently confirmed outcomes for one already-built Git edge. */
+public record PairSelectionResult(
+        List<SelectionDecision> decisions, FailureComparison failureComparison, List<FlakyFailure> flakyFailures) {
+
+    public PairSelectionResult {
+        Objects.requireNonNull(decisions, "decisions");
+        Objects.requireNonNull(failureComparison, "failureComparison");
+        Objects.requireNonNull(flakyFailures, "flakyFailures");
+        decisions = List.copyOf(decisions);
+        flakyFailures = List.copyOf(flakyFailures);
+    }
+}

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/MutationCandidateGeneratorTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/MutationCandidateGeneratorTest.java
@@ -1,0 +1,89 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MutationCandidateGeneratorTest {
+
+    private final MutationCandidateGenerator generator = new MutationCandidateGenerator();
+
+    @Test
+    void generatesSortedProductionCandidatesAndIgnoresCommentsAndStrings(@TempDir Path project) throws Exception {
+        write(project, "com.example.Beta", """
+                package com.example;
+                class Beta {
+                    boolean value() { return false; }
+                }
+                """);
+        write(project, "com.example.Alpha", """
+                package com.example;
+                class Alpha {
+                    boolean value(int left, int right) {
+                        // true == false
+                        String ignored = "true != false";
+                        return true && left == right;
+                    }
+                }
+                """);
+
+        List<MutationCandidate> candidates = generator.generate(project, null, 10);
+
+        assertEquals(List.of(
+                "com.example.Alpha:BOOLEAN_LITERAL:true:false",
+                "com.example.Alpha:EQUALITY_OPERATOR:==:!=",
+                "com.example.Beta:BOOLEAN_LITERAL:false:true"),
+                candidates.stream().map(this::describe).toList());
+    }
+
+    @Test
+    void filtersByExactClassAndAppliesTheLimitAfterStableOrdering(@TempDir Path project) throws Exception {
+        write(project, "com.example.Beta", """
+                package com.example;
+                class Beta { boolean value() { return false; } }
+                """);
+        write(project, "com.example.Alpha", """
+                package com.example;
+                class Alpha { boolean value() { return true; } }
+                """);
+
+        List<MutationCandidate> filtered = generator.generate(project, "com.example.Beta", 10);
+        List<MutationCandidate> limited = generator.generate(project, null, 1);
+
+        assertEquals(List.of("com.example.Beta:BOOLEAN_LITERAL:false:true"),
+                filtered.stream().map(this::describe).toList());
+        assertEquals(List.of("com.example.Alpha:BOOLEAN_LITERAL:true:false"),
+                limited.stream().map(this::describe).toList());
+    }
+
+    @Test
+    void candidateAppliesItsSingleReplacementAtTheRecordedOffset(@TempDir Path project) throws Exception {
+        Path source = write(project, "com.example.Alpha", """
+                package com.example;
+                class Alpha { boolean value() { return true; } }
+                """);
+        MutationCandidate candidate = generator.generate(project, null, 1).getFirst();
+
+        String mutated = candidate.applyTo(Files.readString(source));
+
+        assertFalse(mutated.contains("return true"));
+        assertEquals("false", candidate.replacement());
+    }
+
+    private Path write(Path project, String className, String source) throws Exception {
+        Path file = project.resolve("src/main/java/" + className.replace('.', '/') + ".java");
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, source);
+        return file;
+    }
+
+    private String describe(MutationCandidate candidate) {
+        return candidate.className() + ":" + candidate.operator() + ":" + candidate.original()
+                + ":" + candidate.replacement();
+    }
+}

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/MutationCommandIntegrationTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/MutationCommandIntegrationTest.java
@@ -1,0 +1,95 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class MutationCommandIntegrationTest {
+
+    @Test
+    void reportsAPassWhenTheKillingTestTracksTheMutatedClass(@TempDir Path project, @TempDir Path outDir)
+            throws Exception {
+        Path agentJar = findOwnAgentJar();
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(project);
+        fixture.addSystemDependency(null, agentJar);
+        fixture.writeClass("com.example.Flag",
+                "package com.example; public class Flag { public boolean value() { return true; } }");
+        fixture.writeTest("com.example.FlagTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertTrue;
+                class FlagTest {
+                    @Test void detectsFalse() { assertTrue(new Flag().value()); }
+                }
+                """);
+        fixture.commit("baseline");
+        Path reportFile = outDir.resolve("mutation.json");
+
+        int exitCode = new MutationCommand().run(config(project, reportFile, "com.example.Flag"), agentJar);
+
+        MutationReport report = new ObjectMapper().readValue(reportFile.toFile(), MutationReport.class);
+        assertEquals(0, exitCode);
+        assertEquals(1, report.coverage().testKilledMutants());
+        assertEquals(1, report.coverage().selectedKillingTests());
+        assertEquals(0, report.coverage().skippedKillingTests());
+        assertFalse(Files.readString(project.resolve("src/main/java/com/example/Flag.java")).contains("return false"));
+    }
+
+    @Test
+    void reportsAFailWhenAConfirmedKillingTestWasNotTracked(@TempDir Path project, @TempDir Path outDir)
+            throws Exception {
+        Path agentJar = findOwnAgentJar();
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(project);
+        fixture.addSystemDependency(null, agentJar);
+        fixture.writeClass("com.example.Shared",
+                "package com.example; public class Shared { public static boolean value() { return true; } }");
+        fixture.writeTest("com.example.AaaWarmupTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                class AaaWarmupTest { @Test void warmsUp() {} }
+                """);
+        fixture.writeTest("com.example.GapTest", """
+                package com.example;
+                import org.junit.jupiter.api.BeforeAll;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.assertTrue;
+                class GapTest {
+                    static boolean cached;
+                    @BeforeAll static void warmUp() { cached = Shared.value(); }
+                    @Test void detectsMutation() { assertTrue(cached); }
+                }
+                """);
+        fixture.commit("baseline");
+        Path reportFile = outDir.resolve("mutation.json");
+
+        int exitCode = new MutationCommand().run(config(project, reportFile, "com.example.Shared"), agentJar);
+
+        MutationReport report = new ObjectMapper().readValue(reportFile.toFile(), MutationReport.class);
+        assertEquals(1, exitCode);
+        assertEquals(1, report.coverage().testKilledMutants());
+        assertEquals(1, report.coverage().skippedKillingTests());
+        assertEquals("com.example.GapTest", report.experiments().getFirst().skippedKillingTests().getFirst().className());
+    }
+
+    private MutationConfig config(Path project, Path report, String className) {
+        return new MutationConfig(project, report, className, 1, 1, 10, null,
+                MutationConfig.DEFAULT_BUILD_TIMEOUT_MINUTES, false);
+    }
+
+    private static Path findOwnAgentJar() throws IOException {
+        Path targetDir = Path.of("target");
+        try (var stream = Files.list(targetDir)) {
+            return stream.filter(path -> path.getFileName().toString().matches("blastradius-validator-.*\\.jar"))
+                    .filter(path -> !path.getFileName().toString().contains("sources"))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("agent jar not found in target/"));
+        }
+    }
+}

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/MutationReportTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/MutationReportTest.java
@@ -1,0 +1,55 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import io.github.baokhang83.blastradius.validator.verdict.Verdict;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MutationReportTest {
+
+    @Test
+    void skippedConfirmedKillingTestFailsTheMutationVerdictAndStaysVisibleInCoverage() {
+        TestIdentity killingTest = new TestIdentity("com.example.FlagTest", "detectsFalse");
+        MutationExperiment skippedKiller = new MutationExperiment(
+                candidate(), "mutant-sha", MutationStatus.KILLED, null,
+                List.of(killingTest), List.of(), List.of(killingTest), List.of());
+        MutationExperiment unbuildable = new MutationExperiment(
+                candidate(), "broken-sha", MutationStatus.UNBUILDABLE, "compilation failed",
+                List.of(), List.of(), List.of(), List.of());
+
+        MutationReport report = MutationReport.from("baseline-sha", List.of(), List.of(skippedKiller, unbuildable), 2, 0);
+
+        assertEquals(Verdict.FAIL, report.verdict());
+        assertEquals(2, report.coverage().generatedMutations());
+        assertEquals(1, report.coverage().compilableMutants());
+        assertEquals(1, report.coverage().testKilledMutants());
+        assertEquals(1, report.coverage().mutationKillingTests());
+        assertEquals(0, report.coverage().selectedKillingTests());
+        assertEquals(1, report.coverage().skippedKillingTests());
+        assertTrue(report.experiments().getFirst().skippedKillingTests().contains(killingTest));
+    }
+
+    @Test
+    void unbuildableAndFlakyMutantsDoNotCreateASoundnessFailure() {
+        MutationExperiment unbuildable = new MutationExperiment(
+                candidate(), "broken-sha", MutationStatus.UNBUILDABLE, "compilation failed",
+                List.of(), List.of(), List.of(), List.of());
+        MutationExperiment flaky = new MutationExperiment(
+                candidate(), "flaky-sha", MutationStatus.SURVIVED, null,
+                List.of(), List.of(), List.of(), List.of(new TestIdentity("com.example.FlagTest", "flaky")));
+
+        MutationReport report = MutationReport.from("baseline-sha", List.of(), List.of(unbuildable, flaky), 2, 0);
+
+        assertEquals(Verdict.PASS, report.verdict());
+        assertEquals(1, report.coverage().flakyMutantFailures());
+        assertEquals(1, report.coverage().unbuildableMutants());
+    }
+
+    private MutationCandidate candidate() {
+        return new MutationCandidate("src/main/java/com/example/Flag.java", "com.example.Flag",
+                MutationOperator.BOOLEAN_LITERAL, 1, "true", "false");
+    }
+}

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/MutationTextSummaryRendererTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/MutationTextSummaryRendererTest.java
@@ -1,0 +1,26 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class MutationTextSummaryRendererTest {
+
+    @Test
+    void rendersTheSoundnessDenominatorAndSkippedKillingTest() {
+        TestIdentity test = new TestIdentity("com.example.FlagTest", "detectsFalse");
+        MutationExperiment experiment = new MutationExperiment(
+                new MutationCandidate("src/main/java/com/example/Flag.java", "com.example.Flag",
+                        MutationOperator.BOOLEAN_LITERAL, 0, "true", "false"),
+                "mutant", MutationStatus.KILLED, null, List.of(test), List.of(), List.of(test), List.of());
+
+        String text = new MutationTextSummaryRenderer().render(
+                MutationReport.from("baseline", List.of(), List.of(experiment), 1, 0));
+
+        assertTrue(text.contains("Verdict: FAIL"));
+        assertTrue(text.contains("killing tests skipped: 1"));
+        assertTrue(text.contains("skipped killing test: com.example.FlagTest#detectsFalse"));
+    }
+}

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/SyntheticMutationCheckoutTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/SyntheticMutationCheckoutTest.java
@@ -1,0 +1,57 @@
+package io.github.baokhang83.blastradius.validator.mutation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import io.github.baokhang83.blastradius.core.testsupport.FixtureProjectBuilder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.ObjectId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SyntheticMutationCheckoutTest {
+
+    @Test
+    void commitsTheMutationAsADirectChildWithoutChangingTheTargetWorktree(
+            @TempDir Path project, @TempDir Path scratchParent) throws Exception {
+        String source = "package com.example; class Flag { boolean value() { return true; } }";
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(project);
+        fixture.writeClass("com.example.Flag", source);
+        fixture.commit("baseline");
+        String baseline = head(project);
+        Path targetSource = project.resolve("src/main/java/com/example/Flag.java");
+        MutationCandidate candidate = new MutationCandidate(
+                "src/main/java/com/example/Flag.java", "com.example.Flag", MutationOperator.BOOLEAN_LITERAL,
+                source.indexOf("true"), "true", "false");
+
+        String mutant;
+        try (SyntheticMutationCheckout checkout = SyntheticMutationCheckout.forTargetProject(project, scratchParent)) {
+            checkout.checkoutBaseline(baseline);
+            mutant = checkout.commit(candidate);
+
+            try (Git scratch = Git.open(checkout.workTree().toFile())) {
+                assertEquals(baseline, scratch.getRepository().parseCommit(ObjectId.fromString(mutant))
+                        .getParent(0).getName());
+            }
+            assertFalse(Files.readString(checkout.workTree().resolve(candidate.sourcePath())).contains("return true"));
+        }
+
+        assertEquals(baseline, head(project));
+        assertEquals(source, Files.readString(targetSource));
+        try (Git target = Git.open(project.toFile())) {
+            assertTrueClean(target);
+        }
+    }
+
+    private String head(Path project) throws Exception {
+        try (Git git = Git.open(project.toFile())) {
+            return git.getRepository().resolve("HEAD").name();
+        }
+    }
+
+    private void assertTrueClean(Git git) throws Exception {
+        assertFalse(git.status().call().hasUncommittedChanges());
+    }
+}

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/selection/PairSelectionAnalyzerTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/selection/PairSelectionAnalyzerTest.java
@@ -1,0 +1,41 @@
+package io.github.baokhang83.blastradius.validator.selection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.baokhang83.blastradius.core.git.ChangedFile;
+import io.github.baokhang83.blastradius.core.git.FileKind;
+import io.github.baokhang83.blastradius.core.tracking.DependencyRecordSet;
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import io.github.baokhang83.blastradius.validator.build.GroundTruthResult;
+import io.github.baokhang83.blastradius.validator.build.Outcome;
+import io.github.baokhang83.blastradius.validator.git.CommitPair;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class PairSelectionAnalyzerTest {
+
+    private final PairSelectionAnalyzer analyzer = new PairSelectionAnalyzer();
+
+    @Test
+    void usesTheSameDependencyDecisionForAConfirmedNewFailure() {
+        TestIdentity test = new TestIdentity("com.example.FlagTest", "detectsFalse");
+        List<ChangedFile> changedFiles = List.of(
+                new ChangedFile("src/main/java/com/example/Flag.java", FileKind.JAVA_SOURCE, "com.example.Flag"));
+        DependencyRecordSet baseline = new DependencyRecordSet(
+                Map.of(test, Map.of("com.example.Flag", "checksum")), Set.of());
+        CommitPair edge = CommitPair.analyzed("base", "mutant", changedFiles);
+
+        PairSelectionResult result = analyzer.analyze(
+                edge, baseline,
+                List.of(new GroundTruthResult(test, Outcome.PASSED)),
+                List.of(new GroundTruthResult(test, Outcome.CONFIRMED_FAILED)), null);
+
+        assertTrue(result.decisions().getFirst().selected());
+        assertEquals(1, result.failureComparison().coverage().newlyConfirmedFailingTests());
+        assertEquals(1, result.failureComparison().coverage().selectedNewlyConfirmedFailures());
+        assertTrue(result.failureComparison().wouldMissCases().isEmpty());
+    }
+}

--- a/docs/fluencyloop/features/add-opt-in-bounded-mutation-based-validator-soundness-valida/design.md
+++ b/docs/fluencyloop/features/add-opt-in-bounded-mutation-based-validator-soundness-valida/design.md
@@ -1,0 +1,129 @@
+# Design: Add opt-in, bounded mutation-based validator soundness validation for issue 187
+
+started: 2026-08-01
+
+## Purpose
+
+Historical replay observes whatever regressions happened to be committed. A mutation run deliberately introduces a small, controlled defect and checks whether Blastradius selects every test that demonstrably catches it. It strengthens evidence about selection soundness, but it is not a proof that every real change or every possible defect is covered.
+
+The feature is a separate `mutate` CLI action rather than an extra default on `run`. Mutation testing is expensive and changes a scratch clone, so requiring an explicit action keeps historical validator behavior and its safe default intact.
+
+## Operator contract
+
+`mutate` accepts a Maven Java project and resolves its current `HEAD` as baseline `B`. It offers bounded, deterministic work through a production-class filter, maximum candidate count, and wall-clock time limit. Candidate files and token locations are sorted before limits are applied, making the same baseline and options produce the same sampled corpus.
+
+The initial mutation set is deliberately small: boolean-literal inversion and equality or relational operator inversion. Each replacement preserves the source token category, so a candidate starts from a compilable expression shape. The mutant build remains the final authority: an unbuildable mutation is reported, never treated as a selection failure.
+
+For one mutation, the oracle is:
+
+1. A full-suite build of `B`, with the tracking agent, records dependencies and baseline test outcomes.
+2. The runner writes the mutation only in a disposable clone and commits it as `M`, whose direct parent is `B`.
+3. A full-suite build of `M` establishes outcomes. Every initially failing test is rerun by the existing `GroundTruthResolver`.
+4. A test is a killing test only if it passed at `B` and is `CONFIRMED_FAILED` at `M`. A failure that passes on confirmation is a flake, and a failure already present at `B` is not eligible.
+5. The shared pair-selection path evaluates the real Git edge `B -> M`. Every eligible killing test must be selected. Any skipped killing test makes the mutation verdict fail.
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class Main {
+    +main(args)
+  }
+  class MutationCommand {
+    +run(config, agentJar) int
+  }
+  class MutationConfig {
+    +projectPath Path
+    +classFilter String
+    +maxMutations int
+    +timeLimitMinutes long
+  }
+  class MutationCandidateGenerator {
+    +generate(baselineTree, filter) List~MutationCandidate~
+  }
+  class MutationCandidate {
+    +sourcePath String
+    +className String
+    +operator MutationOperator
+    +offset int
+    +before String
+    +after String
+  }
+  class SyntheticMutationCheckout {
+    +checkoutBaseline(sha) Path
+    +commit(candidate) String
+  }
+  class PairSelectionAnalyzer {
+    +analyze(edge, baseline, mutant, repository, headTree) PairSelectionResult
+  }
+  class GroundTruthResolver {
+    +resolve(projectDir, agentJar, dependencyOutput) GroundTruthResolution
+  }
+  class MutationReport {
+    +verdict Verdict
+    +coverage MutationCoverage
+    +experiments List~MutationExperiment~
+  }
+
+  Main --> MutationCommand
+  MutationCommand --> MutationConfig
+  MutationCommand --> MutationCandidateGenerator
+  MutationCommand --> SyntheticMutationCheckout
+  MutationCommand --> GroundTruthResolver
+  MutationCommand --> PairSelectionAnalyzer
+  MutationCommand --> MutationReport
+  MutationCandidateGenerator --> MutationCandidate
+  SyntheticMutationCheckout --> MutationCandidate
+  PairSelectionAnalyzer --> GroundTruthResolver
+```
+
+`PairSelectionAnalyzer` is the one shared seam: both history replay and mutation replay give it a direct Git edge plus established baseline and head builds. This prevents mutation mode from quietly becoming a different selection implementation.
+
+## Sequence: one mutation experiment
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Command as MutationCommand
+  participant Clone as Disposable clone
+  participant Build as GroundTruthResolver
+  participant Select as PairSelectionAnalyzer
+  participant Report as MutationReport
+
+  User->>Command: mutate project options
+  Command->>Clone: clone target and resolve baseline B
+  Command->>Build: build B with tracking agent
+  Build-->>Command: dependencies and baseline outcomes
+  Command->>Clone: checkout B, apply candidate, commit M
+  Command->>Build: build full suite at M
+  Build-->>Command: confirmed mutant outcomes
+  Command->>Select: analyze direct edge B to M
+  Select-->>Command: selected tests and skipped killing tests
+  Command->>Report: record identity, outcome, denominator, verdict
+  Command->>Clone: discard clone
+  Command-->>User: JSON report and text summary
+```
+
+## Result model
+
+`MutationReport` keeps all attempted experiments rather than only successful ones. Its coverage denominator separately records generated candidates, time or limit-skipped candidates, unbuildable mutants, baseline-clean mutants, mutants with confirmed killing tests, confirmed killing tests, selected killing tests, skipped killing tests, and flaky mutant failures. Each experiment contains the mutation identity, synthetic SHA, build outcome, confirmed killing tests, selected killing tests, and skipped killing tests.
+
+The overall verdict is `PASS` when no eligible killing test was skipped. It is `FAIL` when at least one confirmed killing test was skipped. A run-level inability to establish the baseline or write a report remains exit code `2`; individual bad mutants are observations in the report, not reasons to discard the run.
+
+## Test slices
+
+1. Define and test deterministic candidate generation and bounded filtering.
+2. Define and test scratch-clone mutation commits: `M` has `B` as its direct parent and the source repository worktree is unchanged.
+3. Extract and test the shared pair-selection seam from historical replay.
+4. Add mutation oracle classification and report and text-rendering contract tests.
+5. Add fixture-backed end-to-end cases for a correctly selected killing test and a deliberately untracked, skipped killing test.
+6. Wire the opt-in CLI, documentation, and a real Maven-project smoke run.
+
+## Constitution check
+
+- **I — TDD:** each slice starts with focused failing tests; fixture integration comes after the small deterministic units.
+- **II — simplicity:** the first operator set is intentionally narrow and needs no parser framework or mutation-engine dependency.
+- **III — safety:** a verdict only speaks about confirmed killing tests. Build failures, flakes, and pre-existing baseline failures stay visible but are excluded from the soundness denominator.
+- **IV — deterministic core:** candidate ordering, sampling, and operators are fixed and opt-in, with no statistical inference.
+- **V — explainability:** each reported outcome retains source location, replacement, synthetic edge, killing tests, and selection result.
+- **VII — cleanup:** the synthetic clone is disposed after the run; every mutation returns to `B` before the next one so no build or source state leaks between experiments.

--- a/docs/fluencyloop/features/add-opt-in-bounded-mutation-based-validator-soundness-valida/sessions/create-synthetic-mutation-commits-in-disposable-checkouts.md
+++ b/docs/fluencyloop/features/add-opt-in-bounded-mutation-based-validator-soundness-valida/sessions/create-synthetic-mutation-commits-in-disposable-checkouts.md
@@ -1,0 +1,17 @@
+# Session: Create synthetic mutation commits in disposable checkouts
+
+- **intent:** Create synthetic mutation commits in disposable checkouts
+- **started:** 2026-08-01
+
+## Decision: Create mutations as real commits in the existing disposable-clone lifecycle
+
+- **where:** `CommitCheckout` and `SyntheticMutationCheckout`
+- **why:** A committed child gives the selector its normal Git edge while one established cleanup path proves the target worktree is never mutated.
+- **alternative:** Patch the target project then revert it, or create a second ad hoc clone implementation — rejected: both make accidental state leakage and lifecycle drift more likely.
+- **design:** [sequence: one mutation experiment](../design.md#sequence-one-mutation-experiment)
+- **constitution:** §III, §VII
+- **trust:** ✓ verified
+
+## Knowledge transfer
+
+The key distinction is between a source-file edit and a Git edge. The selector reasons over the diff from a base SHA to a head SHA, so a synthetic commit makes the experiment exercise that exact production path rather than an approximation. The checkout test verifies both sides of the safety property: `M` names `B` as its direct parent, and the source repository remains at its original SHA with a clean worktree. The synthetic author identity exists only in the disposable clone and has no effect on the project under analysis.

--- a/docs/fluencyloop/features/add-opt-in-bounded-mutation-based-validator-soundness-valida/sessions/generate-deterministic-bounded-java-mutation-candidates.md
+++ b/docs/fluencyloop/features/add-opt-in-bounded-mutation-based-validator-soundness-valida/sessions/generate-deterministic-bounded-java-mutation-candidates.md
@@ -1,0 +1,17 @@
+# Session: Generate deterministic, bounded Java mutation candidates
+
+- **intent:** Generate deterministic, bounded Java mutation candidates
+- **started:** 2026-08-01
+
+## Decision: Enumerate a narrow token-preserving corpus deterministically
+
+- **where:** `blastradius-validator/.../mutation/MutationCandidateGenerator`
+- **why:** Boolean and comparison-token inversions give the first mutation corpus meaningful, reproducible defects without adding a parser framework or making historical validator runs expensive.
+- **alternative:** Integrate a general mutation-testing engine or mutate arbitrary Java syntax — rejected: that would broaden the feature beyond a controlled soundness corpus and obscure why a candidate exists.
+- **design:** [operator contract](../design.md#operator-contract)
+- **constitution:** §II, §IV, §V
+- **trust:** ✓ verified
+
+## Knowledge transfer
+
+The generator is deliberately not deciding whether a mutation is valuable or whether it will be killed. It only produces a stable list of small edits, then later slices let the target project's compiler and full test suite be the authorities. Skipping comments, strings, characters, and text blocks matters because changing explanatory text would create a misleading mutation that has no executable behavior. Applying limits only after sorting gives an operator reproducible evidence: the same project revision and limits select the same starting corpus.

--- a/docs/fluencyloop/features/add-opt-in-bounded-mutation-based-validator-soundness-valida/sessions/run-bounded-mutation-experiments-and-report-confirmed-misses.md
+++ b/docs/fluencyloop/features/add-opt-in-bounded-mutation-based-validator-soundness-valida/sessions/run-bounded-mutation-experiments-and-report-confirmed-misses.md
@@ -1,0 +1,17 @@
+# Session: Run bounded mutation experiments and report confirmed misses
+
+- **intent:** Run bounded mutation experiments and report confirmed misses
+- **started:** 2026-08-01
+
+## Decision: Require a confirmed full-suite outcome before judging selection
+
+- **where:** `validator/mutation/MutationCommand` and mutation report types
+- **why:** A test counts as killing only when it passed at baseline and is a confirmed failure on the synthetic child, so a validator miss has an observable regression behind it rather than a guess.
+- **alternative:** Treat every mutant build failure or first failing test as evidence — rejected: compilation failures and flakes cannot establish that a selected test would have detected the mutation.
+- **design:** [operator contract](../design.md#operator-contract)
+- **constitution:** §I, §III, §IV, §V
+- **trust:** ✓ verified
+
+## Knowledge transfer
+
+The mutation command is opt-in, but `--mutation-class` is not required. Without it, the runner scans deterministic production-source order and stops at the configured class, mutation, and time bounds; the class option is an exact filter for a focused investigation. Baseline dependencies are recorded once with the tracking agent, while each synthetic child is judged by an agent-free full-suite run. The report then shows the whole denominator, including unbuildable mutations, existing baseline failures, flakes, confirmed killing tests, and selected versus skipped killing tests. The two fixture integrations prove both outcomes: a normal tracked dependency passes, while the known `@BeforeAll` gap surfaces as a failed mutation verdict.

--- a/docs/fluencyloop/features/add-opt-in-bounded-mutation-based-validator-soundness-valida/sessions/share-pair-selection-between-historical-and-mutation-replay.md
+++ b/docs/fluencyloop/features/add-opt-in-bounded-mutation-based-validator-soundness-valida/sessions/share-pair-selection-between-historical-and-mutation-replay.md
@@ -1,0 +1,17 @@
+# Session: Share pair selection between historical and mutation replay
+
+- **intent:** Share pair selection between historical and mutation replay
+- **started:** 2026-08-01
+
+## Decision: Share selection and comparison after builds are established
+
+- **where:** `validator/selection/PairSelectionAnalyzer`
+- **why:** Historical and synthetic edges now use one dependency-to-decision and confirmed-failure comparison path, so an observed mutation miss means the same selection logic would miss it during history replay.
+- **alternative:** Copy `RunCommand` selection code into mutation mode — rejected: copied logic can drift and would make the evidence weaker precisely where the feature is meant to increase trust.
+- **design:** [class diagram](../design.md#class-diagram)
+- **constitution:** §I, §III, §V
+- **trust:** ✓ verified
+
+## Knowledge transfer
+
+The build scheduler remains separate from selection because history replay needs caching and concurrency, while mutation replay creates one new head at a time. Once each has a baseline dependency record and full-suite outcomes, however, their correctness question is identical: which tests would the selector choose for this edge, and did it omit a newly confirmed failure? Extracting just that seam preserves the mature historical scheduling behavior while eliminating duplicate verdict logic. The existing end-to-end history fixtures stayed green after the extraction, including the known would-miss case.


### PR DESCRIPTION
## Summary

- add the opt-in `mutate` validator action for bounded mutation-based soundness validation
- create each mutant as a real direct Git child in a disposable clone, leaving the supplied repository unchanged
- record the full evidence denominator: unbuildable mutants, baseline failures, flakes, confirmed killing tests, and selected versus skipped killing tests
- share the established pair-selection/comparison path with historical replay, preventing mutation validation from using divergent selection logic
- document deterministic corpus bounds with `--max-mutation-classes`, `--max-mutations`, and `--mutation-time-limit-minutes`

## Validation

- `mvn -B --no-transfer-progress clean verify`
- focused mutation suite: candidate generation, report/text rendering, synthetic-commit isolation, and both full pipeline fixtures

## FluencyLoop review

Design: `docs/fluencyloop/features/add-opt-in-bounded-mutation-based-validator-soundness-valida/design.md`

Key decisions:

- generate a small deterministic token-preserving corpus instead of integrating a general mutation engine
- commit mutations in the existing disposable checkout lifecycle instead of touching the target worktree
- evaluate synthetic and historical edges through one shared pair-selection path
- require a baseline pass plus a confirmed mutant failure before treating a test as a killing test

Constitution check: all recorded decisions are verified and align with Principles I–V and VII.

Note: one post-session commit clarifies the public bound name as `--max-mutation-classes`; the behavior is journaled in the preceding mutation-run session.
