### PR TITLE
feat: add direct invocation fallback for cached dependencies

### DIFF
--- a/.fluencyloop/state.json
+++ b/.fluencyloop/state.json
@@ -1,10 +1,10 @@
 {
-  "feature": "220-decide-whether-to-mitigate-string-dispatched-cached-depe",
-  "branch": "feature/220-decide-whether-to-mitigate-string-dispatched-cached-depe",
+  "feature": "225-prototype-direct-invocation-reference-fallback-for-cache",
+  "branch": "feature/225-prototype-direct-invocation-reference-fallback-for-cache",
   "stage": "build",
-  "last_session": "docs/fluencyloop/features/220-decide-whether-to-mitigate-string-dispatched-cached-depe/sessions/001-record-bounded-direct-invocation-reference-fallback-deci.md",
+  "last_session": "docs/fluencyloop/features/225-prototype-direct-invocation-reference-fallback-for-cache/sessions/001-track-and-select-bounded-direct-invocation-references.md",
   "base_ref": "main",
-  "feature_dir": "docs/fluencyloop/features/220-decide-whether-to-mitigate-string-dispatched-cached-depe",
+  "feature_dir": "docs/fluencyloop/features/225-prototype-direct-invocation-reference-fallback-for-cache",
   "plan": "",
   "updated": "2026-08-05"
 }

--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ See [`blastradius-maven-plugin/README.md`](blastradius-maven-plugin/README.md) f
 configuration reference, what each build mode (`TRACK`/`SELECT`/`FALLBACK`) prints, and how
 to set it up in CI.
 
+### Cached string-dispatch fallback
+
+Format-3 indexes also retain direct method-owner references for project classes that a test
+actually executed. This can recover a dependency hidden when a cached string API skips its parser,
+but it is intentionally class-level conservative and may select an extra test. It is **on by
+default**: a fresh format-3 index uses this safety net automatically. Disable it for a comparison
+with Maven `-Dblastradius.directInvocationFallback=false`, or Gradle
+`directInvocationFallback = false` in the `blastradius` block. Explain output names both the
+executed source class and changed target for every such selection.
+
 ### Sharing indexes across CI runners
 
 By default, indexes stay under the workspace's `.blastradius/` directory. That directory is a
@@ -252,7 +262,8 @@ Full text and rationale: [`.specify/memory/constitution.md`](.specify/memory/con
 
 ## Known limitations
 
-- A class reached only through a **string-dispatched API** may go unattributed:
+- A class reached only through a **string-dispatched API** can still be unattributed when it is not
+  a direct invocation target of an executed project class:
   if the call is `select("div > p")` and the parse behind it sits on a cached path, the calling test
   never records a load of the parser it truly depends on. Measured, not hypothetical — this is what
   left 750 `QueryParser`-dependent tests unselected in the jsoup replay above. It bites hardest

--- a/blastradius-core/build.gradle
+++ b/blastradius-core/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'org.eclipse.jgit:org.eclipse.jgit:6.9.0.202403050737-r'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
     implementation 'org.junit.platform:junit-platform-launcher:1.10.2'
+    implementation 'org.ow2.asm:asm:9.10.1'
 
     testImplementation platform('org.junit:junit-bom:5.10.2')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/index/DependencyIndexFormat.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/index/DependencyIndexFormat.java
@@ -4,7 +4,7 @@ package io.github.baokhang83.blastradius.core.index;
 public final class DependencyIndexFormat {
 
     /** The version emitted for every newly tracked dependency index. */
-    public static final int CURRENT_VERSION = 2;
+    public static final int CURRENT_VERSION = 3;
 
     private static final int LEGACY_UNVERSIONED_VERSION = 0;
 

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/DirectInvocationReferenceSelector.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/DirectInvocationReferenceSelector.java
@@ -1,0 +1,22 @@
+package io.github.baokhang83.blastradius.core.selection;
+
+import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
+import java.util.Map;
+import java.util.Set;
+
+/** Selects a test when one of its dynamically-executed classes directly references a changed class. */
+final class DirectInvocationReferenceSelector {
+
+    SelectionDecision select(TestIdentity test, Map<String, Set<String>> directInvocationOwners,
+            Set<String> changedClassNames) {
+        for (Map.Entry<String, Set<String>> source : directInvocationOwners.entrySet()) {
+            for (String changedClassName : changedClassNames) {
+                if (source.getValue().contains(changedClassName)
+                        || source.getValue().stream().anyMatch(owner -> owner.startsWith(changedClassName + "$"))) {
+                    return SelectionDecision.directInvocationReference(test, source.getKey(), changedClassName);
+                }
+            }
+        }
+        return SelectionDecision.noMatch(test);
+    }
+}

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionDecision.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionDecision.java
@@ -11,16 +11,28 @@ import java.util.Objects;
  * @param selected             whether it was selected
  * @param reason               the reason (see {@link SelectionReason})
  * @param matchedChangedClass  the specific changed class responsible, only present when
- *                             {@code reason == DEPENDENCY_MATCH}
+ *                             {@code reason == DEPENDENCY_MATCH || reason == DIRECT_INVOCATION_REFERENCE}
+ * @param directInvocationSourceClass the executed class that declared the direct invocation,
+ *                                    only present for {@code DIRECT_INVOCATION_REFERENCE}
  */
 public record SelectionDecision(
-        TestIdentity test, boolean selected, SelectionReason reason, String matchedChangedClass) {
+        TestIdentity test, boolean selected, SelectionReason reason, String matchedChangedClass,
+        String directInvocationSourceClass) {
+
+    /** Preserves callers that do not carry a direct-invocation source. */
+    public SelectionDecision(TestIdentity test, boolean selected, SelectionReason reason, String matchedChangedClass) {
+        this(test, selected, reason, matchedChangedClass, null);
+    }
 
     public SelectionDecision {
         Objects.requireNonNull(test, "test");
         Objects.requireNonNull(reason, "reason");
-        if (reason == SelectionReason.DEPENDENCY_MATCH) {
+        if (reason == SelectionReason.DEPENDENCY_MATCH || reason == SelectionReason.DIRECT_INVOCATION_REFERENCE) {
             Objects.requireNonNull(matchedChangedClass, "matchedChangedClass required for DEPENDENCY_MATCH");
+        }
+        if (reason == SelectionReason.DIRECT_INVOCATION_REFERENCE) {
+            Objects.requireNonNull(directInvocationSourceClass,
+                    "directInvocationSourceClass required for DIRECT_INVOCATION_REFERENCE");
         }
         boolean expectedSelected = reason != SelectionReason.NO_MATCH;
         if (selected != expectedSelected) {
@@ -29,26 +41,31 @@ public record SelectionDecision(
     }
 
     public static SelectionDecision dependencyMatch(TestIdentity test, String matchedChangedClass) {
-        return new SelectionDecision(test, true, SelectionReason.DEPENDENCY_MATCH, matchedChangedClass);
+        return new SelectionDecision(test, true, SelectionReason.DEPENDENCY_MATCH, matchedChangedClass, null);
+    }
+
+    public static SelectionDecision directInvocationReference(
+            TestIdentity test, String sourceClass, String matchedChangedClass) {
+        return new SelectionDecision(test, true, SelectionReason.DIRECT_INVOCATION_REFERENCE, matchedChangedClass, sourceClass);
     }
 
     public static SelectionDecision fallback(TestIdentity test) {
-        return new SelectionDecision(test, true, SelectionReason.FALLBACK_NON_SOURCE_CHANGE, null);
+        return new SelectionDecision(test, true, SelectionReason.FALLBACK_NON_SOURCE_CHANGE, null, null);
     }
 
     public static SelectionDecision fallbackAmbientDependency(TestIdentity test) {
-        return new SelectionDecision(test, true, SelectionReason.FALLBACK_AMBIENT_DEPENDENCY, null);
+        return new SelectionDecision(test, true, SelectionReason.FALLBACK_AMBIENT_DEPENDENCY, null, null);
     }
 
     public static SelectionDecision fallbackNonSourceDependentModule(TestIdentity test) {
-        return new SelectionDecision(test, true, SelectionReason.FALLBACK_NON_SOURCE_DEPENDENT_MODULE, null);
+        return new SelectionDecision(test, true, SelectionReason.FALLBACK_NON_SOURCE_DEPENDENT_MODULE, null, null);
     }
 
     public static SelectionDecision newOrModifiedTest(TestIdentity test) {
-        return new SelectionDecision(test, true, SelectionReason.NEW_OR_MODIFIED_TEST, null);
+        return new SelectionDecision(test, true, SelectionReason.NEW_OR_MODIFIED_TEST, null, null);
     }
 
     public static SelectionDecision noMatch(TestIdentity test) {
-        return new SelectionDecision(test, false, SelectionReason.NO_MATCH, null);
+        return new SelectionDecision(test, false, SelectionReason.NO_MATCH, null, null);
     }
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionEngine.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionEngine.java
@@ -24,6 +24,7 @@ public final class SelectionEngine {
     private final AmbientDependencySelector ambientDependencySelector = new AmbientDependencySelector();
     private final NewOrModifiedTestSelector newOrModifiedTestSelector = new NewOrModifiedTestSelector();
     private final DependencyMatchSelector dependencyMatchSelector = new DependencyMatchSelector();
+    private final DirectInvocationReferenceSelector directInvocationReferenceSelector = new DirectInvocationReferenceSelector();
 
     /**
      * @param allTests           every test in the suite
@@ -39,7 +40,19 @@ public final class SelectionEngine {
             Set<TestIdentity> newOrModifiedTests,
             List<ChangedFile> changedFiles,
             Set<String> ambientDependencies) {
-        return selectAll(allTests, testDependencies, newOrModifiedTests, changedFiles, ambientDependencies, null);
+        return selectAll(allTests, testDependencies, Map.of(), newOrModifiedTests, changedFiles, ambientDependencies, null);
+    }
+
+    /** As {@link #selectAll(Set, Map, Set, List, Set)}, with optional one-hop direct references. */
+    public List<SelectionDecision> selectAll(
+            Set<TestIdentity> allTests,
+            Map<TestIdentity, Set<String>> testDependencies,
+            Map<TestIdentity, Map<String, Set<String>>> directInvocationOwnersByTest,
+            Set<TestIdentity> newOrModifiedTests,
+            List<ChangedFile> changedFiles,
+            Set<String> ambientDependencies) {
+        return selectAll(allTests, testDependencies, directInvocationOwnersByTest, newOrModifiedTests,
+                changedFiles, ambientDependencies, null);
     }
 
     /**
@@ -51,6 +64,19 @@ public final class SelectionEngine {
     public List<SelectionDecision> selectAll(
             Set<TestIdentity> allTests,
             Map<TestIdentity, Set<String>> testDependencies,
+            Set<TestIdentity> newOrModifiedTests,
+            List<ChangedFile> changedFiles,
+            Set<String> ambientDependencies,
+        ReactorScope reactorScope) {
+        return selectAll(allTests, testDependencies, Map.of(), newOrModifiedTests, changedFiles,
+                ambientDependencies, reactorScope);
+    }
+
+    /** As the reactor-aware overload, with optional one-hop direct references. */
+    public List<SelectionDecision> selectAll(
+            Set<TestIdentity> allTests,
+            Map<TestIdentity, Set<String>> testDependencies,
+            Map<TestIdentity, Map<String, Set<String>>> directInvocationOwnersByTest,
             Set<TestIdentity> newOrModifiedTests,
             List<ChangedFile> changedFiles,
             Set<String> ambientDependencies,
@@ -89,7 +115,13 @@ public final class SelectionEngine {
                 continue;
             }
             Set<String> dependencies = testDependencies.getOrDefault(test.baselineKey(), Set.of());
-            decisions.add(dependencyMatchSelector.select(test, dependencies, changedClassNames));
+            SelectionDecision directMatch = dependencyMatchSelector.select(test, dependencies, changedClassNames);
+            if (directMatch.selected()) {
+                decisions.add(directMatch);
+                continue;
+            }
+            decisions.add(directInvocationReferenceSelector.select(
+                    test, directInvocationOwnersByTest.getOrDefault(test.baselineKey(), Map.of()), changedClassNames));
         }
         return decisions;
     }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionReason.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionReason.java
@@ -4,6 +4,12 @@ package io.github.baokhang83.blastradius.core.selection;
 public enum SelectionReason {
     /** The test's tracked dependencies intersect a changed class (FR-002). */
     DEPENDENCY_MATCH,
+    /**
+     * A class the test demonstrably executed declares a direct method invocation to a changed
+     * class. This bounded, class-level fallback can over-select a branch that did not execute,
+     * but always names both the executed source and changed target (issue #225).
+     */
+    DIRECT_INVOCATION_REFERENCE,
     /** A non-Java-source change forced selection of every test (FR-006). */
     FALLBACK_NON_SOURCE_CHANGE,
     /**

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenter.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenter.java
@@ -98,6 +98,27 @@ final class AmbientClassInstrumenter {
         return changed.get() ? writer.toByteArray() : null;
     }
 
+    /** Direct method-invocation owner types declared by this class, collected without executing it. */
+    Set<String> directInvocationOwners(byte[] bytecode) {
+        Set<String> owners = new HashSet<>();
+        new ClassReader(bytecode).accept(new ClassVisitor(Opcodes.ASM9) {
+            @Override
+            public MethodVisitor visitMethod(int access, String name, String descriptor, String signature,
+                    String[] exceptions) {
+                MethodVisitor delegate = super.visitMethod(access, name, descriptor, signature, exceptions);
+                return new MethodVisitor(Opcodes.ASM9, delegate) {
+                    @Override
+                    public void visitMethodInsn(int opcode, String owner, String name, String descriptor,
+                            boolean isInterface) {
+                        owners.add(owner.replace('/', '.'));
+                        super.visitMethodInsn(opcode, owner, name, descriptor, isInterface);
+                    }
+                };
+            }
+        }, ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+        return Set.copyOf(owners);
+    }
+
     /**
      * Computes target-project stack-map-frame hierarchy relationships from class-file resources
      * rather than {@link Class#forName(String, boolean, ClassLoader)}. A transformer runs while

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordFile.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordFile.java
@@ -10,4 +10,13 @@ import java.util.Set;
  * protocol between {@link DependencyRecordWriter} and {@link DependencyRecordReader} — never
  * persisted across builds — so its shape is free to change without a version migration.
  */
-record DependencyRecordFile(List<DependencyRecord> tests, Set<String> ambientDependencies) {}
+record DependencyRecordFile(
+        List<DependencyRecord> tests,
+        List<DirectInvocationRecord> directInvocations,
+        Set<String> ambientDependencies) {
+
+    DependencyRecordFile {
+        directInvocations = directInvocations == null ? List.of() : List.copyOf(directInvocations);
+        ambientDependencies = ambientDependencies == null ? Set.of() : Set.copyOf(ambientDependencies);
+    }
+}

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordReader.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordReader.java
@@ -28,7 +28,10 @@ public final class DependencyRecordReader {
             DependencyRecordFile file = mapper.readValue(inputFile.toFile(), DependencyRecordFile.class);
             Map<TestIdentity, Map<String, String>> tests = file.tests().stream()
                     .collect(Collectors.toUnmodifiableMap(DependencyRecord::test, DependencyRecord::dependencies));
-            return new DependencyRecordSet(tests, file.ambientDependencies());
+            Map<TestIdentity, Map<String, Set<String>>> directInvocations = file.directInvocations().stream()
+                    .collect(Collectors.toUnmodifiableMap(
+                            DirectInvocationRecord::test, DirectInvocationRecord::sourceToTargetClasses));
+            return new DependencyRecordSet(tests, directInvocations, file.ambientDependencies());
         } catch (IOException e) {
             throw new UncheckedIOException("failed to read dependency record from " + inputFile, e);
         }
@@ -55,6 +58,7 @@ public final class DependencyRecordReader {
         Path parent = baseOutputFile.toAbsolutePath().getParent();
         String prefix = baseOutputFile.getFileName().toString() + ".";
         Map<TestIdentity, Map<String, String>> mergedTests = new HashMap<>();
+        Map<TestIdentity, Map<String, Set<String>>> mergedDirectInvocations = new HashMap<>();
         Set<String> mergedAmbient = new HashSet<>();
         List<String> crashReasons = new ArrayList<>();
         boolean foundAny = false;
@@ -71,6 +75,8 @@ public final class DependencyRecordReader {
                     combined.putAll(newClasses);
                     return combined;
                 }));
+                sibling.directInvocations().forEach((test, sources) -> mergedDirectInvocations.merge(
+                        test, sources, DependencyRecordReader::mergeDirectInvocations));
                 mergedAmbient.addAll(sibling.ambientDependencies());
             }
         } catch (IOException e) {
@@ -92,7 +98,27 @@ public final class DependencyRecordReader {
         for (TestIdentity test : mergedTests.keySet()) {
             mergedAmbient.remove(test.className());
         }
-        return new DependencyRecordSet(Map.copyOf(mergedTests), Set.copyOf(mergedAmbient));
+        return new DependencyRecordSet(
+                Map.copyOf(mergedTests), immutableDirectInvocations(mergedDirectInvocations), Set.copyOf(mergedAmbient));
+    }
+
+    private static Map<String, Set<String>> mergeDirectInvocations(
+            Map<String, Set<String>> first, Map<String, Set<String>> second) {
+        Map<String, Set<String>> merged = new HashMap<>(first);
+        second.forEach((source, targets) -> merged.merge(source, targets, (left, right) -> {
+            Set<String> union = new HashSet<>(left);
+            union.addAll(right);
+            return union;
+        }));
+        return merged;
+    }
+
+    private static Map<TestIdentity, Map<String, Set<String>>> immutableDirectInvocations(
+            Map<TestIdentity, Map<String, Set<String>>> directInvocations) {
+        return directInvocations.entrySet().stream().collect(Collectors.toUnmodifiableMap(
+                Map.Entry::getKey,
+                test -> test.getValue().entrySet().stream().collect(Collectors.toUnmodifiableMap(
+                        Map.Entry::getKey, source -> Set.copyOf(source.getValue())))));
     }
 
     private static String readCrashReason(Path markerFile) {

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordSet.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordSet.java
@@ -9,4 +9,13 @@ import java.util.Set;
  * the first test's tracking window opened in any fork — also unioned, since each fork's
  * discovery pass can force-load a different subset.
  */
-public record DependencyRecordSet(Map<TestIdentity, Map<String, String>> tests, Set<String> ambientDependencies) {}
+public record DependencyRecordSet(
+        Map<TestIdentity, Map<String, String>> tests,
+        Map<TestIdentity, Map<String, Set<String>>> directInvocations,
+        Set<String> ambientDependencies) {
+
+    /** Preserves callers built against the format-2 in-memory representation. */
+    public DependencyRecordSet(Map<TestIdentity, Map<String, String>> tests, Set<String> ambientDependencies) {
+        this(tests, Map.of(), ambientDependencies);
+    }
+}

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordWriter.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordWriter.java
@@ -33,11 +33,20 @@ public final class DependencyRecordWriter {
 
     public void write(Path outputFile, Map<TestIdentity, Map<String, String>> recordedDependencies,
             Set<String> ambientDependencies) {
+        write(outputFile, recordedDependencies, Map.of(), ambientDependencies);
+    }
+
+    public void write(Path outputFile, Map<TestIdentity, Map<String, String>> recordedDependencies,
+            Map<TestIdentity, Map<String, Set<String>>> directInvocations, Set<String> ambientDependencies) {
         List<DependencyRecord> records = recordedDependencies.entrySet().stream()
                 .map(entry -> new DependencyRecord(entry.getKey(), entry.getValue()))
                 .toList();
+        List<DirectInvocationRecord> directInvocationRecords = directInvocations.entrySet().stream()
+                .map(entry -> new DirectInvocationRecord(entry.getKey(), entry.getValue()))
+                .toList();
         try {
-            mapper.writeValue(outputFile.toFile(), new DependencyRecordFile(records, ambientDependencies));
+            mapper.writeValue(outputFile.toFile(), new DependencyRecordFile(
+                    records, directInvocationRecords, ambientDependencies));
         } catch (IOException e) {
             throw new UncheckedIOException("failed to write dependency record to " + outputFile, e);
         }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java
@@ -104,6 +104,8 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
 
     private final Supplier<TestIdentity> currentTestSupplier;
     private final Map<TestIdentity, Map<String, String>> checksumsByTest = new ConcurrentHashMap<>();
+    private final Map<TestIdentity, Map<String, Set<String>>> directInvocationOwnersByTest = new ConcurrentHashMap<>();
+    private final Map<String, Set<String>> directInvocationOwnersByClass = new ConcurrentHashMap<>();
     private final Set<String> ambientDependencies = ConcurrentHashMap.newKeySet();
     private final Set<String> pendingAmbientRetransformations = ConcurrentHashMap.newKeySet();
     private final Set<String> transformedAmbientClasses = ConcurrentHashMap.newKeySet();
@@ -150,7 +152,8 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
         if (agentArgs != null && !agentArgs.isBlank()) {
             Path outputFile = Path.of(agentArgs + "." + ProcessHandle.current().pid());
             Runtime.getRuntime().addShutdownHook(new Thread(() -> runShutdownHook(
-                    outputFile, agent::recordedDependencies, agent::ambientDependencies,
+                    outputFile, agent::recordedDependencies, agent::directInvocationOwnersByTest,
+                    agent::ambientDependencies,
                     new DependencyRecordWriter())));
         }
     }
@@ -167,10 +170,16 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
      */
     static void runShutdownHook(Path outputFile, Supplier<Map<TestIdentity, Map<String, String>>> recordedDependencies,
             Supplier<Set<String>> ambientDependencies, DependencyRecordWriter writer) {
+        runShutdownHook(outputFile, recordedDependencies, Map::of, ambientDependencies, writer);
+    }
+
+    static void runShutdownHook(Path outputFile, Supplier<Map<TestIdentity, Map<String, String>>> recordedDependencies,
+            Supplier<Map<TestIdentity, Map<String, Set<String>>>> directInvocations,
+            Supplier<Set<String>> ambientDependencies, DependencyRecordWriter writer) {
         try {
             Map<TestIdentity, Map<String, String>> recorded = recordedDependencies.get();
             if (!recorded.isEmpty()) {
-                writer.write(outputFile, recorded, ambientDependencies.get());
+                writer.write(outputFile, recorded, directInvocations.get(), ambientDependencies.get());
             }
         } catch (Throwable t) {
             try {
@@ -197,6 +206,8 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
                 byte[] instrumented = ambientClassInstrumenter.instrument(dottedClassName, classfileBuffer, loader);
                 if (instrumented != null) {
                     ambientChecksums.put(dottedClassName, sha256Hex(classfileBuffer));
+                    directInvocationOwnersByClass.put(
+                            dottedClassName, ambientClassInstrumenter.directInvocationOwners(classfileBuffer));
                     transformedAmbientClasses.add(dottedClassName);
                 }
                 return instrumented;
@@ -225,6 +236,8 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
                     instrumented = ambientClassInstrumenter.instrument(dottedClassName, classfileBuffer, loader);
                     if (instrumented != null) {
                         ambientChecksums.put(dottedClassName, checksum);
+                        directInvocationOwnersByClass.put(
+                                dottedClassName, ambientClassInstrumenter.directInvocationOwners(classfileBuffer));
                     }
                 } catch (RuntimeException ignored) {
                     // Stays uninstrumented, same as any class the instrumenter can't rewrite.
@@ -301,6 +314,13 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
             checksumsByTest
                     .computeIfAbsent(currentTest, ignored -> new ConcurrentHashMap<>())
                     .putIfAbsent(className, checksum);
+            Set<String> directOwners = directInvocationOwnersByClass.get(className);
+            if (directOwners != null && !directOwners.isEmpty()) {
+                directInvocationOwnersByTest
+                        .computeIfAbsent(currentTest, ignored -> new ConcurrentHashMap<>())
+                        .computeIfAbsent(className, ignored -> ConcurrentHashMap.newKeySet())
+                        .addAll(directOwners);
+            }
         }
     }
 
@@ -473,6 +493,15 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
                         Map.Entry::getKey, e -> Map.copyOf(e.getValue())));
     }
 
+    /** Immutable snapshot of {@code test -> executed source class -> direct invocation owners}. */
+    public Map<TestIdentity, Map<String, Set<String>>> directInvocationOwnersByTest() {
+        return directInvocationOwnersByTest.entrySet().stream()
+                .collect(java.util.stream.Collectors.toUnmodifiableMap(
+                        Map.Entry::getKey,
+                        test -> test.getValue().entrySet().stream().collect(java.util.stream.Collectors.toUnmodifiableMap(
+                                Map.Entry::getKey, source -> Set.copyOf(source.getValue())))));
+    }
+
     /** Class names loaded before the first test's tracking window opened in this fork. */
     public Set<String> ambientDependencies() {
         return Set.copyOf(ambientDependencies);
@@ -528,13 +557,25 @@ public final class DependencyTrackingAgent implements ClassFileTransformer {
 
     void unionContainerDependenciesForTests(TestIdentity container, Set<TestIdentity> memberTests) {
         Map<String, String> containerDependencies = checksumsByTest.remove(container);
-        if (containerDependencies == null || containerDependencies.isEmpty()) {
+        Map<String, Set<String>> containerDirectInvocations = directInvocationOwnersByTest.remove(container);
+        boolean hasDependencies = containerDependencies != null && !containerDependencies.isEmpty();
+        boolean hasDirectInvocations = containerDirectInvocations != null && !containerDirectInvocations.isEmpty();
+        if (!hasDependencies && !hasDirectInvocations) {
             return;
         }
         for (TestIdentity test : memberTests) {
-            Map<String, String> testDependencies =
-                    checksumsByTest.computeIfAbsent(test, ignored -> new ConcurrentHashMap<>());
-            containerDependencies.forEach(testDependencies::putIfAbsent);
+            if (hasDependencies) {
+                Map<String, String> testDependencies =
+                        checksumsByTest.computeIfAbsent(test, ignored -> new ConcurrentHashMap<>());
+                containerDependencies.forEach(testDependencies::putIfAbsent);
+            }
+            if (hasDirectInvocations) {
+                Map<String, Set<String>> testDirectInvocations =
+                        directInvocationOwnersByTest.computeIfAbsent(test, ignored -> new ConcurrentHashMap<>());
+                containerDirectInvocations.forEach((source, owners) -> testDirectInvocations
+                        .computeIfAbsent(source, ignored -> ConcurrentHashMap.newKeySet())
+                        .addAll(owners));
+            }
         }
     }
 

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DirectInvocationRecord.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DirectInvocationRecord.java
@@ -1,0 +1,7 @@
+package io.github.baokhang83.blastradius.core.tracking;
+
+import java.util.Map;
+import java.util.Set;
+
+/** One test's executed source classes and their declared direct invocation-owner classes. */
+public record DirectInvocationRecord(TestIdentity test, Map<String, Set<String>> sourceToTargetClasses) {}

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/SelectionEngineTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/SelectionEngineTest.java
@@ -72,6 +72,47 @@ class SelectionEngineTest {
     }
 
     @Test
+    void directInvocationReferenceSelectsOnlyTheTestThatExecutedItsSourceClass() {
+        List<ChangedFile> changed = List.of(new ChangedFile(
+                "src/main/java/com/example/QueryParser.java", FileKind.JAVA_SOURCE, "com.example.QueryParser"));
+
+        List<SelectionDecision> decisions = engine.selectAll(
+                Set.of(MATCHED_TEST, UNRELATED_TEST),
+                Map.of(MATCHED_TEST, Set.of("com.example.Selector"), UNRELATED_TEST, Set.of("com.example.Other")),
+                Map.of(MATCHED_TEST, Map.of("com.example.Selector", Set.of("com.example.QueryParser"))),
+                Set.of(),
+                changed,
+                Set.of());
+
+        SelectionDecision matched = decisions.stream().filter(d -> d.test().equals(MATCHED_TEST)).findFirst().orElseThrow();
+        SelectionDecision unrelated = decisions.stream().filter(d -> d.test().equals(UNRELATED_TEST)).findFirst().orElseThrow();
+
+        assertTrue(matched.selected());
+        assertEquals(SelectionReason.DIRECT_INVOCATION_REFERENCE, matched.reason());
+        assertEquals("com.example.QueryParser", matched.matchedChangedClass());
+        assertEquals("com.example.Selector", matched.directInvocationSourceClass());
+        assertEquals(SelectionReason.NO_MATCH, unrelated.reason());
+    }
+
+    @Test
+    void ordinaryDependencyMatchTakesPrecedenceOverDirectInvocationReference() {
+        List<ChangedFile> changed = List.of(new ChangedFile(
+                "src/main/java/com/example/QueryParser.java", FileKind.JAVA_SOURCE, "com.example.QueryParser"));
+
+        SelectionDecision decision = engine.selectAll(
+                        Set.of(MATCHED_TEST),
+                        Map.of(MATCHED_TEST, Set.of("com.example.QueryParser")),
+                        Map.of(MATCHED_TEST, Map.of("com.example.Selector", Set.of("com.example.QueryParser"))),
+                        Set.of(),
+                        changed,
+                        Set.of())
+                .getFirst();
+
+        assertEquals(SelectionReason.DEPENDENCY_MATCH, decision.reason());
+        assertEquals(null, decision.directInvocationSourceClass());
+    }
+
+    @Test
     void kotlinFileFacadeCandidateContributesToDependencyMatching() {
         List<ChangedFile> changed = List.of(new ChangedFile(
                 "src/main/kotlin/com/example/Greeting.kt", FileKind.JAVA_SOURCE, "com.example.Greeting"));

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenterTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/AmbientClassInstrumenterTest.java
@@ -2,10 +2,12 @@ package io.github.baokhang83.blastradius.core.tracking;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class AmbientClassInstrumenterTest {
@@ -62,6 +64,21 @@ class AmbientClassInstrumenterTest {
 
         assertDoesNotThrow(() -> instrumenter.instrument(
                 FrameMergingNestedType.class.getName(), original, rejectingLoader));
+    }
+
+    @Test
+    void collectsDirectMethodInvocationOwnersFromTheOriginalClass() throws Exception {
+        byte[] original;
+        try (InputStream stream = NestedConstructorArgConstruction.class
+                .getResourceAsStream("AmbientClassInstrumenterTest$NestedConstructorArgConstruction.class")) {
+            assertNotNull(stream, "fixture class bytes must be available as a resource");
+            original = stream.readAllBytes();
+        }
+
+        Set<String> owners = instrumenter.directInvocationOwners(original);
+
+        assertTrue(owners.contains(Wrapper.class.getName()));
+        assertTrue(owners.contains(ArrayList.class.getName()));
     }
 
     static final class Wrapper {

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordIoTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyRecordIoTest.java
@@ -135,4 +135,24 @@ class DependencyRecordIoTest {
         assertFalse(merged.ambientDependencies().contains("com.example.a.FooTest"));
         assertFalse(merged.ambientDependencies().contains("com.example.b.UsesFooTest"));
     }
+
+    @Test
+    void readAllMergesDirectInvocationOwnersAcrossForks(@TempDir Path tempDir) throws Exception {
+        Path base = tempDir.resolve("dependencies.json");
+        TestIdentity fooTest = new TestIdentity("com.example.FooTest", "checksFoo");
+        writer.write(base.resolveSibling(base.getFileName() + ".111"),
+                Map.of(fooTest, Map.of("com.example.Selector", "abc")),
+                Map.of(fooTest, Map.of("com.example.Selector", Set.of("com.example.QueryParser"))),
+                Set.of());
+        writer.write(base.resolveSibling(base.getFileName() + ".222"),
+                Map.of(fooTest, Map.of("com.example.Helper", "def")),
+                Map.of(fooTest, Map.of("com.example.Selector", Set.of("com.example.TokenQueue"))),
+                Set.of());
+
+        DependencyRecordSet merged = reader.readAll(base);
+
+        assertEquals(Set.of("com.example.QueryParser", "com.example.TokenQueue"), merged.directInvocations()
+                .get(fooTest)
+                .get("com.example.Selector"));
+    }
 }

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgentTest.java
@@ -169,6 +169,30 @@ class DependencyTrackingAgentTest {
     }
 
     @Test
+    void executedProjectClassContributesItsDirectInvocationOwnersToTheCurrentTest() throws Exception {
+        currentTest.set(null);
+        byte[] fixtureBytes = classBytes(DirectInvocationFixture.class);
+        String fixtureName = "com.example.DirectInvocationFixture";
+        agent.transform(null, fixtureName.replace('.', '/'), null, productionProtectionDomain(), fixtureBytes);
+
+        Field installedAgentField = DependencyTrackingAgent.class.getDeclaredField("installedAgent");
+        installedAgentField.setAccessible(true);
+        Object previousInstalledAgent = installedAgentField.get(null);
+        installedAgentField.set(null, agent);
+        try {
+            currentTest.set(FOO_TEST);
+            DependencyTrackingAgent.recordAmbientExecution(fixtureName);
+        } finally {
+            installedAgentField.set(null, previousInstalledAgent);
+        }
+
+        assertTrue(agent.directInvocationOwnersByTest()
+                .get(FOO_TEST)
+                .get(fixtureName)
+                .contains(String.class.getName()));
+    }
+
+    @Test
     void differentTestsAreRecordedSeparately() {
         TestIdentity barTest = new TestIdentity("com.example.BarTest", "checksSubtract");
 
@@ -347,10 +371,20 @@ class DependencyTrackingAgentTest {
     }
 
     private static byte[] ownClassBytes() throws Exception {
-        try (InputStream stream = DependencyTrackingAgentTest.class
-                .getResourceAsStream("DependencyTrackingAgentTest.class")) {
+        return classBytes(DependencyTrackingAgentTest.class);
+    }
+
+    private static byte[] classBytes(Class<?> type) throws Exception {
+        String resourceName = type.getName().substring(type.getName().lastIndexOf('.') + 1) + ".class";
+        try (InputStream stream = type.getResourceAsStream(resourceName)) {
             assertTrue(stream != null, "test class bytes must be available as a resource");
             return stream.readAllBytes();
+        }
+    }
+
+    static final class DirectInvocationFixture {
+        static String stringify(int value) {
+            return String.valueOf(value);
         }
     }
 

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ApplySelectionAction.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/ApplySelectionAction.java
@@ -29,13 +29,16 @@ final class ApplySelectionAction implements Action<Task> {
     private final String comparisonBaseCommit;
     private final String headCommit;
     private final ConfiguredIndexStore configuredStore;
+    private final boolean directInvocationFallback;
 
-    ApplySelectionAction(File repositoryDirectory, String indexPathKey, String comparisonBaseCommit, String headCommit, ConfiguredIndexStore configuredStore) {
+    ApplySelectionAction(File repositoryDirectory, String indexPathKey, String comparisonBaseCommit, String headCommit,
+            ConfiguredIndexStore configuredStore, boolean directInvocationFallback) {
         this.repositoryDirectory = repositoryDirectory;
         this.indexPathKey = indexPathKey;
         this.comparisonBaseCommit = comparisonBaseCommit;
         this.headCommit = headCommit;
         this.configuredStore = configuredStore;
+        this.directInvocationFallback = directInvocationFallback;
     }
 
     @Override
@@ -65,7 +68,8 @@ final class ApplySelectionAction implements Action<Task> {
                     test.getClasspath().getFiles(), test.getTestClassesDirs().getFiles());
             List<ChangedFile> changedFiles = new ChangedFileClassifier().classify(
                     repositoryDirectory.toPath(), comparisonBaseCommit, headCommit);
-            List<SelectionDecision> decisions = computeDecisions(allTests, applicability.index(), changedFiles);
+            List<SelectionDecision> decisions = computeDecisions(
+                    allTests, applicability.index(), changedFiles, directInvocationFallback);
             applyFilter(test, decisions);
             test.getLogger().lifecycle("[blastradius] SELECT — {} / {} tests selected", decisions.stream()
                     .filter(SelectionDecision::selected)
@@ -77,6 +81,11 @@ final class ApplySelectionAction implements Action<Task> {
 
     private static List<SelectionDecision> computeDecisions(Set<TestIdentity> allTests, DependencyIndex index,
             List<ChangedFile> changedFiles) {
+        return computeDecisions(allTests, index, changedFiles, true);
+    }
+
+    private static List<SelectionDecision> computeDecisions(Set<TestIdentity> allTests, DependencyIndex index,
+            List<ChangedFile> changedFiles, boolean directInvocationFallback) {
         Map<TestIdentity, Set<String>> dependenciesByTest = index.testDependenciesByTest().entrySet().stream()
                 .collect(Collectors.toMap(
                         entry -> entry.getKey().baselineKey(),
@@ -86,6 +95,11 @@ final class ApplySelectionAction implements Action<Task> {
                             merged.addAll(second);
                             return merged;
                         }));
+        Map<TestIdentity, Map<String, Set<String>>> directInvocationsByTest = index.directInvocationsByTest()
+                .entrySet().stream().collect(Collectors.toMap(
+                        entry -> entry.getKey().baselineKey(),
+                        Map.Entry::getValue,
+                        ApplySelectionAction::mergeDirectInvocations));
         Set<String> changedClassNames = changedFiles.stream()
                 .flatMap(file -> file.candidateClassNames().stream())
                 .collect(Collectors.toUnmodifiableSet());
@@ -94,7 +108,19 @@ final class ApplySelectionAction implements Action<Task> {
                         test, !dependenciesByTest.containsKey(test.baselineKey()), changedClassNames))
                 .collect(Collectors.toSet());
         return new SelectionEngine().selectAll(
-                allTests, dependenciesByTest, newOrModifiedTests, changedFiles, Set.of());
+                allTests, dependenciesByTest, directInvocationFallback ? directInvocationsByTest : Map.of(), newOrModifiedTests,
+                changedFiles, index.ambientDependencies());
+    }
+
+    private static Map<String, Set<String>> mergeDirectInvocations(
+            Map<String, Set<String>> first, Map<String, Set<String>> second) {
+        Map<String, Set<String>> merged = new java.util.HashMap<>(first);
+        second.forEach((source, targets) -> merged.merge(source, targets, (left, right) -> {
+            Set<String> union = new java.util.HashSet<>(left);
+            union.addAll(right);
+            return Set.copyOf(union);
+        }));
+        return Map.copyOf(merged);
     }
 
     private static void applyFilter(Test test, List<SelectionDecision> decisions) {

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusExtension.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusExtension.java
@@ -11,6 +11,9 @@ public abstract class BlastradiusExtension {
     /** Root-relative index-file template; each resolved commit receives its own key. */
     public abstract Property<String> getIndexPath();
 
+    /** Controls the enabled-by-default one-hop direct-invocation fallback in format-3 indexes. */
+    public abstract Property<Boolean> getDirectInvocationFallback();
+
     /** Selects the local file store or the shared S3-compatible store. */
     public abstract Property<String> getIndexStore();
 

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusPlugin.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusPlugin.java
@@ -17,6 +17,7 @@ public final class BlastradiusPlugin implements Plugin<Project> {
         BlastradiusExtension extension = project.getExtensions()
                 .create("blastradius", BlastradiusExtension.class);
         extension.getIndexPath().convention(".blastradius/index.json");
+        extension.getDirectInvocationFallback().convention(true);
         extension.getIndexStore().convention("file");
         extension.getS3Prefix().convention("");
 
@@ -34,15 +35,17 @@ public final class BlastradiusPlugin implements Plugin<Project> {
                     extension.getS3Prefix().get(), extension.getS3Region().getOrNull(), extension.getS3Endpoint().getOrNull());
 
             project.getTasks().withType(Test.class).configureEach(test -> configureTest(
-                    project, test, repositoryDirectory, indexPathKey, resolvedGitState, extension.getBaseRef().get(), indexStore));
+                    project, test, repositoryDirectory, indexPathKey, resolvedGitState, extension.getBaseRef().get(),
+                    indexStore, extension));
         }));
     }
 
     private static void configureTest(Project project, Test test, Path repositoryDirectory, String indexPathKey, GitBuildState gitState,
-            String baseReference, ConfiguredIndexStore indexStore) {
+            String baseReference, ConfiguredIndexStore indexStore, BlastradiusExtension extension) {
         test.getInputs().property("blastradius.baseReference", baseReference);
         test.getInputs().property("blastradius.headCommit", gitState.headCommit());
         test.getInputs().property("blastradius.baseReferenceCommit", gitState.baseReferenceCommit());
+        test.getInputs().property("blastradius.directInvocationFallback", extension.getDirectInvocationFallback());
 
         if (gitState.baseReferenceBuild()) {
             configureTracking(test, repositoryDirectory, indexPathKey, gitState.headCommit(), indexStore);
@@ -57,7 +60,8 @@ public final class BlastradiusPlugin implements Plugin<Project> {
                     .files(project.files(baselineIndexPath.toFile()).filter(File::isFile))
                     .withPathSensitivity(PathSensitivity.RELATIVE);
             test.doFirst(new ApplySelectionAction(
-                    repositoryDirectory.toFile(), indexPathKey, comparisonBase, gitState.headCommit(), indexStore));
+                    repositoryDirectory.toFile(), indexPathKey, comparisonBase, gitState.headCommit(), indexStore,
+                    extension.getDirectInvocationFallback().get()));
         }
         
     }

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/DependencyIndex.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/DependencyIndex.java
@@ -7,21 +7,41 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-record DependencyIndex(int formatVersion, String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies) {
+record DependencyIndex(int formatVersion, String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies,
+        List<TestDirectInvocationEntry> directInvocations, Set<String> ambientDependencies) {
 
     DependencyIndex {
         formatVersion = DependencyIndexFormat.migrateLegacyVersion(formatVersion);
+        directInvocations = directInvocations == null ? List.of() : List.copyOf(directInvocations);
+        ambientDependencies = ambientDependencies == null ? Set.of() : Set.copyOf(ambientDependencies);
     }
 
     DependencyIndex(String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies) {
-        this(DependencyIndexFormat.CURRENT_VERSION, anchorCommit, builtAt, testDependencies);
+        this(anchorCommit, builtAt, testDependencies, List.of(), Set.of());
+    }
+
+    DependencyIndex(int formatVersion, String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies) {
+        this(formatVersion, anchorCommit, builtAt, testDependencies, List.of(), Set.of());
+    }
+
+    DependencyIndex(String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies,
+            List<TestDirectInvocationEntry> directInvocations, Set<String> ambientDependencies) {
+        this(DependencyIndexFormat.CURRENT_VERSION, anchorCommit, builtAt,
+                testDependencies, directInvocations, ambientDependencies);
     }
 
     record TestDependencyEntry(TestIdentity test, Set<String> dependsOnClasses) {}
 
+    record TestDirectInvocationEntry(TestIdentity test, Map<String, Set<String>> sourceToTargetClasses) {}
+
     Map<TestIdentity, Set<String>> testDependenciesByTest() {
         return testDependencies.stream()
                 .collect(Collectors.toUnmodifiableMap(TestDependencyEntry::test, TestDependencyEntry::dependsOnClasses));
+    }
+
+    Map<TestIdentity, Map<String, Set<String>>> directInvocationsByTest() {
+        return directInvocations.stream().collect(Collectors.toUnmodifiableMap(
+                TestDirectInvocationEntry::test, TestDirectInvocationEntry::sourceToTargetClasses));
     }
 
     boolean hasCurrentFormat() {

--- a/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/WriteTrackingIndexAction.java
+++ b/blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/WriteTrackingIndexAction.java
@@ -36,11 +36,15 @@ final class WriteTrackingIndexAction implements Action<Task> {
             List<DependencyIndex.TestDependencyEntry> entries = recorded.tests().entrySet().stream()
                     .map(entry -> new DependencyIndex.TestDependencyEntry(entry.getKey(), entry.getValue().keySet()))
                     .toList();
+            List<DependencyIndex.TestDirectInvocationEntry> directInvocations = recorded.directInvocations().entrySet().stream()
+                    .map(entry -> new DependencyIndex.TestDirectInvocationEntry(entry.getKey(), entry.getValue()))
+                    .toList();
             Path repositoryRoot = repositoryDirectory.toPath().toAbsolutePath().normalize();
             String indexKey = CommitIndexKey.forCommit(indexPathKey, anchorCommit);
             IndexStore<DependencyIndex> store = configuredStore.create(repositoryDirectory);
             try {
-                store.put(indexKey, new DependencyIndex(anchorCommit, Instant.now().toString(), entries));
+                store.put(indexKey, new DependencyIndex(
+                        anchorCommit, Instant.now().toString(), entries, directInvocations, recorded.ambientDependencies()));
             } finally {
                 ConfiguredIndexStore.close(store);
             }

--- a/blastradius-gradle-plugin/src/test/java/io/github/baokhang83/blastradius/gradle/BlastradiusPluginFunctionalTest.java
+++ b/blastradius-gradle-plugin/src/test/java/io/github/baokhang83/blastradius/gradle/BlastradiusPluginFunctionalTest.java
@@ -80,6 +80,49 @@ class BlastradiusPluginFunctionalTest {
     }
 
     @Test
+    void selectsAnExecutedSourceClassForItsChangedDirectInvocationTarget() throws Exception {
+        writeProject();
+        write("src/main/java/example/Selector.java", """
+                package example;
+                public final class Selector {
+                    public int selectCached() { return 1; }
+                    public int parseOnCacheMiss() { return QueryParser.parse(); }
+                }
+                """);
+        write("src/main/java/example/QueryParser.java",
+                "package example; public final class QueryParser { public static int parse() { return 1; } }\n");
+        write("src/test/java/example/SelectorTest.java", """
+                package example;
+
+                import java.nio.file.Files;
+                import java.nio.file.Path;
+                import org.junit.jupiter.api.Test;
+
+                class SelectorTest {
+                    @Test
+                    void selectsQuery() throws Exception {
+                        new Selector().selectCached();
+                        Files.writeString(Path.of("build/selector-ran"), "ran");
+                    }
+                }
+        """);
+        String baselineCommit = commitBaseline();
+        BuildResult trackResult = runGradle("clean", "test");
+        assertTrue(trackResult.getOutput().contains("[blastradius] TRACK — 3 / 3 tests selected"), trackResult.getOutput());
+        Files.deleteIfExists(projectDir.resolve("build/foo-ran"));
+        Files.deleteIfExists(projectDir.resolve("build/bar-ran"));
+        Files.deleteIfExists(projectDir.resolve("build/selector-ran"));
+        changeQueryParser();
+
+        BuildResult result = runGradle("clean", "test");
+
+        assertTrue(result.getOutput().contains("[blastradius] SELECT — 1 / 3 tests selected"), result.getOutput());
+        assertTrue(Files.exists(projectDir.resolve("build/selector-ran")));
+        assertFalse(Files.exists(projectDir.resolve("build/foo-ran")));
+        assertFalse(Files.exists(projectDir.resolve("build/bar-ran")));
+    }
+
+    @Test
     void selectsAgainstTheMergeBaseWhenMainAdvancesAfterTheFeatureBranches() throws Exception {
         writeProject();
         String branchPoint = commitBaseline();
@@ -204,6 +247,16 @@ class BlastradiusPluginFunctionalTest {
         }
     }
 
+    private void changeQueryParser() throws Exception {
+        write("src/main/java/example/QueryParser.java",
+                "package example; public final class QueryParser { public static int parse() { return 2; } }\n");
+        try (Git git = Git.open(projectDir.toFile())) {
+            git.checkout().setCreateBranch(true).setName("feature").call();
+            git.add().addFilepattern("src/main/java/example/QueryParser.java").call();
+            git.commit().setMessage("change query parser").setAuthor("fixture", "fixture@example.invalid").call();
+        }
+    }
+
     private void advanceMainWithBarChange() throws Exception {
         try (Git git = Git.open(projectDir.toFile())) {
             git.checkout().setName("main").call();
@@ -219,6 +272,7 @@ class BlastradiusPluginFunctionalTest {
     private void writeIndex(String baselineCommit) throws IOException {
         write(CommitIndexKey.forCommit(".blastradius/index.json", baselineCommit), """
                 {
+                  "formatVersion": 3,
                   "anchorCommit": "%s",
                   "builtAt": "2026-07-20T00:00:00Z",
                   "testDependencies": [

--- a/blastradius-maven-plugin/README.md
+++ b/blastradius-maven-plugin/README.md
@@ -109,6 +109,7 @@ separate page for each goal, including `help-mojo.html` and `select-mojo.html`.
 | `s3Endpoint` | `-Ds3Endpoint` | — | no | Optional S3-compatible endpoint, for example MinIO. Path-style access is enabled when supplied. |
 | — | `-Dblastradius.mode=track` | — | no | Force `TRACK` regardless of what commit you're on — for explicitly pre-warming the index outside an ordinary trunk build. |
 | — | `-Dblastradius.explain=true` | `false` | no | Print the full per-test decision listing to the console, not just the aggregate summary. |
+| — | `-Dblastradius.directInvocationFallback=false` | `true` | no | Disable the enabled-by-default one-hop fallback for a project class a test executed that directly invokes a changed class. It can conservatively select an extra test and reports both classes with `blastradius.explain`. |
 
 `indexPath` is one shared index namespace for the whole reactor (see
 [Multi-module reactors](#multi-module-reactors)) — configure it once at the root; every

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/DependencyIndex.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/index/DependencyIndex.java
@@ -19,16 +19,30 @@ import java.util.stream.Collectors;
  * DependencyMatchSelector} logic only ever consumes class names.
  */
 public record DependencyIndex(int formatVersion, String anchorCommit, String builtAt,
-        List<TestDependencyEntry> testDependencies, Set<String> ambientDependencies) {
+        List<TestDependencyEntry> testDependencies, List<TestDirectInvocationEntry> directInvocations,
+        Set<String> ambientDependencies) {
 
     public DependencyIndex {
         formatVersion = DependencyIndexFormat.migrateLegacyVersion(formatVersion);
+        directInvocations = directInvocations == null ? List.of() : List.copyOf(directInvocations);
         ambientDependencies = ambientDependencies == null ? Set.of() : Set.copyOf(ambientDependencies);
     }
 
     public DependencyIndex(String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies,
             Set<String> ambientDependencies) {
-        this(DependencyIndexFormat.CURRENT_VERSION, anchorCommit, builtAt, testDependencies, ambientDependencies);
+        this(anchorCommit, builtAt, testDependencies, List.of(), ambientDependencies);
+    }
+
+    /** Compatibility constructor for callers deliberately exercising an older format. */
+    public DependencyIndex(int formatVersion, String anchorCommit, String builtAt,
+            List<TestDependencyEntry> testDependencies, Set<String> ambientDependencies) {
+        this(formatVersion, anchorCommit, builtAt, testDependencies, List.of(), ambientDependencies);
+    }
+
+    public DependencyIndex(String anchorCommit, String builtAt, List<TestDependencyEntry> testDependencies,
+            List<TestDirectInvocationEntry> directInvocations, Set<String> ambientDependencies) {
+        this(DependencyIndexFormat.CURRENT_VERSION, anchorCommit, builtAt,
+                testDependencies, directInvocations, ambientDependencies);
     }
 
     /** Convenience for callers that don't populate {@code ambientDependencies} (mostly tests). */
@@ -38,10 +52,19 @@ public record DependencyIndex(int formatVersion, String anchorCommit, String bui
 
     public record TestDependencyEntry(TestIdentity test, Set<String> dependsOnClasses) {}
 
+    /** A test's dynamically-executed source classes and their declared direct target classes. */
+    public record TestDirectInvocationEntry(TestIdentity test, Map<String, Set<String>> sourceToTargetClasses) {}
+
     /** {@code testDependencies}, reshaped into the map form the selection engine consumes. */
     public Map<TestIdentity, Set<String>> testDependenciesByTest() {
         return testDependencies.stream()
                 .collect(Collectors.toUnmodifiableMap(TestDependencyEntry::test, TestDependencyEntry::dependsOnClasses));
+    }
+
+    /** Direct references reshaped into the map form the selection engine consumes. */
+    public Map<TestIdentity, Map<String, Set<String>>> directInvocationsByTest() {
+        return directInvocations.stream().collect(Collectors.toUnmodifiableMap(
+                TestDirectInvocationEntry::test, TestDirectInvocationEntry::sourceToTargetClasses));
     }
 
     public boolean hasCurrentFormat() {

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
@@ -85,6 +85,10 @@ public final class SelectMojo extends AbstractMojo {
     @Parameter(property = "blastradius.explain", defaultValue = "false")
     private boolean explain;
 
+    /** Controls the enabled-by-default, one-hop static fallback recorded by format-3 indexes (issue #225). */
+    @Parameter(property = "blastradius.directInvocationFallback", defaultValue = "true")
+    private boolean directInvocationFallback;
+
     /**
      * Set only by {@link TrackRunner}, on the {@code mvn} subprocess it forks against this
      * same project directory to gather instrumented dependency data. That subprocess's pom
@@ -319,7 +323,8 @@ public final class SelectMojo extends AbstractMojo {
             Map<TestIdentity, Long> durationsByTest) throws MojoExecutionException {
         try {
             Set<TestIdentity> allTests = discoverProjectTests();
-            List<SelectionDecision> decisions = computeDecisions(allTests, applicability.index(), changes.changedFiles());
+            List<SelectionDecision> decisions = computeDecisions(
+                    allTests, applicability.index(), changes.changedFiles(), directInvocationFallback);
             Set<TestIdentity> selectedTests = decisions.stream()
                     .filter(SelectionDecision::selected)
                     .map(SelectionDecision::test)
@@ -380,6 +385,11 @@ public final class SelectMojo extends AbstractMojo {
      */
     static List<SelectionDecision> computeDecisions(Set<TestIdentity> allTests, DependencyIndex index,
             List<ChangedFile> changedFiles) {
+        return computeDecisions(allTests, index, changedFiles, true);
+    }
+
+    static List<SelectionDecision> computeDecisions(Set<TestIdentity> allTests, DependencyIndex index,
+            List<ChangedFile> changedFiles, boolean directInvocationFallback) {
         Map<TestIdentity, Set<String>> testDependencies = index.testDependenciesByTest().entrySet().stream()
                 .collect(Collectors.toMap(
                         entry -> entry.getKey().baselineKey(),
@@ -389,6 +399,12 @@ public final class SelectMojo extends AbstractMojo {
                             union.addAll(b);
                             return union;
                         }));
+
+        Map<TestIdentity, Map<String, Set<String>>> directInvocations = index.directInvocationsByTest().entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> entry.getKey().baselineKey(),
+                        Map.Entry::getValue,
+                        SelectMojo::mergeDirectInvocations));
 
         Set<String> changedClassNames = changedFiles.stream()
                 .flatMap(file -> file.candidateClassNames().stream())
@@ -400,6 +416,18 @@ public final class SelectMojo extends AbstractMojo {
                 .collect(Collectors.toSet());
 
         return SELECTION_ENGINE.selectAll(
-                allTests, testDependencies, newOrModifiedTests, changedFiles, index.ambientDependencies());
+                allTests, testDependencies, directInvocationFallback ? directInvocations : Map.of(), newOrModifiedTests,
+                changedFiles, index.ambientDependencies());
+    }
+
+    private static Map<String, Set<String>> mergeDirectInvocations(
+            Map<String, Set<String>> first, Map<String, Set<String>> second) {
+        Map<String, Set<String>> merged = new java.util.HashMap<>(first);
+        second.forEach((source, targets) -> merged.merge(source, targets, (left, right) -> {
+            Set<String> union = new java.util.HashSet<>(left);
+            union.addAll(right);
+            return Set.copyOf(union);
+        }));
+        return Map.copyOf(merged);
     }
 }

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/ExplainListingRenderer.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/ExplainListingRenderer.java
@@ -25,7 +25,10 @@ public final class ExplainListingRenderer {
         String matched = decision.matchedChangedClass() == null
                 ? ""
                 : " matchedChangedClass=" + decision.matchedChangedClass();
-        return "[blastradius]   " + testLabel(decision) + " — " + status + " reason=" + decision.reason() + matched;
+        String source = decision.directInvocationSourceClass() == null
+                ? ""
+                : " directInvocationSourceClass=" + decision.directInvocationSourceClass();
+        return "[blastradius]   " + testLabel(decision) + " — " + status + " reason=" + decision.reason() + matched + source;
     }
 
     private static String testLabel(SelectionDecision decision) {

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/track/TrackRunner.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/track/TrackRunner.java
@@ -6,6 +6,7 @@ import io.github.baokhang83.blastradius.core.tracking.DependencyRecordSet;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex.TestDependencyEntry;
+import io.github.baokhang83.blastradius.plugin.index.DependencyIndex.TestDirectInvocationEntry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
@@ -72,7 +73,11 @@ public final class TrackRunner {
         List<TestDependencyEntry> entries = recorded.tests().entrySet().stream()
                 .map(entry -> new TestDependencyEntry(entry.getKey(), entry.getValue().keySet()))
                 .toList();
-        return new DependencyIndex(anchorCommit, Instant.now().toString(), entries, recorded.ambientDependencies());
+        List<TestDirectInvocationEntry> directInvocations = recorded.directInvocations().entrySet().stream()
+                .map(entry -> new TestDirectInvocationEntry(entry.getKey(), entry.getValue()))
+                .toList();
+        return new DependencyIndex(
+                anchorCommit, Instant.now().toString(), entries, directInvocations, recorded.ambientDependencies());
     }
 
     /**

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/DependencyIndexIoTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/index/DependencyIndexIoTest.java
@@ -8,9 +8,11 @@ import io.github.baokhang83.blastradius.core.index.FileIndexStore;
 import io.github.baokhang83.blastradius.core.index.IndexStore;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex.TestDependencyEntry;
+import io.github.baokhang83.blastradius.plugin.index.DependencyIndex.TestDirectInvocationEntry;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -59,6 +61,24 @@ class DependencyIndexIoTest {
 
         assertEquals(Set.of("com.example.Foo"), byTest.get(fooTest));
         assertEquals(Set.of("com.example.Bar"), byTest.get(barTest));
+    }
+
+    @Test
+    void directInvocationsRoundTripAndRemainKeyedByTestIdentity(@TempDir Path tempDir) {
+        IndexStore<DependencyIndex> store = new FileIndexStore<>(tempDir, DependencyIndex.class);
+        TestIdentity selectorTest = new TestIdentity("com.example.SelectorTest", "parsesQuery");
+        DependencyIndex original = new DependencyIndex(
+                "a1b2c3d", "2026-07-09T10:03:00Z", List.of(),
+                List.of(new TestDirectInvocationEntry(
+                        selectorTest, Map.of("com.example.Selector", Set.of("com.example.QueryParser")))), Set.of());
+
+        store.put("direct.json", original);
+        DependencyIndex roundTripped = store.get("direct.json").orElseThrow();
+
+        assertEquals(original, roundTripped);
+        assertEquals(Set.of("com.example.QueryParser"), roundTripped.directInvocationsByTest()
+                .get(selectorTest)
+                .get("com.example.Selector"));
     }
 
     @Test

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/EndToEndTestSupport.java
@@ -10,6 +10,7 @@ import io.github.baokhang83.blastradius.core.tracking.DependencyRecordReader;
 import io.github.baokhang83.blastradius.core.tracking.DependencyRecordSet;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex.TestDependencyEntry;
+import io.github.baokhang83.blastradius.plugin.index.DependencyIndex.TestDirectInvocationEntry;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -204,7 +205,11 @@ final class EndToEndTestSupport {
         List<TestDependencyEntry> entries = recorded.tests().entrySet().stream()
                 .map(e -> new TestDependencyEntry(e.getKey(), e.getValue().keySet()))
                 .toList();
-        return new DependencyIndex(anchorCommit, Instant.now().toString(), entries, recorded.ambientDependencies());
+        List<TestDirectInvocationEntry> directInvocations = recorded.directInvocations().entrySet().stream()
+                .map(e -> new TestDirectInvocationEntry(e.getKey(), e.getValue()))
+                .toList();
+        return new DependencyIndex(
+                anchorCommit, Instant.now().toString(), entries, directInvocations, recorded.ambientDependencies());
     }
 
     static void writeIndex(Path projectDir, DependencyIndex index) {

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeSelectionTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectModeSelectionTest.java
@@ -11,7 +11,9 @@ import io.github.baokhang83.blastradius.core.selection.SelectionReason;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex;
 import io.github.baokhang83.blastradius.plugin.index.DependencyIndex.TestDependencyEntry;
+import io.github.baokhang83.blastradius.plugin.index.DependencyIndex.TestDirectInvocationEntry;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -66,5 +68,25 @@ class SelectModeSelectionTest {
         assertEquals(1, decisions.size());
         assertFalse(decisions.get(0).selected());
         assertEquals(SelectionReason.NO_MATCH, decisions.get(0).reason());
+    }
+
+    @Test
+    void selectsAnExecutedSourceClassWithAChangedDirectInvocationTarget() {
+        TestIdentity selectorTest = new TestIdentity("com.example.SelectorTest", "parsesQuery");
+        DependencyIndex index = new DependencyIndex("abc123", "2026-07-09T10:00:00Z",
+                List.of(new TestDependencyEntry(selectorTest, Set.of("com.example.Selector"))),
+                List.of(new TestDirectInvocationEntry(
+                        selectorTest, Map.of("com.example.Selector", Set.of("com.example.QueryParser")))),
+                Set.of());
+        List<ChangedFile> changedFiles = List.of(new ChangedFile(
+                "src/main/java/com/example/QueryParser.java", FileKind.JAVA_SOURCE, "com.example.QueryParser"));
+
+        SelectionDecision defaultDecision = SelectMojo.computeDecisions(Set.of(selectorTest), index, changedFiles).getFirst();
+        SelectionDecision disabledDecision = SelectMojo.computeDecisions(Set.of(selectorTest), index, changedFiles, false).getFirst();
+
+        assertEquals(SelectionReason.DIRECT_INVOCATION_REFERENCE, defaultDecision.reason());
+        assertEquals(SelectionReason.NO_MATCH, disabledDecision.reason());
+        assertEquals("com.example.Selector", defaultDecision.directInvocationSourceClass());
+        assertEquals("com.example.QueryParser", defaultDecision.matchedChangedClass());
     }
 }

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/ExplainListingRendererTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/ExplainListingRendererTest.java
@@ -46,4 +46,19 @@ class ExplainListingRendererTest {
 
         assertEquals(List.of(), renderer.render(report));
     }
+
+    @Test
+    void listsTheExecutedSourceForADirectInvocationReference() {
+        TestIdentity matched = new TestIdentity("com.example.SelectorTest", "selectsCachedQuery");
+        BuildReport report = BuildReport.forSelect(
+                IndexApplicability.applicable(new DependencyIndex("abc123", "2026-07-09T10:00:00Z", List.of())),
+                List.of(SelectionDecision.directInvocationReference(
+                        matched, "com.example.Selector", "com.example.QueryParser")));
+
+        String line = renderer.render(report).getFirst();
+
+        assertTrue(line.contains("DIRECT_INVOCATION_REFERENCE"));
+        assertTrue(line.contains("matchedChangedClass=com.example.QueryParser"));
+        assertTrue(line.contains("directInvocationSourceClass=com.example.Selector"));
+    }
 }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/selection/PairSelectionAnalyzer.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/selection/PairSelectionAnalyzer.java
@@ -13,6 +13,8 @@ import io.github.baokhang83.blastradius.validator.git.CommitPair;
 import io.github.baokhang83.blastradius.validator.verdict.FlakyFailure;
 import io.github.baokhang83.blastradius.validator.verdict.WouldMissComparator;
 import java.util.List;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -42,6 +44,8 @@ public final class PairSelectionAnalyzer {
                             union.addAll(right);
                             return union;
                         }));
+        Map<TestIdentity, Map<String, Set<String>>> directInvocations = mergeDirectInvocations(
+                baselineDependencies.directInvocations());
         Set<String> changedClassNames = edge.changedFiles().stream()
                 .flatMap(file -> file.candidateClassNames().stream())
                 .collect(Collectors.toUnmodifiableSet());
@@ -53,7 +57,7 @@ public final class PairSelectionAnalyzer {
                         test, !testDependencies.containsKey(test.baselineKey()), changedClassNames))
                 .collect(Collectors.toSet());
         List<SelectionDecision> decisions = selectionEngine.selectAll(
-                allTests, testDependencies, newOrModifiedTests, edge.changedFiles(),
+                allTests, testDependencies, directInvocations, newOrModifiedTests, edge.changedFiles(),
                 baselineDependencies.ambientDependencies(), reactorScope);
         List<FlakyFailure> flakyFailures = headOutcomes.stream()
                 .filter(result -> result.outcome() == Outcome.FLAKY)
@@ -61,5 +65,20 @@ public final class PairSelectionAnalyzer {
                 .toList();
         return new PairSelectionResult(
                 decisions, wouldMissComparator.compare(edge, decisions, headOutcomes, baselineOutcomes), flakyFailures);
+    }
+
+    private static Map<TestIdentity, Map<String, Set<String>>> mergeDirectInvocations(
+            Map<TestIdentity, Map<String, Set<String>>> directInvocations) {
+        Map<TestIdentity, Map<String, Set<String>>> merged = new HashMap<>();
+        directInvocations.forEach((test, sourceToTargets) -> {
+            Map<String, Set<String>> targetsBySource = merged.computeIfAbsent(test.baselineKey(), ignored -> new HashMap<>());
+            sourceToTargets.forEach((source, targets) -> targetsBySource
+                    .computeIfAbsent(source, ignored -> new HashSet<>())
+                    .addAll(targets));
+        });
+        return merged.entrySet().stream().collect(Collectors.toUnmodifiableMap(
+                Map.Entry::getKey,
+                entry -> entry.getValue().entrySet().stream().collect(Collectors.toUnmodifiableMap(
+                        Map.Entry::getKey, target -> Set.copyOf(target.getValue())))));
     }
 }

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/selection/PairSelectionAnalyzerTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/selection/PairSelectionAnalyzerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.baokhang83.blastradius.core.git.ChangedFile;
 import io.github.baokhang83.blastradius.core.git.FileKind;
+import io.github.baokhang83.blastradius.core.selection.SelectionReason;
 import io.github.baokhang83.blastradius.core.tracking.DependencyRecordSet;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import io.github.baokhang83.blastradius.validator.build.GroundTruthResult;
@@ -36,6 +37,25 @@ class PairSelectionAnalyzerTest {
         assertTrue(result.decisions().getFirst().selected());
         assertEquals(1, result.failureComparison().coverage().newlyConfirmedFailingTests());
         assertEquals(1, result.failureComparison().coverage().selectedNewlyConfirmedFailures());
+        assertTrue(result.failureComparison().wouldMissCases().isEmpty());
+    }
+
+    @Test
+    void selectsAChangedDirectInvocationTargetByDefault() {
+        TestIdentity test = new TestIdentity("com.example.SelectorTest", "usesCachedQuery");
+        List<ChangedFile> changedFiles = List.of(new ChangedFile(
+                "src/main/java/com/example/QueryParser.java", FileKind.JAVA_SOURCE, "com.example.QueryParser"));
+        DependencyRecordSet baseline = new DependencyRecordSet(
+                Map.of(test, Map.of("com.example.Selector", "checksum")),
+                Map.of(test, Map.of("com.example.Selector", Set.of("com.example.QueryParser"))), Set.of());
+        CommitPair edge = CommitPair.analyzed("base", "head", changedFiles);
+
+        PairSelectionResult result = analyzer.analyze(
+                edge, baseline,
+                List.of(new GroundTruthResult(test, Outcome.PASSED)),
+                List.of(new GroundTruthResult(test, Outcome.CONFIRMED_FAILED)), null);
+
+        assertEquals(SelectionReason.DIRECT_INVOCATION_REFERENCE, result.decisions().getFirst().reason());
         assertTrue(result.failureComparison().wouldMissCases().isEmpty());
     }
 }

--- a/docs/fluencyloop/README.md
+++ b/docs/fluencyloop/README.md
@@ -12,9 +12,11 @@ _None yet._
 
 | feature | plan | status | started |
 |---------|------|--------|---------|
+| [--help](features/048-help/design.md) | - | in progress | 2026-08-05 |
 | [core: attribute @BeforeAll-loaded classes to their container's tests](features/219-core-attribute-beforeall-loaded-classes-to-their-contain/design.md) | - | shipped | 2026-08-05 |
-| [decide whether to mitigate string-dispatched cached dependency blind spots](features/220-decide-whether-to-mitigate-string-dispatched-cached-depe/design.md) | - | in progress | 2026-08-05 |
+| [decide whether to mitigate string-dispatched cached dependency blind spots](features/220-decide-whether-to-mitigate-string-dispatched-cached-depe/design.md) | - | shipped | 2026-08-05 |
 | [attribute @AfterAll and inter-test lifecycle dependencies to test containers](features/221-attribute-afterall-and-inter-test-lifecycle-dependencies/design.md) | - | shipped | 2026-08-05 |
+| [prototype direct invocation-reference fallback for cached dependencies](features/225-prototype-direct-invocation-reference-fallback-for-cache/design.md) | - | shipped | 2026-08-05 |
 | [Abstract the index store behind an interface (#25)](features/abstract-the-index-store-behind-an-interface-25/design.md) | - | shipped | 2026-07-20 |
 | [Add explicit flaky-test exclusions to validator target builds](features/add-explicit-flaky-test-exclusions-to-validator-target-build/design.md) | - | shipped | 2026-08-02 |
 | [Add opt-in, bounded mutation-based validator soundness validation for issue 187](features/add-opt-in-bounded-mutation-based-validator-soundness-valida/design.md) | - | shipped | 2026-08-01 |

--- a/docs/fluencyloop/features/225-prototype-direct-invocation-reference-fallback-for-cache/design.md
+++ b/docs/fluencyloop/features/225-prototype-direct-invocation-reference-fallback-for-cache/design.md
@@ -1,0 +1,107 @@
+# Design: prototype direct invocation-reference fallback for cached dependencies
+
+started: 2026-08-05
+branch: feature/225-prototype-direct-invocation-reference-fallback-for-cache
+
+## Scope
+
+The prototype covers the shared tracking protocol and both Maven and Gradle index formats. It
+does not add a transitive call graph or a generic cache hook. The one-hop fallback is enabled by
+default for fresh format-3 indexes. Older indexes
+remain ineligible after the format bump and therefore use the existing full-suite fallback.
+
+## Class diagram
+
+```mermaid
+classDiagram
+    class AmbientClassInstrumenter {
+        +instrument(classBytes)
+        +directInvocationOwners()
+    }
+    class DependencyTrackingAgent {
+        +recordAmbientExecution(sourceClass)
+        +directInvocationsByTest()
+    }
+    class DependencyRecordFile {
+        +tests
+        +directInvocations
+        +ambientDependencies
+    }
+    class DependencyIndex {
+        +testDependencies
+        +directInvocations
+        +formatVersion 3
+    }
+    class SelectionEngine {
+        +selectAll()
+    }
+    class SelectionDecision {
+        +DIRECT_INVOCATION_REFERENCE
+        +sourceClass
+        +matchedChangedClass
+    }
+    AmbientClassInstrumenter --> DependencyTrackingAgent : static direct owners per source class
+    DependencyTrackingAgent --> DependencyRecordFile : writes per-test source to target refs
+    DependencyRecordFile --> DependencyIndex : Maven and Gradle persist refs
+    DependencyIndex --> SelectionEngine : baseline direct refs
+    SelectionEngine --> SelectionDecision : explicit fallback reason
+```
+
+## Sequence: track, persist, and select a cached dependency
+
+```mermaid
+sequenceDiagram
+    participant Agent as Tracking agent
+    participant Instrumenter as ASM instrumenter
+    participant Record as Fork record
+    participant Index as Persisted index
+    participant Selector as Selection engine
+
+    Agent->>Instrumenter: transform executed project class
+    Instrumenter-->>Agent: direct invocation owners for source class
+    Agent->>Agent: test executes source class
+    Agent->>Record: store source class to direct target refs
+    Record->>Index: merge and persist format 3
+    Selector->>Index: read direct refs and changed class
+    Selector-->>Selector: select when source has changed direct target
+    Selector-->>Selector: report source class and changed target
+```
+
+## Design decisions
+
+- **Collect static references at transform time, attribute only at runtime:** ASM records each
+  project class's declared direct method-invocation owners once while transforming it. The agent
+  adds those references to a test only when that source class actually executes under the test's
+  current identity. This retains the dynamic tracker as the gate and avoids per-invocation hooks.
+- **Persist source and target, not only target:** a `test → source class → direct target classes`
+  shape lets selection explain why it over-selected a test. Flattening to target classes would
+  lose the executed source that made the fallback trustworthy enough to audit.
+- **Separate format safety from the default selection policy:** format 3 carries the metadata and
+  rejects older indexes safely. Fresh indexes enable the one-hop rule by default; Maven and Gradle
+  each retain an explicit `false` setting for baseline comparisons and emergency rollback.
+- **Keep one-hop precedence below ordinary dependency matching:** direct dynamic matches retain
+  their existing reason. The fallback runs only when no direct dependency intersects the changed
+  class, after broad fallback and new-or-modified-test rules have kept their current precedence.
+
+## Acceptance checks
+
+1. Unit tests prove a direct owner is recorded for an executed project class and never attributed
+   merely because the class was transformed.
+2. Core selection tests show that a changed direct target selects only the matching test with both
+   source and target in its reason.
+3. Maven and Gradle index round trips preserve the metadata and reject pre-format-3 indexes.
+4. The jsoup `QueryParser` replay reports recovered killing tests and selection expansion under
+   the default policy.
+
+## Constitution check
+
+- **I. Test-driven development:** add failing tracker, selection, and index compatibility tests
+  before each implementation slice.
+- **II. Simplicity:** retain a single-hop data shape and avoid a general call graph abstraction.
+- **III. Safety over speed:** the rule can only select extra tests, and an unreadable index stays
+  on the existing full-suite fallback path.
+- **IV. Deterministic core before ML:** all edges and reasons derive deterministically from class
+  bytecode and recorded test execution.
+- **V. Explainability:** the decision carries both the executed source and changed target.
+- **VIII. No avoidable work on the hot path:** extract references during existing transformation,
+  then use in-memory maps at method entry without filesystem work.

--- a/docs/fluencyloop/features/225-prototype-direct-invocation-reference-fallback-for-cache/sessions/001-track-and-select-bounded-direct-invocation-references.md
+++ b/docs/fluencyloop/features/225-prototype-direct-invocation-reference-fallback-for-cache/sessions/001-track-and-select-bounded-direct-invocation-references.md
@@ -1,0 +1,35 @@
+# Session: track and select bounded direct invocation references
+
+- **intent:** track and select bounded direct invocation references
+- **started:** 2026-08-05
+
+## Knowledge transfer
+
+- **Runtime gate and static expansion:** direct invocation owners are extracted from a project
+  class's bytecode during the existing transform, but are added to a test only when the class
+  executes while that test identity is active. This preserves dynamic observation as the entry
+  condition while covering a skipped cache-miss branch. **Status:** implemented.
+- **Auditable one-hop selection:** the index retains `test → executed source → direct targets`.
+  A direct-reference selection therefore carries both the source and changed target, while an
+  ordinary dynamic dependency match retains precedence. **Status:** implemented.
+- **Index compatibility:** direct references require format 3. Older persisted indexes are not
+  considered current and keep the established full-suite fallback behavior. **Status:**
+  implemented.
+
+## Decision: gate one-hop static references behind dynamic execution
+
+- **where:** `blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/tracking/DependencyTrackingAgent.java and blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionEngine.java`
+- **why:** Static direct owners are only associated after their source class executes for a test, preserving a bounded explainable expansion that covers cached branches without claiming transitive reachability.
+- **alternative:** A whole-program call graph or per-invocation instrumentation — rejected: both broaden analysis or miss a cache-hit branch while adding more hot-path work.
+- **design:** ../design.md#design-decisions
+- **constitution:** §II, §III, §IV, §V, §VIII
+- **trust:** ✓ verified
+
+## Decision: enable the bounded fallback by default
+
+- **where:** `blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java and blastradius-gradle-plugin/src/main/java/io/github/baokhang83/blastradius/gradle/BlastradiusPlugin.java`
+- **why:** The user chose the conservative, explainable one-hop safety net as the normal product policy; format-3 compatibility still keeps older indexes on the existing safe fallback path.
+- **alternative:** Default the rule off until a replay completes — rejected: that would leave the known cached-dispatch gap unprotected despite an explicit user decision to prefer safe over-selection.
+- **design:** ../design.md#design-decisions
+- **constitution:** §III, §IV, §V
+- **trust:** ✓ verified


### PR DESCRIPTION
Closes #225

## Summary

- persist one-hop direct method-owner references only for project classes a test actually executed
- select changed direct targets by default in Maven, Gradle, and validator replay, with source and target in explain output
- bump indexes to format 3; older indexes retain the existing safe fallback behavior
- add core, Maven, Gradle functional, and validator coverage

## Follow-up

#227 will run the jsoup QueryParser replay after merge and publish recovered-killer and selection-expansion evidence in the README.

## Verification

- `mvn -pl blastradius-core -Dtest=SelectionEngineTest,AmbientClassInstrumenterTest,DependencyTrackingAgentTest,DependencyRecordIoTest test`
- `mvn -pl blastradius-maven-plugin -am -Dtest=DependencyIndexIoTest,SelectModeSelectionTest,ExplainListingRendererTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./gradlew :blastradius-gradle-plugin:test`
- `mvn -f blastradius-validator/pom.xml test`