### PR TITLE
docs: decide cached dependency mitigation direction

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,10 +1,10 @@
 {
-  "feature": "221-attribute-afterall-and-inter-test-lifecycle-dependencies",
-  "branch": "feature/221-attribute-afterall-and-inter-test-lifecycle-dependencies",
+  "feature": "220-decide-whether-to-mitigate-string-dispatched-cached-depe",
+  "branch": "feature/220-decide-whether-to-mitigate-string-dispatched-cached-depe",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/221-attribute-afterall-and-inter-test-lifecycle-dependencies/sessions/001-rearm-container-identity-for-cleanup-and-inter-test-life.md",
+  "last_session": "docs/fluencyloop/features/220-decide-whether-to-mitigate-string-dispatched-cached-depe/sessions/001-record-bounded-direct-invocation-reference-fallback-deci.md",
   "base_ref": "main",
-  "feature_dir": "docs/fluencyloop/features/221-attribute-afterall-and-inter-test-lifecycle-dependencies",
+  "feature_dir": "docs/fluencyloop/features/220-decide-whether-to-mitigate-string-dispatched-cached-depe",
   "plan": "",
   "updated": "2026-08-05"
 }

--- a/docs/fluencyloop/README.md
+++ b/docs/fluencyloop/README.md
@@ -13,7 +13,8 @@ _None yet._
 | feature | plan | status | started |
 |---------|------|--------|---------|
 | [core: attribute @BeforeAll-loaded classes to their container's tests](features/219-core-attribute-beforeall-loaded-classes-to-their-contain/design.md) | - | shipped | 2026-08-05 |
-| [attribute @AfterAll and inter-test lifecycle dependencies to test containers](features/221-attribute-afterall-and-inter-test-lifecycle-dependencies/design.md) | - | in progress | 2026-08-05 |
+| [decide whether to mitigate string-dispatched cached dependency blind spots](features/220-decide-whether-to-mitigate-string-dispatched-cached-depe/design.md) | - | in progress | 2026-08-05 |
+| [attribute @AfterAll and inter-test lifecycle dependencies to test containers](features/221-attribute-afterall-and-inter-test-lifecycle-dependencies/design.md) | - | shipped | 2026-08-05 |
 | [Abstract the index store behind an interface (#25)](features/abstract-the-index-store-behind-an-interface-25/design.md) | - | shipped | 2026-07-20 |
 | [Add explicit flaky-test exclusions to validator target builds](features/add-explicit-flaky-test-exclusions-to-validator-target-build/design.md) | - | shipped | 2026-08-02 |
 | [Add opt-in, bounded mutation-based validator soundness validation for issue 187](features/add-opt-in-bounded-mutation-based-validator-soundness-valida/design.md) | - | shipped | 2026-08-01 |

--- a/docs/fluencyloop/features/220-decide-whether-to-mitigate-string-dispatched-cached-depe/design.md
+++ b/docs/fluencyloop/features/220-decide-whether-to-mitigate-string-dispatched-cached-depe/design.md
@@ -1,0 +1,136 @@
+# Design: decide whether to mitigate string-dispatched cached dependency blind spots
+
+started: 2026-08-05
+branch: feature/220-decide-whether-to-mitigate-string-dispatched-cached-depe
+relates to: #220, #41
+
+## Problem
+
+The tracker records a dependency only when an instrumented class executes while a test identity
+is current. Its callbacks already cover method entry, field access, type references, and class
+literals. A string-dispatched API with a cached parse result can bypass all of them: a test calls
+`select("div > p")`, receives a cached evaluator, and never executes `QueryParser` even though a
+change to that parser can alter the test result.
+
+The jsoup historical replay measured this as 745 skipped killing tests for four `QueryParser`
+mutants. The selection rule behaved as designed; the missing edge is not present in the dynamic
+record. This feature decides whether a generic mitigation is justified, rather than silently
+adding a broad and potentially noisy analysis layer.
+
+## Class diagram
+
+```mermaid
+classDiagram
+    class DynamicTracker {
+        +recordAmbientExecution(className)
+        +recordedDependencies()
+    }
+    class CachedStringApi {
+        +select(query)
+        -cache
+    }
+    class QueryParser {
+        +parse(query)
+    }
+    class DirectInvocationFallback {
+        +recordPotentialTargets(executedClass)
+        +selectForDirectTarget(changedClass)
+    }
+    class CacheHeuristic {
+        +observeCacheHit(key, producer)
+    }
+    class OperationalBackstop {
+        +dailyFullSuite()
+    }
+    class ResearchAdr {
+        +decision
+        +evidence
+        +alternatives
+    }
+    CachedStringApi --> QueryParser : parse on cache miss only
+    DynamicTracker --> CachedStringApi : sees executed bytecode only
+    DirectInvocationFallback ..> QueryParser : stores direct potential target
+    CacheHeuristic ..> CachedStringApi : requires API-specific semantics
+    ResearchAdr --> DirectInvocationFallback : chooses bounded prototype
+    ResearchAdr --> CacheHeuristic : evaluates
+    ResearchAdr --> OperationalBackstop : evaluates
+```
+
+## Sequence: cached call and research decision
+
+```mermaid
+sequenceDiagram
+    participant Test as Test method
+    participant Api as Cached string API
+    participant Cache as Evaluator cache
+    participant Parser as QueryParser
+    participant Tracker as Dynamic tracker
+    participant Index as Dependency index
+    participant ADR as Research ADR
+
+    Test->>Api: select(string query)
+    Api->>Cache: lookup query
+    Cache-->>Api: cached evaluator
+    Api-->>Test: matching result
+    Note over Parser,Tracker: Parser does not execute, so no dynamic edge exists
+    Tracker->>Index: retain direct invocation owners for executed project classes
+    ADR->>ADR: reject a whole-program graph and generic cache hooks
+    ADR-->>Index: prototype one-hop optional fallback with explicit reason
+```
+
+## Research shape
+
+- **Whole-program static or hybrid call graph:** Build a per-test method reachability graph and
+  select a test when a changed class is reachable from it, even without execution. SootUp's
+  documented call graph algorithms require a complete type hierarchy and explicit entry methods,
+  while dynamic dispatch, reflection, generated code, and string-to-parser routing still need
+  modelling. A sufficiently safe graph risks selecting much of the suite and introduces a large
+  analysis dependency into the hot selection path.
+- **Bounded direct-invocation fallback:** Retain the direct invocation-owner references visible in
+  the bytecode of a project class only after a test dynamically demonstrated that the class ran.
+  If a changed project class is one of those direct potential targets, select that test with a
+  reason naming both classes. This single-hop, class-level rule can over-attribute a skipped
+  branch to the test, but it does not need to understand a cache's key or invalidation semantics.
+- **Targeted cache instrumentation:** Observe a cache hit and attribute the cache producer class
+  to the current test. This can be precise for one known library only if the cache key, producer,
+  invalidation rules, wrappers, and concurrency semantics are modelled. A generic `Map` hook cannot
+  recover those semantics and would create unbounded false edges.
+- **Operational backstop:** Keep the documented string-DSL limitation and rely on the existing
+  daily full-suite recommendation. This preserves the deterministic dynamic core and requires no
+  new dependency, but retains the measured jsoup exposure until a narrow, evidence-backed optional
+  adapter earns its own feature.
+
+## Decision
+
+Record the research decision in `research.md` and pursue an **optional, bounded
+direct-invocation-reference prototype** in [#225](https://github.com/baokhang83/blastradius/issues/225).
+The prototype is deliberately narrower than a whole-program call graph: it starts from a class
+the test demonstrably executed, follows only its declared direct invocation owners, and stops.
+It is class-level conservative, so a method branch that did not run can still cause an extra test
+to be selected. That is acceptable only while measurement confirms the fallback recovers the
+jsoup `QueryParser` misses without an impractical selection expansion.
+
+Reject a mandatory whole-program graph and generic cache instrumentation for this feature. The
+former needs broad classpath and entry-point modelling, while the latter cannot generically infer
+cache producer, key, invalidation, wrapper, or concurrency semantics. The existing daily full
+suite remains the operational backstop while the optional prototype is evaluated.
+
+## Decision criteria for #225
+
+1. A mitigation must either retain an explainable concrete reason for each extra test or remain
+   opt-in for a named API family.
+2. It must improve the measured jsoup `QueryParser` case without turning unrelated Java projects
+   into near-full-suite runs.
+3. It must not make static inference the mandatory core, because the project constitution requires
+   dynamic tracking as the primary mechanism for reflective and runtime-generated edges.
+
+## Constitution check
+
+- **II. Simplicity:** do not embed a general program-analysis framework without a second concrete
+  use case and a measured selection benefit.
+- **III. Safety over speed:** a possible dependency may justify more tests, but the evidence must
+  show the fallback improves rather than merely globalizes selection.
+- **IV. Deterministic core before ML:** any result remains deterministic and explainable; no
+  statistical prediction is in scope.
+- **V. Explainability:** cache or reachability fallback would need to report the named rule and
+  changed class, never an opaque confidence score.

--- a/docs/fluencyloop/features/220-decide-whether-to-mitigate-string-dispatched-cached-depe/research.md
+++ b/docs/fluencyloop/features/220-decide-whether-to-mitigate-string-dispatched-cached-depe/research.md
@@ -1,0 +1,83 @@
+# ADR: bounded fallback for cached string-dispatch dependencies
+
+- Status: decided
+- Issue: [#220](https://github.com/baokhang83/blastradius/issues/220)
+- Follow-up: [#225](https://github.com/baokhang83/blastradius/issues/225)
+- Date: 2026-08-05
+
+## Context and evidence
+
+The core index records dynamic class dependencies. A test that calls a string-based API can
+depend on a parser without executing that parser when a prior parse result is cached. The dynamic
+record therefore contains no `QueryParser` edge even though changing `QueryParser` can change the
+test's result.
+
+The [historical replay analysis](../../../../HISTORICAL_REPLAY_ANALYSIS.md) measured the exposure
+in jsoup: 3,068 of 47,866 killing executions were skipped, representing 750 distinct tests. Four
+`org.jsoup.select.QueryParser` mutants account for 2,980 skips across the same 745 tests. Of 665
+killing tests selected for those four mutants, 635 recorded `QueryParser`; none of the 745 skipped
+tests did. This is incomplete dynamic input, rather than a failure in the selection rule.
+
+The cache behavior is a plausible cause: jsoup's
+[QueryParser documentation](https://jsoup.org/apidocs/org/jsoup/select/QueryParser.html) describes
+parsing a CSS query into an evaluator and reusing the result. A cache hit can avoid parser
+execution completely.
+
+## Decision
+
+Pursue the optional prototype in [#225](https://github.com/baokhang83/blastradius/issues/225):
+
+1. For a project class that a test dynamically executed, retain its directly declared
+   method-invocation owner classes as potential targets.
+2. During selection, if a changed project class is a retained direct potential target of an
+   executed class, select that test and emit a reason naming the executed class and changed target.
+3. Keep this one-hop, class-level expansion optional until replay results justify enabling it by
+   default.
+
+This is deliberately conservative. It can select a test although the executed method did not take
+the branch containing the invocation. That over-attribution is observable in the selection reason
+and is safer than leaving the dynamic edge invisible.
+
+## Alternatives considered
+
+### Mandatory whole-program static call graph — rejected
+
+A general call graph needs a complete type hierarchy and an explicit entry model. The
+[SootUp call graph documentation](https://soot-oss.github.io/SootUp/latest/callgraphs/) makes those
+inputs explicit. Dynamic dispatch, reflection, generated code, and string routing still require
+additional modelling. Making that broad analysis mandatory would complicate the dynamic core and
+would likely over-select across ordinary projects.
+
+### Generic cache instrumentation — rejected
+
+Intercepting generic maps or cache libraries cannot establish which computation produced a value,
+what key identifies it, when it is invalidated, whether a wrapper transforms it, or how concurrent
+access changes attribution. A precise solution would be library-specific, which is not justified
+before a concrete second case exists.
+
+### Document the limitation permanently — rejected for now
+
+The daily full suite remains the safety backstop, but the replay evidence is concentrated enough to
+justify measuring a narrow deterministic fallback. The project should not silently expand to a
+whole-program analysis merely to address this case.
+
+## Success conditions and guardrails
+
+- Measure #225 against the jsoup `QueryParser` replay case, including recovered killing tests and
+  total selection expansion.
+- Do not enable the fallback by default without that evidence.
+- Retain the dynamic index as the primary source of dependencies.
+- Do not introduce a transitive call graph or generic cache hook as part of #225.
+- Every fallback selection must expose its concrete executed-class and changed-target reason.
+- Keep analysis precomputed or cached so class-load processing does not add avoidable filesystem or
+  syscall work.
+
+## Constitution check
+
+- **II. Simplicity:** one bounded, proven shape precedes any reusable analysis abstraction.
+- **III. Safety over speed:** the rule only expands selection, and the daily full suite remains a
+  complementary backstop.
+- **IV. Deterministic core before ML:** the fallback is deterministic and optional.
+- **V. Explainability:** every extra selection names both sides of the direct-reference rule.
+- **VIII. No avoidable work on the hot path:** persistent metadata must be computed or cached
+  without repeated filesystem work during class-load events.

--- a/docs/fluencyloop/features/220-decide-whether-to-mitigate-string-dispatched-cached-depe/sessions/001-record-bounded-direct-invocation-reference-fallback-deci.md
+++ b/docs/fluencyloop/features/220-decide-whether-to-mitigate-string-dispatched-cached-depe/sessions/001-record-bounded-direct-invocation-reference-fallback-deci.md
@@ -1,0 +1,27 @@
+# Session: record bounded direct-invocation-reference fallback decision
+
+- **intent:** record bounded direct-invocation-reference fallback decision
+- **started:** 2026-08-05
+
+## Knowledge transfer
+
+- **Dynamic index blind spot:** a dependency appears in the index only when the relevant class
+  executes while a test identity is current. A cached string-dispatch API can return a prior parse
+  result without executing its parser, leaving a real dependency absent from the test record.
+  **Status:** documented.
+- **Bounded hybrid rule:** direct invocation-owner metadata is useful only as an optional,
+  single-hop expansion from a class the test dynamically executed. It produces an auditable,
+  conservative reason without claiming a whole-program reachability proof. **Status:** follow-up
+  in #225.
+- **Cache instrumentation limit:** a generic cache hook cannot recover a cache value's producer,
+  key, invalidation, wrappers, or concurrency semantics. A precise adapter would be specific to a
+  demonstrated library case. **Status:** documented.
+
+## Decision: pursue a bounded direct-invocation-reference prototype
+
+- **where:** `docs/fluencyloop/features/220-decide-whether-to-mitigate-string-dispatched-cached-depe/research.md`
+- **why:** The concentrated jsoup QueryParser misses justify measuring a one-hop, class-level conservative fallback that remains explainable and optional.
+- **alternative:** Mandatory whole-program call graph and generic cache instrumentation — rejected: broad reachability modelling and cache semantics would add speculative complexity without a second proven case.
+- **design:** ../design.md#decision
+- **constitution:** §II, §III, §IV, §V, §VIII
+- **trust:** ✓ verified


### PR DESCRIPTION
Closes #220

## Summary
- records the jsoup cached string-dispatch evidence and its dynamic-tracking blind spot
- rejects mandatory whole-program static analysis and generic cache instrumentation
- records an optional, one-hop direct-invocation-reference prototype in #225

## Verification
- `git diff --check`
- FluencyLoop review: one journaled commit, no unjournaled drift

## Constitution
Checked against §§II, III, IV, V, and VIII: keep the dynamic core primary, make the fallback deterministic and explicit, constrain it to one hop, and measure its selection expansion before any default enablement.