### PR TITLE
validator: exclude configured flaky tests

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
   "feature": "add-explicit-flaky-test-exclusions-to-validator-target-build",
   "branch": "feature/add-explicit-flaky-test-exclusions-to-validator-target-build",
-  "stage": "design",
-  "last_session": "",
+  "stage": "build",
+  "last_session": "docs/fluencyloop/features/add-explicit-flaky-test-exclusions-to-validator-target-build/sessions/make-test-exclusions-auditable-across-validator-modes.md",
   "base_ref": "main",
   "updated": "2026-08-02"
 }

--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,8 +1,8 @@
 {
-  "feature": "add-opt-in-bounded-mutation-based-validator-soundness-valida",
-  "branch": "feature/add-opt-in-bounded-mutation-based-validator-soundness-valida",
-  "stage": "build",
-  "last_session": "docs/fluencyloop/features/add-opt-in-bounded-mutation-based-validator-soundness-valida/sessions/run-bounded-mutation-experiments-and-report-confirmed-misses.md",
+  "feature": "add-explicit-flaky-test-exclusions-to-validator-target-build",
+  "branch": "feature/add-explicit-flaky-test-exclusions-to-validator-target-build",
+  "stage": "design",
+  "last_session": "",
   "base_ref": "main",
-  "updated": "2026-08-01"
+  "updated": "2026-08-02"
 }

--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ do not become soundness failures. This is sampled fault evidence, not a claim th
 changes or every possible defect are covered. Use the optional `--mutation-class <FQCN>` only
 when you want to focus the bounded run on one production class.
 
+### Excluding known flaky tests
+
+Both validator actions accept `--skipped-tests` with one or more comma-separated, fully qualified
+test-class names. The named tests are excluded from every target Maven build, including baseline,
+head, mutation, and confirmation runs. The JSON and text reports list them explicitly, so the
+result is clear about the test population it did not observe.
+
+```sh
+--skipped-tests org.app.FlakyTest,org.app2.Flaky2Test
+```
+
+This is an opt-in evidence boundary, not a pass verdict for the skipped tests. Use exact class
+names only; method patterns and wildcard expressions are intentionally not accepted.
+
 ## How it works
 
 1. **Track.** On a build of your base branch, a `java.lang.instrument` agent watches every

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunner.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunner.java
@@ -54,6 +54,7 @@ public final class MavenBuildRunner {
     private final long timeoutMinutes;
     private final boolean isolatedRepo;
     private final boolean skipBuildExtras;
+    private final SkippedTests skippedTests;
 
     /** No {@code -T} flag: the target project's reactor builds serially, as it always has. */
     public MavenBuildRunner() {
@@ -99,6 +100,12 @@ public final class MavenBuildRunner {
      */
     public MavenBuildRunner(Integer parallelThreads, long timeoutMinutes, boolean isolatedRepo,
             boolean skipBuildExtras) {
+        this(parallelThreads, timeoutMinutes, isolatedRepo, skipBuildExtras, SkippedTests.none());
+    }
+
+    /** Creates a runner that consistently excludes the supplied known-flaky test classes. */
+    public MavenBuildRunner(Integer parallelThreads, long timeoutMinutes, boolean isolatedRepo,
+            boolean skipBuildExtras, SkippedTests skippedTests) {
         if (parallelThreads != null && parallelThreads < 1) {
             throw new IllegalArgumentException("parallelThreads must be positive, got: " + parallelThreads);
         }
@@ -109,6 +116,7 @@ public final class MavenBuildRunner {
         this.timeoutMinutes = timeoutMinutes;
         this.isolatedRepo = isolatedRepo;
         this.skipBuildExtras = skipBuildExtras;
+        this.skippedTests = java.util.Objects.requireNonNull(skippedTests, "skippedTests");
     }
 
     /**
@@ -331,8 +339,9 @@ public final class MavenBuildRunner {
             args.add("-T");
             args.add(String.valueOf(parallelThreads));
         }
-        if (testSelector != null) {
-            args.add("-Dtest=" + testSelector);
+        String effectiveSelector = skippedTests.appendTo(testSelector);
+        if (effectiveSelector != null) {
+            args.add("-Dtest=" + effectiveSelector);
             // Without this, a multi-module reactor aborts the whole build at the first
             // module that has test sources but none matching testSelector (found running
             // against apache/shenyu, whose shenyu-common module has no test named after

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/SkippedTests.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/SkippedTests.java
@@ -1,0 +1,52 @@
+package io.github.baokhang83.blastradius.validator.build;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/** Explicit, class-level test exclusions supplied to the validator. */
+public record SkippedTests(List<String> classes) {
+
+    private static final Pattern CLASS_NAME = Pattern.compile(
+            "[A-Za-z_$][A-Za-z0-9_$]*(?:\\.[A-Za-z_$][A-Za-z0-9_$]*)+");
+
+    public SkippedTests {
+        Objects.requireNonNull(classes, "classes");
+        classes = List.copyOf(classes);
+    }
+
+    public static SkippedTests none() {
+        return new SkippedTests(List.of());
+    }
+
+    /** Parses one or more comma-separated CLI values into ordered, distinct class names. */
+    public static SkippedTests parse(List<String> values) {
+        Objects.requireNonNull(values, "values");
+        LinkedHashSet<String> names = new LinkedHashSet<>();
+        for (String value : values) {
+            Objects.requireNonNull(value, "skipped test value");
+            for (String entry : value.split(",", -1)) {
+                String className = entry.trim();
+                if (!CLASS_NAME.matcher(className).matches()) {
+                    throw new IllegalArgumentException("skipped tests must be fully qualified class names: " + entry);
+                }
+                names.add(className);
+            }
+        }
+        return new SkippedTests(List.copyOf(names));
+    }
+
+    /** Adds Surefire negative patterns to a nullable positive selector. */
+    public String appendTo(String selector) {
+        if (classes.isEmpty()) {
+            return selector;
+        }
+        List<String> selectors = new java.util.ArrayList<>();
+        if (selector != null) {
+            selectors.add(selector);
+        }
+        classes.forEach(className -> selectors.add("!" + className));
+        return String.join(",", selectors);
+    }
+}

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/Main.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/Main.java
@@ -2,6 +2,7 @@ package io.github.baokhang83.blastradius.validator.cli;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.baokhang83.blastradius.validator.git.HistoryMode;
+import io.github.baokhang83.blastradius.validator.build.SkippedTests;
 import io.github.baokhang83.blastradius.validator.mutation.MutationCommand;
 import io.github.baokhang83.blastradius.validator.mutation.MutationConfig;
 import io.github.baokhang83.blastradius.validator.mutation.MutationReport;
@@ -11,6 +12,8 @@ import io.github.baokhang83.blastradius.validator.report.TextSummaryRenderer;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * CLI entry point. Usage:
@@ -48,6 +51,7 @@ public final class Main {
         long buildTimeoutMinutes = RunConfig.DEFAULT_BUILD_TIMEOUT_MINUTES;
         boolean skipBuildExtras = false;
         HistoryMode historyMode = HistoryMode.ALL_PARENTS;
+        List<String> skippedTestValues = new ArrayList<>();
 
         for (int i = 1; i < args.length; i++) {
             switch (args[i]) {
@@ -61,6 +65,7 @@ public final class Main {
                 case "--build-timeout-minutes" -> buildTimeoutMinutes = Long.parseLong(args[++i]);
                 case "--skip-build-extras" -> skipBuildExtras = true;
                 case "--history-mode" -> historyMode = HistoryMode.fromCliValue(args[++i]);
+                case "--skipped-tests" -> skippedTestValues.add(args[++i]);
                 default -> {
                     System.err.println("unknown argument: " + args[i]);
                     System.exit(2);
@@ -77,7 +82,8 @@ public final class Main {
 
         try {
             RunConfig config = new RunConfig(projectPath, commits, reportOut, mavenThreads, fastGroundTruth,
-                    buildConcurrency, buildTimeoutMinutes, skipBuildExtras, historyMode);
+                    buildConcurrency, buildTimeoutMinutes, skipBuildExtras, historyMode,
+                    SkippedTests.parse(skippedTestValues));
             int exitCode = new RunCommand().run(config);
             printSummary(reportOut, summaryOut, exitCode);
             System.exit(exitCode);
@@ -98,6 +104,7 @@ public final class Main {
         Integer mavenThreads = null;
         long buildTimeoutMinutes = MutationConfig.DEFAULT_BUILD_TIMEOUT_MINUTES;
         boolean skipBuildExtras = false;
+        List<String> skippedTestValues = new ArrayList<>();
         for (int i = 1; i < args.length; i++) {
             switch (args[i]) {
                 case "--project-path" -> projectPath = Path.of(args[++i]);
@@ -110,6 +117,7 @@ public final class Main {
                 case "--maven-threads" -> mavenThreads = Integer.parseInt(args[++i]);
                 case "--build-timeout-minutes" -> buildTimeoutMinutes = Long.parseLong(args[++i]);
                 case "--skip-build-extras" -> skipBuildExtras = true;
+                case "--skipped-tests" -> skippedTestValues.add(args[++i]);
                 default -> {
                     System.err.println("unknown argument: " + args[i]);
                     System.exit(2);
@@ -124,7 +132,8 @@ public final class Main {
         }
         try {
             MutationConfig config = new MutationConfig(projectPath, reportOut, classFilter, maxMutationClasses, maxMutations,
-                    timeLimitMinutes, mavenThreads, buildTimeoutMinutes, skipBuildExtras);
+                    timeLimitMinutes, mavenThreads, buildTimeoutMinutes, skipBuildExtras,
+                    SkippedTests.parse(skippedTestValues));
             int exitCode = new MutationCommand().run(config);
             printMutationSummary(reportOut, summaryOut, exitCode);
             System.exit(exitCode);
@@ -173,10 +182,10 @@ public final class Main {
         System.err.println("usage: run --project-path <path> --commits <N> --report-out <path> "
                 + "[--summary-out <path>] [--maven-threads <N>] [--fast-ground-truth] "
                 + "[--build-concurrency <K>] [--build-timeout-minutes <M>] [--skip-build-extras] "
-                + "[--history-mode <all-parents|first-parent>]\n"
+                + "[--history-mode <all-parents|first-parent>] [--skipped-tests <FQCN,...>]\n"
                 + "   or: mutate --project-path <path> --report-out <path> [--summary-out <path>] "
                 + "[--mutation-class <FQCN>] [--max-mutation-classes <N>] [--max-mutations <N>] "
                 + "[--mutation-time-limit-minutes <M>] [--maven-threads <N>] "
-                + "[--build-timeout-minutes <M>] [--skip-build-extras]");
+                + "[--build-timeout-minutes <M>] [--skip-build-extras] [--skipped-tests <FQCN,...>]");
     }
 }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
@@ -109,7 +109,7 @@ public final class RunCommand {
             boolean isolatedRepo = config.buildConcurrency() > 1;
             buildRunner = new MavenBuildRunner(
                     config.mavenParallelThreads(), config.buildTimeoutMinutes(), isolatedRepo,
-                    config.skipBuildExtras());
+                    config.skipBuildExtras(), config.skippedTests());
             groundTruthResolver = new GroundTruthResolver(buildRunner);
 
             jdkMismatchDetector.detect(config.projectPath()).ifPresent(System.err::println);
@@ -230,7 +230,7 @@ public final class RunCommand {
         Verdict verdict = verdictCalculator.calculate(allMisses);
         SavingsSummary savingsSummary = savingsSummaryAggregator.aggregate(allDecisions);
         return new AnalysisReport(verdict, config.historyMode(), analyzedPairs, excludedPairs, failureCoverage,
-                allMisses, allFlaky, savingsSummary);
+                allMisses, allFlaky, savingsSummary, config.skippedTests().classes());
     }
 
     private record PairAnalysis(

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunConfig.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunConfig.java
@@ -1,5 +1,6 @@
 package io.github.baokhang83.blastradius.validator.cli;
 
+import io.github.baokhang83.blastradius.validator.build.SkippedTests;
 import io.github.baokhang83.blastradius.validator.git.HistoryMode;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -41,11 +42,13 @@ import java.util.Objects;
  *                             during {@code clean test} but change neither which tests run nor
  *                             whether they pass. Pure per-build wall-clock savings; soundness-
  *                             neutral (constitution §III), unlike scoping the reactor.
+ * @param skippedTests         opt-in exact test classes to exclude from every target build. They
+ *                             are retained in the resulting report as an explicit evidence boundary.
  */
 public record RunConfig(
         Path projectPath, int commitWindowSize, Path reportOutputPath, Integer mavenParallelThreads,
         boolean fastGroundTruth, int buildConcurrency, long buildTimeoutMinutes, boolean skipBuildExtras,
-        HistoryMode historyMode) {
+        HistoryMode historyMode, SkippedTests skippedTests) {
 
     /** Default build timeout in minutes when the operator doesn't override it. */
     public static final long DEFAULT_BUILD_TIMEOUT_MINUTES = 5;
@@ -85,7 +88,16 @@ public record RunConfig(
             Path projectPath, int commitWindowSize, Path reportOutputPath, Integer mavenParallelThreads,
             boolean fastGroundTruth, int buildConcurrency, long buildTimeoutMinutes, boolean skipBuildExtras) {
         this(projectPath, commitWindowSize, reportOutputPath, mavenParallelThreads, fastGroundTruth,
-                buildConcurrency, buildTimeoutMinutes, skipBuildExtras, HistoryMode.ALL_PARENTS);
+                buildConcurrency, buildTimeoutMinutes, skipBuildExtras, HistoryMode.ALL_PARENTS, SkippedTests.none());
+    }
+
+    /** Compatibility constructor for callers that do not use explicit test exclusions. */
+    public RunConfig(
+            Path projectPath, int commitWindowSize, Path reportOutputPath, Integer mavenParallelThreads,
+            boolean fastGroundTruth, int buildConcurrency, long buildTimeoutMinutes, boolean skipBuildExtras,
+            HistoryMode historyMode) {
+        this(projectPath, commitWindowSize, reportOutputPath, mavenParallelThreads, fastGroundTruth,
+                buildConcurrency, buildTimeoutMinutes, skipBuildExtras, historyMode, SkippedTests.none());
     }
 
     public RunConfig {
@@ -101,6 +113,7 @@ public record RunConfig(
         }
         Objects.requireNonNull(reportOutputPath, "reportOutputPath");
         Objects.requireNonNull(historyMode, "historyMode");
+        Objects.requireNonNull(skippedTests, "skippedTests");
         if (Files.isDirectory(reportOutputPath)) {
             throw new IllegalArgumentException("reportOutputPath must be a file path, not a directory: " + reportOutputPath);
         }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCommand.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCommand.java
@@ -55,7 +55,8 @@ public final class MutationCommand {
             new JdkMismatchDetector().detect(config.projectPath()).ifPresent(System.err::println);
             scratchParent = Files.createTempDirectory("blastradius-mutations-");
             MavenBuildRunner buildRunner = new MavenBuildRunner(
-                    config.mavenParallelThreads(), config.buildTimeoutMinutes(), false, config.skipBuildExtras());
+                    config.mavenParallelThreads(), config.buildTimeoutMinutes(), false, config.skipBuildExtras(),
+                    config.skippedTests());
             GroundTruthResolver groundTruthResolver = new GroundTruthResolver(buildRunner);
             try (SyntheticMutationCheckout checkout =
                     SyntheticMutationCheckout.forTargetProject(config.projectPath(), scratchParent)) {
@@ -98,7 +99,8 @@ public final class MutationCommand {
                             baselineDependencies, baselineOutcomes, mutantResolution.results()));
                 }
                 MutationReport report = MutationReport.from(
-                        baselineSha, baselineFailingTests, experiments, candidates.size(), timeLimitSkipped);
+                        baselineSha, baselineFailingTests, experiments, candidates.size(), timeLimitSkipped,
+                        config.skippedTests().classes());
                 reportWriter.write(config.reportOutputPath(), report);
                 return report.verdict() == io.github.baokhang83.blastradius.validator.verdict.Verdict.PASS ? 0 : 1;
             }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationConfig.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationConfig.java
@@ -1,5 +1,6 @@
 package io.github.baokhang83.blastradius.validator.mutation;
 
+import io.github.baokhang83.blastradius.validator.build.SkippedTests;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
@@ -14,7 +15,8 @@ public record MutationConfig(
         long timeLimitMinutes,
         Integer mavenParallelThreads,
         long buildTimeoutMinutes,
-        boolean skipBuildExtras) {
+        boolean skipBuildExtras,
+        SkippedTests skippedTests) {
 
     public static final int DEFAULT_MAX_CLASSES = 10;
     public static final int DEFAULT_MAX_MUTATIONS = 20;
@@ -23,12 +25,22 @@ public record MutationConfig(
 
     public MutationConfig(Path projectPath, Path reportOutputPath) {
         this(projectPath, reportOutputPath, null, DEFAULT_MAX_CLASSES, DEFAULT_MAX_MUTATIONS,
-                DEFAULT_TIME_LIMIT_MINUTES, null, DEFAULT_BUILD_TIMEOUT_MINUTES, false);
+                DEFAULT_TIME_LIMIT_MINUTES, null, DEFAULT_BUILD_TIMEOUT_MINUTES, false, SkippedTests.none());
+    }
+
+    /** Compatibility constructor for callers that do not use explicit test exclusions. */
+    public MutationConfig(
+            Path projectPath, Path reportOutputPath, String classFilter, int maxMutationClasses,
+            int maxMutations, long timeLimitMinutes, Integer mavenParallelThreads,
+            long buildTimeoutMinutes, boolean skipBuildExtras) {
+        this(projectPath, reportOutputPath, classFilter, maxMutationClasses, maxMutations,
+                timeLimitMinutes, mavenParallelThreads, buildTimeoutMinutes, skipBuildExtras, SkippedTests.none());
     }
 
     public MutationConfig {
         Objects.requireNonNull(projectPath, "projectPath");
         Objects.requireNonNull(reportOutputPath, "reportOutputPath");
+        Objects.requireNonNull(skippedTests, "skippedTests");
         if (!Files.isDirectory(projectPath) || !Files.isDirectory(projectPath.resolve(".git"))) {
             throw new IllegalArgumentException("projectPath must be a local git repository: " + projectPath);
         }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationReport.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationReport.java
@@ -11,7 +11,8 @@ public record MutationReport(
         String baselineCommit,
         List<TestIdentity> baselineFailingTests,
         MutationCoverage coverage,
-        List<MutationExperiment> experiments) {
+        List<MutationExperiment> experiments,
+        List<String> skippedTests) {
 
     public MutationReport {
         Objects.requireNonNull(verdict, "verdict");
@@ -21,6 +22,7 @@ public record MutationReport(
         Objects.requireNonNull(experiments, "experiments");
         baselineFailingTests = List.copyOf(baselineFailingTests);
         experiments = List.copyOf(experiments);
+        skippedTests = skippedTests == null ? List.of() : List.copyOf(skippedTests);
     }
 
     public static MutationReport from(
@@ -29,6 +31,17 @@ public record MutationReport(
             List<MutationExperiment> experiments,
             int generatedMutations,
             int timeLimitSkippedMutations) {
+        return from(baselineCommit, baselineFailingTests, experiments, generatedMutations,
+                timeLimitSkippedMutations, List.of());
+    }
+
+    public static MutationReport from(
+            String baselineCommit,
+            List<TestIdentity> baselineFailingTests,
+            List<MutationExperiment> experiments,
+            int generatedMutations,
+            int timeLimitSkippedMutations,
+            List<String> skippedTests) {
         int unbuildable = (int) experiments.stream().filter(e -> e.status() == MutationStatus.UNBUILDABLE).count();
         int compilable = experiments.size() - unbuildable;
         int killed = (int) experiments.stream().filter(e -> e.status() == MutationStatus.KILLED).count();
@@ -40,6 +53,6 @@ public record MutationReport(
                 generatedMutations, experiments.size(), timeLimitSkippedMutations, unbuildable, compilable,
                 baselineFailingTests.isEmpty() ? compilable : 0, killed, killingTests, selected, skipped, flaky);
         return new MutationReport(skipped == 0 ? Verdict.PASS : Verdict.FAIL, baselineCommit,
-                baselineFailingTests, coverage, experiments);
+                baselineFailingTests, coverage, experiments, skippedTests);
     }
 }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationTextSummaryRenderer.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationTextSummaryRenderer.java
@@ -9,6 +9,10 @@ public final class MutationTextSummaryRenderer {
         MutationCoverage coverage = report.coverage();
         StringBuilder text = new StringBuilder("Verdict: ").append(report.verdict()).append('\n');
         text.append("Baseline: ").append(report.baselineCommit()).append('\n');
+        text.append("Skipped test classes: ").append(report.skippedTests().size()).append('\n');
+        for (String skippedTest : report.skippedTests()) {
+            text.append("  - ").append(skippedTest).append('\n');
+        }
         text.append("Mutation coverage:\n");
         text.append("  - generated: ").append(coverage.generatedMutations()).append('\n');
         text.append("  - attempted: ").append(coverage.attemptedMutations()).append('\n');

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/report/AnalysisReport.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/report/AnalysisReport.java
@@ -23,7 +23,26 @@ public record AnalysisReport(
         FailureCoverage failureCoverage,
         List<WouldMissCase> wouldMissCases,
         List<FlakyFailure> flakyFailures,
-        SavingsSummary savingsSummary) {
+        SavingsSummary savingsSummary,
+        List<String> skippedTests) {
+
+    public AnalysisReport {
+        skippedTests = skippedTests == null ? List.of() : List.copyOf(skippedTests);
+    }
+
+    /** Compatibility constructor for callers that do not use explicit test exclusions. */
+    public AnalysisReport(
+            Verdict verdict,
+            HistoryMode historyMode,
+            List<CommitPair> analyzedCommitPairs,
+            List<CommitPair> excludedCommitPairs,
+            FailureCoverage failureCoverage,
+            List<WouldMissCase> wouldMissCases,
+            List<FlakyFailure> flakyFailures,
+            SavingsSummary savingsSummary) {
+        this(verdict, historyMode, analyzedCommitPairs, excludedCommitPairs, failureCoverage,
+                wouldMissCases, flakyFailures, savingsSummary, List.of());
+    }
 
     /** Compatibility constructor for callers that do not yet supply the newly-visible fields. */
     public AnalysisReport(
@@ -34,7 +53,7 @@ public record AnalysisReport(
             List<FlakyFailure> flakyFailures,
             SavingsSummary savingsSummary) {
         this(verdict, HistoryMode.ALL_PARENTS, analyzedCommitPairs, excludedCommitPairs,
-                legacyFailureCoverage(wouldMissCases), wouldMissCases, flakyFailures, savingsSummary);
+                legacyFailureCoverage(wouldMissCases), wouldMissCases, flakyFailures, savingsSummary, List.of());
     }
 
     private static FailureCoverage legacyFailureCoverage(List<WouldMissCase> wouldMissCases) {

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/report/TextSummaryRenderer.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/report/TextSummaryRenderer.java
@@ -21,6 +21,10 @@ public final class TextSummaryRenderer {
                     .append(" excluded — see report for reasons)");
         }
         sb.append('\n');
+        sb.append("Skipped test classes: ").append(report.skippedTests().size()).append('\n');
+        for (String skippedTest : report.skippedTests()) {
+            sb.append("  - ").append(skippedTest).append('\n');
+        }
         FailureCoverage coverage = report.failureCoverage();
         sb.append("Failure coverage:\n");
         sb.append("  - Pairs with newly confirmed failures: ")

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunnerTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunnerTest.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -64,6 +65,29 @@ class MavenBuildRunnerTest {
         BuildResult result = runner.run(projectDir, null, null);
 
         assertTrue(result.exitCode() != 0);
+    }
+
+    @Test
+    void excludedFailingTestDoesNotRunInTheFullSuite(@TempDir Path projectDir) {
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.writeTest("com.example.StableTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                class StableTest { @Test void passes() {} }
+                """);
+        fixture.writeTest("com.example.FlakyTest", """
+                package com.example;
+                import org.junit.jupiter.api.Test;
+                import static org.junit.jupiter.api.Assertions.fail;
+                class FlakyTest { @Test void failsWhenRun() { fail("known flaky test"); } }
+                """);
+        fixture.commit("initial");
+
+        BuildResult result = new MavenBuildRunner(null, 5, false, false,
+                SkippedTests.parse(List.of("com.example.FlakyTest"))).run(projectDir, null, null);
+
+        assertEquals(0, result.exitCode(), result.output());
+        assertTrue(result.output().contains("Tests run: 1"), result.output());
     }
 
     @Test
@@ -218,6 +242,19 @@ class MavenBuildRunnerTest {
                     "-DfailIfNoTests=false", "-Dsurefire.failIfNoSpecifiedTests=false"
                 },
                 new MavenBuildRunner().command("com.example.FooTest#passes", null));
+    }
+
+    @Test
+    void fullSuiteCommandCarriesExplicitNegativeTestSelectors() {
+        SkippedTests skipped = SkippedTests.parse(List.of("org.app.FlakyTest,org.app2.Flaky2Test"));
+
+        assertArrayEquals(
+                new String[] {
+                    MavenLauncher.resolve(), "-B", "--no-transfer-progress", "clean", "test",
+                    "-Dtest=!org.app.FlakyTest,!org.app2.Flaky2Test",
+                    "-DfailIfNoTests=false", "-Dsurefire.failIfNoSpecifiedTests=false"
+                },
+                new MavenBuildRunner(null, 5, false, false, skipped).command(null));
     }
 
     @Test

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/SkippedTestsTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/SkippedTestsTest.java
@@ -1,0 +1,28 @@
+package io.github.baokhang83.blastradius.validator.build;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SkippedTestsTest {
+
+    @Test
+    void normalizesCommaSeparatedValuesAndAppendsNegativeSelectors() {
+        SkippedTests skipped = SkippedTests.parse(List.of(
+                " org.app.FlakyTest,org.app2.Flaky2Test ", "org.app.FlakyTest"));
+
+        assertEquals(List.of("org.app.FlakyTest", "org.app2.Flaky2Test"), skipped.classes());
+        assertEquals("!org.app.FlakyTest,!org.app2.Flaky2Test", skipped.appendTo(null));
+        assertEquals("org.app.TargetTest#passes,!org.app.FlakyTest,!org.app2.Flaky2Test",
+                skipped.appendTo("org.app.TargetTest#passes"));
+    }
+
+    @Test
+    void rejectsBlankOrNonClassEntries() {
+        assertThrows(IllegalArgumentException.class, () -> SkippedTests.parse(List.of("org.app.FlakyTest,")));
+        assertThrows(IllegalArgumentException.class, () -> SkippedTests.parse(List.of("org.app.*")));
+        assertThrows(IllegalArgumentException.class, () -> SkippedTests.parse(List.of("FlakyTest")));
+    }
+}

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/cli/RunConfigTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/cli/RunConfigTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.github.baokhang83.blastradius.validator.build.SkippedTests;
 import io.github.baokhang83.blastradius.validator.git.HistoryMode;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -25,6 +26,7 @@ class RunConfigTest {
         assertEquals(50, config.commitWindowSize());
         assertEquals(reportOut, config.reportOutputPath());
         assertEquals(HistoryMode.ALL_PARENTS, config.historyMode());
+        assertEquals(SkippedTests.none(), config.skippedTests());
     }
 
     @Test

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/MutationReportTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/MutationReportTest.java
@@ -48,6 +48,14 @@ class MutationReportTest {
         assertEquals(1, report.coverage().unbuildableMutants());
     }
 
+    @Test
+    void reportCarriesExplicitSkippedTestClasses() {
+        MutationReport report = MutationReport.from("baseline-sha", List.of(), List.of(), 0, 0,
+                List.of("org.app.FlakyTest"));
+
+        assertEquals(List.of("org.app.FlakyTest"), report.skippedTests());
+    }
+
     private MutationCandidate candidate() {
         return new MutationCandidate("src/main/java/com/example/Flag.java", "com.example.Flag",
                 MutationOperator.BOOLEAN_LITERAL, 1, "true", "false");

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/report/AnalysisReportContractTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/report/AnalysisReportContractTest.java
@@ -105,6 +105,16 @@ class AnalysisReportContractTest {
         assertEquals(new FailureCoverage(2, 3, 3, 0), parsed.failureCoverage());
     }
 
+    @Test
+    void reportCarriesExplicitSkippedTestClasses() throws Exception {
+        AnalysisReport report = new AnalysisReport(
+                Verdict.PASS, HistoryMode.ALL_PARENTS, List.of(), List.of(), FailureCoverage.empty(),
+                List.of(), List.of(), aggregator.aggregate(List.of()),
+                List.of("org.app.FlakyTest", "org.app2.Flaky2Test"));
+
+        assertEquals(List.of("org.app.FlakyTest", "org.app2.Flaky2Test"), roundTrip(report).skippedTests());
+    }
+
     private AnalysisReport roundTrip(AnalysisReport report) throws Exception {
         String json = mapper.writeValueAsString(report);
         return mapper.readValue(json, AnalysisReport.class);

--- a/docs/fluencyloop/features/add-explicit-flaky-test-exclusions-to-validator-target-build/design.md
+++ b/docs/fluencyloop/features/add-explicit-flaky-test-exclusions-to-validator-target-build/design.md
@@ -1,0 +1,92 @@
+# Design: Add explicit flaky-test exclusions to validator target builds
+
+started: 2026-08-02
+
+## Purpose
+
+Known flaky test classes can invalidate or slow a validator run even though the operator already knows they are not useful evidence. The optional `--skipped-tests` argument accepts a comma-separated list of fully qualified test class names. The validator passes those exclusions to every target-project Maven invocation, so the tests never execute in baseline builds, head builds, mutation builds, or confirmation reruns.
+
+The option is deliberately opt-in and class-level. It does not claim the resulting report covers the excluded tests, and the report records the exact exclusions so its evidence boundary remains auditable.
+
+## Class diagram
+
+```mermaid
+classDiagram
+  class Main {
+    +runHistory(args)
+    +runMutations(args)
+  }
+  class SkippedTests {
+    +parse(csvValues) SkippedTests
+    +appendTo(selector) String
+    +classes List~String~
+  }
+  class RunConfig {
+    +skippedTests SkippedTests
+  }
+  class MutationConfig {
+    +skippedTests SkippedTests
+  }
+  class MavenBuildRunner {
+    +run(project, agent, output)
+    +runSingleTest(project, test, module)
+  }
+  class AnalysisReport {
+    +skippedTests List~String~
+  }
+  class MutationReport {
+    +skippedTests List~String~
+  }
+
+  Main --> SkippedTests
+  Main --> RunConfig
+  Main --> MutationConfig
+  RunConfig --> SkippedTests
+  MutationConfig --> SkippedTests
+  MavenBuildRunner --> SkippedTests
+  AnalysisReport --> SkippedTests
+  MutationReport --> SkippedTests
+```
+
+`SkippedTests` is a value object shared by both validator actions. It owns parsing, normalization, and selector composition, avoiding two subtly different interpretations of the same CLI value.
+
+## Sequence: excluded target build
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant CLI as Main
+  participant Config as Validator config
+  participant Runner as MavenBuildRunner
+  participant Maven as Target Maven
+  participant Report
+
+  User->>CLI: run or mutate with skipped tests
+  CLI->>Config: parse and validate class names
+  Config->>Runner: provide normalized exclusions
+  Runner->>Runner: compose test selector with exclusions
+  Runner->>Maven: invoke target build
+  Maven-->>Runner: reports without excluded test classes
+  Runner->>Report: record exclusions and observed outcomes
+  Report-->>User: auditable bounded result
+```
+
+## Selector contract
+
+For a full target build, the runner emits one Surefire selector containing negative patterns, such as `-Dtest=!org.app.FlakyTest,!org.app2.Flaky2Test`. For a single-test confirmation, it appends the same negative patterns to the positive test selector. Maven's no-specified-tests safeguards are enabled whenever a selector is present, so a reactor module containing only an excluded test does not abort the remaining modules.
+
+Whitespace around comma-separated values is ignored, duplicates are removed while preserving order, and blank entries are rejected. This first version intentionally accepts classes, not individual methods or wildcard patterns: exact names match the operator's known-flake inventory and make the excluded evidence boundary unambiguous.
+
+## Test slices
+
+1. Parse, normalize, and compose deterministic exclusions.
+2. Verify Maven command construction for both full-suite and single-test commands.
+3. Propagate exclusions through historical and mutation configs and record them in JSON and text reports.
+4. Add a fixture integration where an excluded permanently failing test no longer contaminates a validator run, while a non-excluded test still executes.
+
+## Constitution check
+
+- **I — TDD:** parsing, command composition, and fixture behavior each begin with focused failing tests.
+- **II — simplicity:** one small value object is shared instead of a generic Maven-argument escape hatch.
+- **III — safety:** exclusions are explicit, opt-in, and surfaced in output. They remove evidence from the report rather than silently classifying a flaky outcome as a pass.
+- **V — explainability:** JSON and text summaries identify the test classes that were intentionally not run.

--- a/docs/fluencyloop/features/add-explicit-flaky-test-exclusions-to-validator-target-build/sessions/compose-explicit-test-exclusions-into-every-target-maven-bui.md
+++ b/docs/fluencyloop/features/add-explicit-flaky-test-exclusions-to-validator-target-build/sessions/compose-explicit-test-exclusions-into-every-target-maven-bui.md
@@ -1,0 +1,19 @@
+# Session: Compose explicit test exclusions into every target Maven build
+
+- **intent:** Compose explicit test exclusions into every target Maven build
+- **started:** 2026-08-02
+
+## Decision: Compose exact class exclusions into every Maven selector
+
+- **where:** `validator/build/SkippedTests and MavenBuildRunner`
+- **why:** One normalized exclusion list reaches full builds and confirmation reruns, so known flakes never execute or contaminate the observed ground truth.
+- **alternative:** Filter reports after Maven completes — rejected: the flaky test would still run, fail, hang, or alter shared state.
+- **design:** ../design.md#selector-contract
+- **constitution:** §III, §V
+- **trust:** ✓ verified
+
+## Knowledge transfer
+
+- **SkippedTests:** parses repeated comma-separated CLI values into ordered, distinct fully qualified test classes and rejects blank or wildcard entries, status: documented.
+- **MavenBuildRunner:** adds negative Surefire patterns to both full-suite and single-test selectors, and enables no-specified-tests safeguards whenever exclusions create a selector, status: documented.
+- **Evidence boundary:** excluded classes do not execute and therefore contribute neither dependency records nor outcomes; both JSON and text reports now state that boundary explicitly, status: documented.

--- a/docs/fluencyloop/features/add-explicit-flaky-test-exclusions-to-validator-target-build/sessions/make-test-exclusions-auditable-across-validator-modes.md
+++ b/docs/fluencyloop/features/add-explicit-flaky-test-exclusions-to-validator-target-build/sessions/make-test-exclusions-auditable-across-validator-modes.md
@@ -1,0 +1,19 @@
+# Session: Make test exclusions auditable across validator modes
+
+- **intent:** Make test exclusions auditable across validator modes
+- **started:** 2026-08-02
+
+## Decision: Record exclusions as an explicit report boundary
+
+- **where:** `RunConfig, MutationConfig, AnalysisReport, MutationReport, text summary renderers`
+- **why:** Both validator modes carry the same opt-in exclusion list and write it into their JSON and text reports, so a passing result states exactly which test classes were not observed.
+- **alternative:** Keep exclusions only in Maven command construction and omit them from reports — rejected: that silently changes the evidence population and lets a PASS overstate what was validated.
+- **design:** ../design.md#selector-contract
+- **constitution:** §III, §V
+- **trust:** ✓ verified
+
+## Knowledge transfer
+
+- **RunConfig and MutationConfig:** carry one immutable `SkippedTests` value, defaulting to none for existing callers; both CLI actions parse repeated comma-separated values before constructing their configuration, status: documented.
+- **AnalysisReport and MutationReport:** serialize the exact excluded classes in the source-of-truth JSON and copy the list defensively; text summaries render the same boundary beside their high-level totals, status: documented.
+- **Interpretation:** a configured exclusion prevents execution in all baseline, head, mutation, and confirmation Maven builds, so it is an opt-in reduction of observed evidence rather than a verdict about those tests, status: documented.


### PR DESCRIPTION
## Summary

- add `--skipped-tests` to `run` and `mutate`, accepting repeated comma-separated exact test-class names
- exclude those classes from every target Maven build, including full suites and confirmation reruns
- record the excluded classes in JSON and text reports so the reduced evidence population is explicit

## Validation

- `mvn -B --no-transfer-progress clean verify` (JDK 25)
- focused validator tests: 46 tests, including a fixture where the excluded test would otherwise fail
