### PR TITLE
core: attribute cleanup dependencies to test containers

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,10 +1,10 @@
 {
-  "feature": "219-core-attribute-beforeall-loaded-classes-to-their-contain",
-  "branch": "feature/219-core-attribute-beforeall-loaded-classes-to-their-contain",
+  "feature": "221-attribute-afterall-and-inter-test-lifecycle-dependencies",
+  "branch": "feature/221-attribute-afterall-and-inter-test-lifecycle-dependencies",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/219-core-attribute-beforeall-loaded-classes-to-their-contain/sessions/001-core-mechanism-synthetic-container-identity-stacked-fram.md",
+  "last_session": "docs/fluencyloop/features/221-attribute-afterall-and-inter-test-lifecycle-dependencies/sessions/001-rearm-container-identity-for-cleanup-and-inter-test-life.md",
   "base_ref": "main",
-  "feature_dir": "docs/fluencyloop/features/219-core-attribute-beforeall-loaded-classes-to-their-contain",
+  "feature_dir": "docs/fluencyloop/features/221-attribute-afterall-and-inter-test-lifecycle-dependencies",
   "plan": "",
   "updated": "2026-08-05"
 }

--- a/README.md
+++ b/README.md
@@ -252,14 +252,6 @@ Full text and rationale: [`.specify/memory/constitution.md`](.specify/memory/con
 
 ## Known limitations
 
-- A class loaded only inside a JUnit 5 `@AfterAll` (or between tests, via `@BeforeEach`/
-  `@AfterEach`) is never attributed to any specific test — tracking only attributes loads to
-  tests that are actually executing, and there is no boundary marking "cleanup is about to
-  run" to hook. `@BeforeAll` is attributed (its loads run under the class's own container
-  identity and are unioned into every test the class owns); `@AfterAll` and the gaps between
-  tests are not. Narrow, deterministic, and documented — not a bug being hidden. Lean on the
-  recommended daily full-suite run if this matters for your project. Tracked as a follow-up:
-  [#221](https://github.com/baokhang83/blastradius/issues/221).
 - A class reached only through a **string-dispatched API** may go unattributed for the same reason:
   if the call is `select("div > p")` and the parse behind it sits on a cached path, the calling test
   never records a load of the parser it truly depends on. Measured, not hypothetical — this is what

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/TestBoundaryListener.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/TestBoundaryListener.java
@@ -16,11 +16,13 @@ import org.junit.platform.launcher.TestIdentifier;
  * {@link InheritableThreadLocal}, so {@link DependencyTrackingAgent}'s class-load observations can
  * be attributed to the test that triggered them, including classes first loaded by a child thread.
  *
- * <p>The window also opens one level up: while a class's {@code @BeforeAll} runs, no test method
- * is current yet, so its loads run under a synthetic container-level identity instead (see
- * {@link TestIdentity}'s class-level identity convention). Once the class finishes, whatever that
- * identity accumulated is folded into every test method that ran inside it — see
- * {@link DependencyTrackingAgent#unionContainerDependencies}.
+ * <p>The window also opens one level up: a class container owns a synthetic identity (see
+ * {@link TestIdentity}'s class-level identity convention) while its lifecycle code runs outside a
+ * test method. Once the class finishes, the container's accumulated dependencies are folded into
+ * every test method that ran directly inside it — see
+ * {@link DependencyTrackingAgent#unionContainerDependencies}. This intentionally attributes
+ * between-test and cleanup work to every sibling, which is conservative: it can widen selection
+ * but cannot hide a dependency.
  *
  * <p>Tests must await child-thread work before they finish. The identity is copied when a child
  * thread is created, so work that outlives its test cannot be attributed reliably. Tests executing
@@ -53,14 +55,7 @@ public final class TestBoundaryListener implements TestExecutionListener {
             Deque<ContainerFrame> stack = CONTAINER_STACK.get();
             if (!stack.isEmpty()) {
                 ContainerFrame frame = stack.peek();
-                if (!frame.beforeAllWindowClosed) {
-                    // @BeforeAll's window is exactly [container started, first test started) — close
-                    // it here so hidden classes any test body loads later are never misattributed
-                    // back to the container and unioned into every sibling test.
-                    DependencyTrackingAgent.recordHiddenClassesLoadedSince(
-                            frame.identity, frame.classesAtStart);
-                    frame.beforeAllWindowClosed = true;
-                }
+                closeContainerWindow(frame);
                 frame.memberTests.add(test);
             }
             TestExecutionContext.start(test);
@@ -68,10 +63,15 @@ public final class TestBoundaryListener implements TestExecutionListener {
         } else {
             toContainerIdentity(testIdentifier).ifPresent(container -> {
                 DependencyTrackingAgent.recordAmbientSnapshot();
+                Deque<ContainerFrame> stack = CONTAINER_STACK.get();
+                if (!stack.isEmpty()) {
+                    // A nested class suspends its parent's lifecycle window. Flush hidden classes
+                    // first, then start the inner container so nested test bodies never leak into
+                    // the parent bucket.
+                    closeContainerWindow(stack.peek());
+                }
                 TestExecutionContext.start(container);
-                CONTAINER_STACK
-                        .get()
-                        .push(new ContainerFrame(container, DependencyTrackingAgent.loadedClasses()));
+                stack.push(new ContainerFrame(container, DependencyTrackingAgent.loadedClasses()));
             });
         }
     }
@@ -86,6 +86,7 @@ public final class TestBoundaryListener implements TestExecutionListener {
             }
             TestExecutionContext.finish();
             CLASSES_AT_TEST_START.remove();
+            rearmCurrentContainerWindow();
         } else {
             toContainerIdentity(testIdentifier).ifPresent(container -> {
                 Deque<ContainerFrame> stack = CONTAINER_STACK.get();
@@ -93,16 +94,29 @@ public final class TestBoundaryListener implements TestExecutionListener {
                     return;
                 }
                 ContainerFrame frame = stack.pop();
-                if (!frame.beforeAllWindowClosed) {
-                    // No test ever started under this container (e.g. every test disabled, or a
-                    // container with only further @Nested containers) — still close the window so
-                    // any class @BeforeAll loaded is captured rather than silently dropped.
-                    DependencyTrackingAgent.recordHiddenClassesLoadedSince(
-                            frame.identity, frame.classesAtStart);
-                }
+                closeContainerWindow(frame);
                 DependencyTrackingAgent.unionContainerDependencies(frame.identity, frame.memberTests);
+                rearmCurrentContainerWindow();
             });
         }
+    }
+
+    /** Records hidden classes from one container-owned lifecycle interval and resets its baseline. */
+    private static void closeContainerWindow(ContainerFrame frame) {
+        DependencyTrackingAgent.recordHiddenClassesLoadedSince(frame.identity, frame.classesAtWindowStart);
+        frame.classesAtWindowStart = DependencyTrackingAgent.loadedClasses();
+    }
+
+    /** Restores the innermost container after a child test or nested container has finished. */
+    private static void rearmCurrentContainerWindow() {
+        Deque<ContainerFrame> stack = CONTAINER_STACK.get();
+        if (stack.isEmpty()) {
+            TestExecutionContext.finish();
+            return;
+        }
+        ContainerFrame frame = stack.peek();
+        TestExecutionContext.start(frame.identity);
+        frame.classesAtWindowStart = DependencyTrackingAgent.loadedClasses();
     }
 
     private static TestIdentity toTestIdentity(TestIdentifier testIdentifier) {
@@ -127,20 +141,19 @@ public final class TestBoundaryListener implements TestExecutionListener {
     }
 
     /**
-     * One class's {@code @BeforeAll} attribution window, tracked per thread so {@code @Nested}
-     * classes — which fire their own container start/finish nested inside the outer one — stack
-     * correctly: a test always joins the innermost open container's member set, never an
-     * ancestor's.
+     * One class's lifecycle attribution state, tracked per thread so {@code @Nested} classes
+     * stack correctly. Each hidden-class baseline covers one container-owned interval: before the
+     * first test, between tests, or after the last test. A test always joins the innermost open
+     * container's member set, never an ancestor's.
      */
     private static final class ContainerFrame {
         private final TestIdentity identity;
-        private final Set<Class<?>> classesAtStart;
+        private Set<Class<?>> classesAtWindowStart;
         private final Set<TestIdentity> memberTests = new LinkedHashSet<>();
-        private boolean beforeAllWindowClosed;
 
         ContainerFrame(TestIdentity identity, Set<Class<?>> classesAtStart) {
             this.identity = identity;
-            this.classesAtStart = classesAtStart;
+            this.classesAtWindowStart = classesAtStart;
         }
     }
 }

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingIntegrationTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingIntegrationTest.java
@@ -198,6 +198,44 @@ class DependencyTrackingIntegrationTest {
     }
 
     @Test
+    void classLoadedOnlyDuringAfterAllIsAttributedToEveryClassTest(@TempDir Path projectDir, @TempDir Path outDir)
+            throws Exception {
+        Path agentJar = findOwnAgentJar();
+        Path recordFile = outDir.resolve("deps.json");
+
+        FixtureProjectBuilder fixture = FixtureProjectBuilder.singleModule(projectDir);
+        fixture.addSystemDependency(null, agentJar);
+        fixture.writeClass("com.example.CleanupDependency", """
+                package com.example;
+                public final class CleanupDependency {
+                    public static void close() {}
+                }
+                """);
+        fixture.writeTest("com.example.CleanupDependencyTest", """
+                package com.example;
+                import org.junit.jupiter.api.AfterAll;
+                import org.junit.jupiter.api.Test;
+                class CleanupDependencyTest {
+                    @Test void first() {}
+                    @Test void second() {}
+                    @AfterAll static void cleanup() { CleanupDependency.close(); }
+                }
+                """);
+        fixture.commit("initial");
+
+        runMvnTest(projectDir, agentJar, recordFile);
+
+        Map<TestIdentity, Map<String, String>> recorded = new DependencyRecordReader().readAll(recordFile).tests();
+        TestIdentity first = new TestIdentity("com.example.CleanupDependencyTest", "first");
+        TestIdentity second = new TestIdentity("com.example.CleanupDependencyTest", "second");
+
+        assertTrue(recorded.get(first).containsKey("com.example.CleanupDependency"),
+                "@AfterAll-only dependency must be unioned into the first class test: " + recorded.get(first));
+        assertTrue(recorded.get(second).containsKey("com.example.CleanupDependency"),
+                "@AfterAll-only dependency must be unioned into the second class test: " + recorded.get(second));
+    }
+
+    @Test
     void virtualThreadAttributionIncludesSealedAndHiddenClassLoadsOnJdk25(
             @TempDir Path projectDir, @TempDir Path outDir) throws Exception {
         Path agentJar = findOwnAgentJar();

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/TestBoundaryListenerTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/TestBoundaryListenerTest.java
@@ -1,11 +1,14 @@
 package io.github.baokhang83.blastradius.core.tracking;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -45,7 +48,10 @@ class TestBoundaryListenerTest {
         assertEquals(ProbeTest.class.getName(), observedWhileRunning.get(0).className());
         assertEquals("probe", observedWhileRunning.get(0).methodName());
 
-        assertNull(TestBoundaryListener.currentTest(), "must be cleared once execution finishes");
+        assertEquals(
+                new TestIdentity(TestBoundaryListenerTest.class.getName(), null),
+                TestBoundaryListener.currentTest(),
+                "a nested launcher must restore its enclosing class container when it finishes");
     }
 
     /** A trivial nested class used purely as a probe for the listener under test. */
@@ -87,7 +93,55 @@ class TestBoundaryListenerTest {
         assertEquals("one", observedDuringTests.get(0).methodName());
         assertEquals("two", observedDuringTests.get(1).methodName());
 
-        assertNull(TestBoundaryListener.currentTest(), "must be cleared once the container finishes");
+        assertEquals(
+                new TestIdentity(TestBoundaryListenerTest.class.getName(), null),
+                TestBoundaryListener.currentTest(),
+                "a nested launcher must restore its enclosing class container when it finishes");
+    }
+
+    @Test
+    void afterAllRunsUnderTheSyntheticContainerIdentity() {
+        TestBoundaryListener listener = new TestBoundaryListener();
+        CleanupContainerProbeTest.observedInAfterAll = null;
+
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(DiscoverySelectors.selectClass(CleanupContainerProbeTest.class))
+                .build();
+        Launcher launcher = LauncherFactory.create();
+        launcher.registerTestExecutionListeners(listener);
+        launcher.execute(request);
+
+        assertEquals(
+                new TestIdentity(CleanupContainerProbeTest.class.getName(), null),
+                CleanupContainerProbeTest.observedInAfterAll,
+                "@AfterAll must run under the class-level container identity instead of null");
+        assertEquals(
+                new TestIdentity(TestBoundaryListenerTest.class.getName(), null),
+                TestBoundaryListener.currentTest(),
+                "a nested launcher must restore its enclosing class container when it finishes");
+    }
+
+    @Test
+    void beforeEachAndAfterEachKeepTheirOwningTestIdentity() {
+        TestBoundaryListener listener = new TestBoundaryListener();
+        LifecycleProbeTest.observedDuringLifecycle.clear();
+
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+                .selectors(DiscoverySelectors.selectClass(LifecycleProbeTest.class))
+                .build();
+        Launcher launcher = LauncherFactory.create();
+        launcher.registerTestExecutionListeners(listener);
+        launcher.execute(request);
+
+        assertEquals(4, LifecycleProbeTest.observedDuringLifecycle.size());
+        assertTrue(LifecycleProbeTest.observedDuringLifecycle.stream().allMatch(identity ->
+                identity != null
+                        && identity.className().equals(LifecycleProbeTest.class.getName())
+                        && identity.methodName() != null));
+        assertTrue(LifecycleProbeTest.observedDuringLifecycle.stream()
+                .map(TestIdentity::methodName)
+                .toList()
+                .containsAll(List.of("one", "two")));
     }
 
     /** A trivial nested class used purely as a probe: one @BeforeAll, two tests. */
@@ -97,6 +151,51 @@ class TestBoundaryListenerTest {
         @BeforeAll
         static void beforeAll() {
             observedInBeforeAll = TestBoundaryListener.currentTest();
+        }
+
+        @Test
+        void one() {
+            // no-op
+        }
+
+        @Test
+        void two() {
+            // no-op
+        }
+    }
+
+    /** A probe for class-level cleanup, which runs after the last test has finished. */
+    static class CleanupContainerProbeTest {
+        static TestIdentity observedInAfterAll;
+
+        @Test
+        void one() {
+            // no-op
+        }
+
+        @Test
+        void two() {
+            // no-op
+        }
+
+        @AfterAll
+        static void afterAll() {
+            observedInAfterAll = TestBoundaryListener.currentTest();
+        }
+    }
+
+    /** Proves per-test callbacks remain precise while the container covers only idle windows. */
+    static class LifecycleProbeTest {
+        static final List<TestIdentity> observedDuringLifecycle = new ArrayList<>();
+
+        @BeforeEach
+        void beforeEach() {
+            observedDuringLifecycle.add(TestBoundaryListener.currentTest());
+        }
+
+        @AfterEach
+        void afterEach() {
+            observedDuringLifecycle.add(TestBoundaryListener.currentTest());
         }
 
         @Test

--- a/blastradius-maven-plugin/README.md
+++ b/blastradius-maven-plugin/README.md
@@ -376,14 +376,6 @@ loop, not the other way around.
 
 ## Known limitations
 
-- A class loaded only inside a JUnit 5 `@AfterAll` (or between tests, via `@BeforeEach`/
-  `@AfterEach`) is never attributed to any specific test — dependency tracking only attributes
-  loads to tests that are actually executing, and there is no boundary marking "cleanup is
-  about to run" to hook. `@BeforeAll` is attributed (its loads run under the class's own
-  container identity and are unioned into every test the class owns); `@AfterAll` and the gaps
-  between tests are not. Narrow and deterministic, not a bug being hidden — lean on the daily
-  full-suite run if this matters for your project. Tracked as a follow-up:
-  [#221](https://github.com/baokhang83/blastradius/issues/221).
 - Refreshing the index (`TRACK`) runs the full suite once via a subprocess; correct, but not
   optimized for very slow suites. It only happens on `baseRef` builds, never on PR builds.
 

--- a/docs/fluencyloop/README.md
+++ b/docs/fluencyloop/README.md
@@ -12,7 +12,8 @@ _None yet._
 
 | feature | plan | status | started |
 |---------|------|--------|---------|
-| [core: attribute @BeforeAll-loaded classes to their container's tests](features/219-core-attribute-beforeall-loaded-classes-to-their-contain/design.md) | - | in progress | 2026-08-05 |
+| [core: attribute @BeforeAll-loaded classes to their container's tests](features/219-core-attribute-beforeall-loaded-classes-to-their-contain/design.md) | - | shipped | 2026-08-05 |
+| [attribute @AfterAll and inter-test lifecycle dependencies to test containers](features/221-attribute-afterall-and-inter-test-lifecycle-dependencies/design.md) | - | in progress | 2026-08-05 |
 | [Abstract the index store behind an interface (#25)](features/abstract-the-index-store-behind-an-interface-25/design.md) | - | shipped | 2026-07-20 |
 | [Add explicit flaky-test exclusions to validator target builds](features/add-explicit-flaky-test-exclusions-to-validator-target-build/design.md) | - | shipped | 2026-08-02 |
 | [Add opt-in, bounded mutation-based validator soundness validation for issue 187](features/add-opt-in-bounded-mutation-based-validator-soundness-valida/design.md) | - | shipped | 2026-08-01 |

--- a/docs/fluencyloop/features/221-attribute-afterall-and-inter-test-lifecycle-dependencies/design.md
+++ b/docs/fluencyloop/features/221-attribute-afterall-and-inter-test-lifecycle-dependencies/design.md
@@ -1,0 +1,115 @@
+# Design: attribute @AfterAll and inter-test lifecycle dependencies to test containers
+
+started: 2026-08-05
+branch: feature/221-attribute-afterall-and-inter-test-lifecycle-dependencies
+relates to: #219, #41, gh #221
+
+## Problem
+
+After #219, a class container owns a synthetic `TestIdentity` while `@BeforeAll` runs and
+unions that dependency bucket into its member tests when the container finishes. The listener
+clears the identity when every test finishes, however, so a project class used only after that
+point - especially in `@AfterAll` - has no owner. The JUnit Platform has no distinct lifecycle
+event for "the last child finished, cleanup is about to begin".
+
+The conservative solution is to re-arm the innermost container immediately after every test
+finishes. The container then owns ordinary class loads until the next test starts or the
+container ends. JUnit's ordinary `@BeforeEach` and `@AfterEach` callbacks remain inside their
+own test execution window and keep their precise method identity; only unowned work between
+those windows and class cleanup is unioned to every direct member. It expands selection but
+cannot hide a test that needs to run, satisfying constitution Principle III.
+
+## Class diagram
+
+```mermaid
+classDiagram
+    class TestBoundaryListener {
+        -CLASSES_AT_TEST_START Set~Class~
+        -CONTAINER_STACK Deque~ContainerFrame~
+        +executionStarted(TestIdentifier)
+        +executionFinished(TestIdentifier, TestExecutionResult)
+        -closeContainerWindow(ContainerFrame)
+        -rearmContainerWindow()
+    }
+    class ContainerFrame {
+        +identity TestIdentity
+        +classesAtContainerWindowStart Set~Class~
+        +memberTests Set~TestIdentity~
+    }
+    class TestExecutionContext {
+        +start(TestIdentity)
+        +finish()
+    }
+    class DependencyTrackingAgent {
+        +recordHiddenClassesLoadedSince(TestIdentity, Set~Class~)
+        +unionContainerDependencies(TestIdentity, Set~TestIdentity~)
+    }
+    TestBoundaryListener o-- ContainerFrame : stack per nested class
+    TestBoundaryListener --> TestExecutionContext : publishes active identity
+    TestBoundaryListener --> DependencyTrackingAgent : closes windows and unions dependencies
+    ContainerFrame --> TestIdentity : synthetic container and direct members
+```
+
+`ContainerFrame` retains one mutable hidden-class baseline. Closing a container window records
+hidden classes since that baseline and refreshes it. Re-arming after a test sets a new baseline
+and publishes the container identity. A nested container first closes its parent's active window,
+then restores the parent with a fresh baseline after the nested container finishes.
+
+## Sequence: class lifecycle with cleanup dependency
+
+```mermaid
+sequenceDiagram
+    participant JUnit as JUnit Platform
+    participant Listener as TestBoundaryListener
+    participant Context as TestExecutionContext
+    participant Agent as DependencyTrackingAgent
+
+    JUnit->>Listener: executionStarted(FooTest container)
+    Listener->>Context: start(FooTest container identity)
+    Listener->>Listener: push ContainerFrame(hidden baseline)
+    Note over JUnit: @BeforeAll may load Helper
+    JUnit->>Agent: record Helper under container identity
+    JUnit->>Listener: executionStarted(testOne)
+    Listener->>Agent: close container hidden-class window
+    Listener->>Context: start(testOne)
+    Note over JUnit: testOne and @AfterEach run
+    JUnit->>Listener: executionFinished(testOne)
+    Listener->>Context: start(FooTest container identity)
+    Listener->>Listener: refresh container hidden-class baseline
+    Note over JUnit: inter-test work and @AfterAll may load CleanupHelper
+    JUnit->>Agent: record CleanupHelper under container identity
+    JUnit->>Listener: executionFinished(FooTest container)
+    Listener->>Agent: close final container hidden-class window
+    Listener->>Agent: union container dependencies into direct member tests
+    Listener->>Context: finish or restore parent container
+```
+
+## Decision
+
+- **Accept conservative class-wide attribution after every test.** Re-arming the container after
+  `executionFinished(test)` is the only listener-level point before a later `@AfterAll` load.
+  The existing final union gives an otherwise unowned dependency to every direct member. A
+  listener regression confirms standard `@BeforeEach` and `@AfterEach` callbacks stay under their
+  own test identity, while work outside those test windows is deliberately conservative. The
+  selected approach is deterministic, compact, and safe: it can run extra tests but cannot
+  suppress a failure.
+- **Track hidden classes over each container window, not only the first `@BeforeAll` window.**
+  Named project classes are recorded immediately through the active identity, but hidden classes
+  are visible only as a before/after loaded-class diff. Reusing one mutable window baseline
+  captures `@AfterAll` and inter-test hidden classes without leaking test-body hidden classes into
+  siblings.
+- **Treat nested containers as suspended parent windows.** Before pushing an inner container,
+  flush the parent window; after popping the inner frame, restore the parent identity and reset
+  its hidden-class baseline. This prevents an outer class from absorbing nested test bodies while
+  still allowing its lifecycle cleanup to be attributed safely.
+
+## Constitution check
+
+- **I. Test-driven development:** write listener and real-agent regression tests before the
+  production change, including `@AfterAll` and hidden-class coverage.
+- **II. Simplicity:** extend `ContainerFrame` and listener boundaries directly; no new lifecycle
+  coordinator is needed.
+- **III. Safety over speed:** class-wide attribution is intentionally conservative and never
+  narrows selection.
+- **V. Explainability:** selection reasons remain dependency matches; this changes only how a
+  dependency enters an existing, inspectable baseline.

--- a/docs/fluencyloop/features/221-attribute-afterall-and-inter-test-lifecycle-dependencies/sessions/001-rearm-container-identity-for-cleanup-and-inter-test-life.md
+++ b/docs/fluencyloop/features/221-attribute-afterall-and-inter-test-lifecycle-dependencies/sessions/001-rearm-container-identity-for-cleanup-and-inter-test-life.md
@@ -1,0 +1,33 @@
+# Session: rearm container identity for cleanup and inter-test lifecycle dependencies
+
+- **intent:** rearm container identity for cleanup and inter-test lifecycle dependencies
+- **started:** 2026-08-05
+
+## Knowledge transfer
+
+- **`TestBoundaryListener` container window:** Class lifecycle code runs outside any individual
+  test method, so the listener restores the innermost synthetic container identity after every
+  child test. Ordinary class loads in `@AfterAll` and between tests are then recorded under that
+  container and unioned into every direct member at container finish. status: documented
+- **Per-test callback precision:** The JUnit listener's test execution window includes ordinary
+  `@BeforeEach` and `@AfterEach` callbacks, so they retain the method identity that was already
+  active before this change. The new container window is for the genuinely unowned interval after
+  a test finishes and for class cleanup, not a replacement for per-test attribution. status:
+  documented
+- **Hidden-class accounting:** Hidden and lambda classes cannot be attributed at transform time;
+  they are captured by comparing loaded classes with a per-window baseline. The mutable baseline
+  is refreshed when a container window closes or re-arms, keeping test-body hidden classes out of
+  sibling baselines while still covering cleanup. status: documented
+- **Nested container restoration:** An inner class flushes its parent before it starts. Once the
+  inner frame is unioned and removed, the listener restores the parent identity with a fresh
+  baseline, so nested test execution does not leak into the outer class while later outer cleanup
+  remains attributable. status: documented
+
+## Decision: re-arm the container across every non-test lifecycle interval
+
+- **where:** `blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/TestBoundaryListener.java`
+- **why:** JUnit exposes no cleanup-start boundary, so the container is restored after every child test and its final union conservatively selects every direct member for cleanup or inter-test dependencies.
+- **alternative:** Keep only the @BeforeAll window — rejected: @AfterAll-only dependencies remain unowned and can produce a false negative.
+- **design:** ../design.md#decision
+- **constitution:** §III
+- **trust:** ✓ verified


### PR DESCRIPTION
Closes #221

## Summary
- Re-arm the innermost class container after each test, attributing unowned cleanup and idle-window dependencies conservatively to its direct members.
- Preserve method-precise attribution for normal `@BeforeEach` and `@AfterEach` callbacks.
- Refresh hidden-class baselines per container window and restore parent containers after nested classes.
- Remove the closed lifecycle gap from both Known limitations sections.

## Design
[FluencyLoop design](docs/fluencyloop/features/221-attribute-afterall-and-inter-test-lifecycle-dependencies/design.md)

## Verification
- `mvn -q -pl blastradius-core test`

## Constitution
- §III Safety Over Speed: verified; lifecycle work may widen selection but cannot suppress a dependent test.