### PR TITLE
Fix mutation cache ignoring --skipped-tests

### DIFF
--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/cli/RunCommand.java
@@ -142,7 +142,7 @@ public final class RunCommand {
             // -amd pair can run for the better part of an hour), and each completed experiment is
             // written here rather than held resident for the whole window.
             MutationCache mutationCache = config.mutationValidation() == null ? null
-                    : new MutationCache(mutationCacheDirectory(config.reportOutputPath()));
+                    : new MutationCache(mutationCacheDirectory(config.reportOutputPath()), config.skippedTests());
             try (CheckoutPool pool = CheckoutPool.of(config.projectPath(), scratchParent, concurrency)) {
                 // Phase 1 (expensive, now core-saturated): build every commit the window needs,
                 // concurrently across the pool of isolated clones, persisting each to the cache.

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCache.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCache.java
@@ -1,6 +1,7 @@
 package io.github.baokhang83.blastradius.validator.mutation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.baokhang83.blastradius.validator.build.SkippedTests;
 import io.github.baokhang83.blastradius.validator.git.CommitPair;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -30,13 +31,20 @@ import java.util.Optional;
  *       every mutant's full test-identity lists resident for the whole window.</li>
  * </ul>
  *
- * <p><b>The cache key is the mutant's identity, not the bounding config.</b> A mutant is fully
- * described by its pair ({@code base -> head}) and its single-token source edit ({@code
- * sourcePath}, {@code offset}, {@code operator}, {@code original}, {@code replacement}); its build
- * outcome and selection comparison are deterministic given those. {@code --max-mutations-per-pair}
- * and the class filter change <em>which</em> candidates are generated, not the outcome of any one
- * of them — so they are deliberately kept out of the key, which maximises resume hits (a re-run
- * with a wider bound still reuses every mutant the narrower run already validated).
+ * <p><b>The cache key is the mutant's identity plus whatever changes its build outcome.</b> A
+ * mutant is fully described by its pair ({@code base -> head}) and its single-token source edit
+ * ({@code sourcePath}, {@code offset}, {@code operator}, {@code original}, {@code replacement});
+ * given those <em>and</em> the set of {@link SkippedTests} excluded from every target build, its
+ * build outcome and selection comparison are deterministic. {@code --max-mutations-per-pair} and
+ * the class filter change <em>which</em> candidates are generated, not the outcome of any one of
+ * them — so they are deliberately kept out of the key, which maximises resume hits (a re-run with
+ * a wider bound still reuses every mutant the narrower run already validated). {@code
+ * --skipped-tests} is different: it changes which tests actually run in the mutant's build, so it
+ * changes {@code killingTests}/{@code selectedKillingTests}/{@code skippedTests} on the resulting
+ * experiment — omitting it from the key would let a run with a different skip list silently reuse
+ * an experiment computed under the old one, making {@code --skipped-tests} appear to stop applying
+ * once entries exist on disk. It is folded into the key precisely so that changing it invalidates
+ * the affected entries instead of serving stale ones.
  *
  * <p><b>Only compilable outcomes are cached</b> (see {@link #store}). A {@code KILLED}/{@code
  * SURVIVED} experiment is the deterministic result of a build that ran to completion; an {@code
@@ -51,10 +59,21 @@ import java.util.Optional;
 public final class MutationCache {
 
     private final Path directory;
+    private final SkippedTests skippedTests;
     private final ObjectMapper mapper = new ObjectMapper();
 
     public MutationCache(Path directory) {
+        this(directory, SkippedTests.none());
+    }
+
+    /**
+     * @param skippedTests the exclusions applied to every target build for this run — folded into
+     *                      the cache key (see the class note) so a run with a different skip list
+     *                      never reuses an experiment computed under a different one.
+     */
+    public MutationCache(Path directory, SkippedTests skippedTests) {
         this.directory = directory;
+        this.skippedTests = java.util.Objects.requireNonNull(skippedTests, "skippedTests");
     }
 
     /**
@@ -115,7 +134,8 @@ public final class MutationCache {
         String identity = String.join("\0",
                 pair.baseCommit(), pair.headCommit(), candidate.sourcePath(),
                 Integer.toString(candidate.offset()), candidate.operator().name(),
-                candidate.original(), candidate.replacement());
+                candidate.original(), candidate.replacement(),
+                String.join(",", skippedTests.classes()));
         return directory.resolve(sha256Hex(identity) + ".json");
     }
 

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/MutationCacheTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/mutation/MutationCacheTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import io.github.baokhang83.blastradius.core.git.ChangedFile;
 import io.github.baokhang83.blastradius.core.git.FileKind;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import io.github.baokhang83.blastradius.validator.build.SkippedTests;
 import io.github.baokhang83.blastradius.validator.git.CommitPair;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -72,6 +73,23 @@ class MutationCacheTest {
         // Same pair and file, different token offset — a genuinely different mutant, so a miss.
         assertTrue(cache.load(pair, at42).isPresent());
         assertEquals(Optional.empty(), cache.load(pair, at99));
+    }
+
+    @Test
+    void aDifferentSkippedTestsConfigurationIsADistinctEntrySoTheSkipFlagStaysHonored(@TempDir Path dir) {
+        Path cacheDir = dir.resolve("cache");
+        CommitPair pair = pair();
+        MutationCandidate candidate = candidate();
+
+        MutationCache withoutSkips = new MutationCache(cacheDir);
+        withoutSkips.store(killed(pair, candidate));
+        assertTrue(withoutSkips.load(pair, candidate).isPresent());
+
+        // A run with --skipped-tests must not silently reuse an experiment computed without it —
+        // the skip list changes which tests actually run, so it must change the cache key too.
+        MutationCache withSkips = new MutationCache(
+                cacheDir, SkippedTests.parse(List.of("com.example.SlowTest")));
+        assertEquals(Optional.empty(), withSkips.load(pair, candidate));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `MutationCache` (phase 2's mutation-experiment cache) keyed cached experiments only on the mutant's identity, deliberately excluding config like `--max-mutations-per-pair` since that only changes which candidates are generated
- `--skipped-tests` was excluded the same way, but it changes which tests actually run in the mutant's build — so a cached experiment from one skip config was silently served under a different one, making `--skipped-tests` appear to stop applying in phase 2 once cache entries existed on disk
- Fold `SkippedTests` into the cache key so a changed skip list invalidates only the affected entries instead of reusing stale ones

## Test plan
- [x] Added `aDifferentSkippedTestsConfigurationIsADistinctEntrySoTheSkipFlagStaysHonored` to `MutationCacheTest`, confirming an entry stored without a skip list is not served back once one is added
- [x] `mvn -pl blastradius-validator -am test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)