### PR TITLE
test: stage Maven invoker tracking artifact

### DIFF
--- a/blastradius-maven-plugin/src/it/isolation/prebuild.groovy
+++ b/blastradius-maven-plugin/src/it/isolation/prebuild.groovy
@@ -1,4 +1,5 @@
 def root = new File(basedir.toString())
+def stagedRepository = new File(root.parentFile.parentFile, "it-repo").absolutePath
 def run = { List<String> command ->
     def process = new ProcessBuilder(command).directory(root).redirectErrorStream(true).start()
     def output = process.inputStream.getText("UTF-8")
@@ -13,7 +14,8 @@ run(["git", "config", "user.name", "Blastradius fixture"])
 run(["git", "add", "."])
 run(["git", "commit", "-m", "baseline"])
 run(["git", "tag", "baseline"])
-run(["mvn", "-B", "--no-transfer-progress", "-Dblastradius.mode=track", "clean", "test"])
+run(["mvn", "-B", "--no-transfer-progress", "-Dmaven.repo.local=${stagedRepository}".toString(),
+        "-Dblastradius.mode=track", "clean", "test"])
 
 new File(root, "src/main/java/example/Foo.java").setText("""package example;
 

--- a/blastradius-maven-plugin/src/it/select/prebuild.groovy
+++ b/blastradius-maven-plugin/src/it/select/prebuild.groovy
@@ -1,4 +1,5 @@
 def root = new File(basedir.toString())
+def stagedRepository = new File(root.parentFile.parentFile, "it-repo").absolutePath
 def run = { List<String> command ->
     def process = new ProcessBuilder(command).directory(root).redirectErrorStream(true).start()
     def output = process.inputStream.getText("UTF-8")
@@ -15,7 +16,8 @@ run(["git", "add", "."])
 run(["git", "commit", "-m", "baseline"])
 run(["git", "tag", "baseline"])
 def baselineCommit = run(["git", "rev-parse", "HEAD"]).trim()
-run(["mvn", "-B", "--no-transfer-progress", "-Dblastradius.mode=track", "clean", "test"])
+run(["mvn", "-B", "--no-transfer-progress", "-Dmaven.repo.local=${stagedRepository}".toString(),
+        "-Dblastradius.mode=track", "clean", "test"])
 
 new File(root, "src/main/java/example/Foo.java").setText("""package example;
 


### PR DESCRIPTION
## Summary

Run the `select` and `isolation` invoker prebuild tracking commands against the staged plugin-under-test repository. They previously resolved an older local plugin artifact and wrote format-2 indexes, which the merged format-3 plugin correctly rejected.

## Verification

`mvn -pl blastradius-maven-plugin -am clean verify`

The regenerated select and isolation fixtures each reported `SELECT` with a format-3 index.