### PR TITLE
Fix build timeout never killing a hung process

### DIFF
--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunner.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/MavenBuildRunner.java
@@ -258,11 +258,18 @@ public final class MavenBuildRunner {
 
             Set<ProcessHandle> descendants =
                     awaitDescendantsWhileAlive(process, Duration.ofMinutes(timeoutMinutes));
-            outputReader.join();
-
-            if (process.isAlive()) {
+            // A timed-out process is still alive here, so its stdout pipe is still open and
+            // outputReader.join() below would block on it forever — the kill must happen
+            // before the join, not after, or the deadline above never actually terminates
+            // anything (found running 14+ hours past a 60-minute budget in practice).
+            boolean timedOut = process.isAlive();
+            if (timedOut) {
                 process.destroyForcibly();
                 descendants.forEach(ProcessHandle::destroyForcibly);
+            }
+            outputReader.join();
+
+            if (timedOut) {
                 throw new IllegalStateException(
                         "mvn test timed out against " + projectDir + " after " + timeoutMinutes + "m");
             }


### PR DESCRIPTION
## Summary
- `MavenBuildRunner.run()`'s timeout logic waited for the deadline correctly, but called `outputReader.join()` before checking `process.isAlive()`/killing it. `outputReader` blocks reading the process's stdout until that pipe closes, which only happens once the process exits — so a genuinely hung process made the kill code unreachable and `--build-timeout-minutes` was silently a no-op.
- Caught this live: a mutant rebuild against `httpcomponents-client` had a Surefire JVM pinned at 100% CPU for 14+ hours against a configured 60-minute budget, permanently occupying one of the run's concurrency slots.
- Fix: force-kill the process and its captured descendants first (closing the pipe), then join the output reader, then raise the timeout exception.

## Test plan
- [x] `mvn -pl blastradius-validator -am compile`
- [x] `mvn -pl blastradius-validator -am test -Dtest=MavenBuildRunnerTest` (existing suite, no regressions)
- [x] Verified live: killed the actual hung process tree found during an in-progress validator run; a new worker immediately reclaimed the freed concurrency slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)