### PR TITLE
fix: preserve direct invocation evidence in validator cache

### DIFF
--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/BuildCache.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/build/BuildCache.java
@@ -3,6 +3,7 @@ package io.github.baokhang83.blastradius.validator.build;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.baokhang83.blastradius.core.tracking.DependencyRecord;
 import io.github.baokhang83.blastradius.core.tracking.DependencyRecordSet;
+import io.github.baokhang83.blastradius.core.tracking.DirectInvocationRecord;
 import io.github.baokhang83.blastradius.validator.build.CommitBuildService.BuildKey;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -44,6 +45,13 @@ import java.util.stream.Collectors;
  * the tracking agent, clear the cache directory first.
  */
 public final class BuildCache {
+
+    /**
+     * Bump whenever the cached {@link DependencyRecordSet} representation changes. Keeping this
+     * in the filename makes entries from an older representation an automatic cache miss instead
+     * of letting selection run with incomplete dependency evidence.
+     */
+    private static final int FORMAT_VERSION = 2;
 
     private final Path directory;
     private final ObjectMapper mapper = new ObjectMapper();
@@ -106,7 +114,8 @@ public final class BuildCache {
     }
 
     private Path fileFor(BuildKey key) {
-        return directory.resolve(key.sha() + (key.agentAttached() ? "-agent" : "-noagent") + ".json");
+        return directory.resolve(key.sha() + (key.agentAttached() ? "-agent" : "-noagent")
+                + "-v" + FORMAT_VERSION + ".json");
     }
 
     private static CachedBuild toDto(CommitBuild build) {
@@ -117,9 +126,15 @@ public final class BuildCache {
                         .map(e -> new DependencyRecord(e.getKey(), e.getValue()))
                         .toList()
                 : null;
+        List<DirectInvocationRecord> directInvocations = hasDependencies
+                ? set.directInvocations().entrySet().stream()
+                        .map(e -> new DirectInvocationRecord(e.getKey(), e.getValue()))
+                        .toList()
+                : null;
         Set<String> ambient = hasDependencies ? set.ambientDependencies() : null;
         return new CachedBuild(
-                build.failed(), build.failureReason(), hasDependencies, dependencies, ambient, build.groundTruth());
+                build.failed(), build.failureReason(), hasDependencies, dependencies, directInvocations, ambient,
+                build.groundTruth());
     }
 
     private static CommitBuild fromDto(CachedBuild dto) {
@@ -128,6 +143,12 @@ public final class BuildCache {
                         dto.dependencies().stream()
                                 .collect(Collectors.toUnmodifiableMap(
                                         DependencyRecord::test, DependencyRecord::dependencies)),
+                        dto.directInvocations() == null
+                                ? Map.of()
+                                : dto.directInvocations().stream()
+                                        .collect(Collectors.toUnmodifiableMap(
+                                                DirectInvocationRecord::test,
+                                                DirectInvocationRecord::sourceToTargetClasses)),
                         dto.ambientDependencies())
                 : null;
         List<GroundTruthResult> groundTruth = dto.groundTruth() == null ? List.of() : dto.groundTruth();
@@ -136,8 +157,9 @@ public final class BuildCache {
 
     /**
      * On-disk shape of a cached build. The per-test dependency map is flattened to a
-     * {@code List<DependencyRecord>} — as {@link io.github.baokhang83.blastradius.core.tracking.DependencyRecordReader}
-     * does — because its {@link io.github.baokhang83.blastradius.core.tracking.TestIdentity} key can't be a JSON
+     * {@code List<DependencyRecord>} / {@code List<DirectInvocationRecord>} — as
+     * {@link io.github.baokhang83.blastradius.core.tracking.DependencyRecordReader} does — because
+     * its {@link io.github.baokhang83.blastradius.core.tracking.TestIdentity} key can't be a JSON
      * object key without a custom Jackson key serializer. {@code hasDependencies} distinguishes an
      * agent-free ground-truth build (null {@link DependencyRecordSet}) from an agent build that
      * merely recorded no tests (empty set).
@@ -147,6 +169,7 @@ public final class BuildCache {
             String failureReason,
             boolean hasDependencies,
             List<DependencyRecord> dependencies,
+            List<DirectInvocationRecord> directInvocations,
             Set<String> ambientDependencies,
             List<GroundTruthResult> groundTruth) {}
 }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCache.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCache.java
@@ -53,10 +53,14 @@ import java.util.Optional;
  * would poison every later resume. Mirrors {@code BuildCache}'s "only successful builds" stance.
  *
  * <p><b>Cache validity is the operator's responsibility</b>, exactly as for {@code BuildCache}: the
- * key fingerprints neither the target repository nor this tool's version. Point the run at a
- * different repository or upgrade the tracking agent and you must clear the cache directory first.
+ * key fingerprints neither the target repository nor this tool's version. A cache-schema revision
+ * is included for selection changes that affect the recorded selected/skipped verdict; otherwise,
+ * point the run at a different repository or upgrade the tracking agent and clear the cache first.
  */
 public final class MutationCache {
+
+    /** Bump whenever a change to selection can alter an experiment's selected/skipped verdict. */
+    private static final String SELECTION_CACHE_VERSION = "selection-v2-direct-invocations";
 
     private final Path directory;
     private final SkippedTests skippedTests;
@@ -132,7 +136,7 @@ public final class MutationCache {
      */
     private Path fileFor(CommitPair pair, MutationCandidate candidate) {
         String identity = String.join("\0",
-                pair.baseCommit(), pair.headCommit(), candidate.sourcePath(),
+                SELECTION_CACHE_VERSION, pair.baseCommit(), pair.headCommit(), candidate.sourcePath(),
                 Integer.toString(candidate.offset()), candidate.operator().name(),
                 candidate.original(), candidate.replacement(),
                 String.join(",", skippedTests.classes()));

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/BuildCacheTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/build/BuildCacheTest.java
@@ -21,11 +21,12 @@ import org.junit.jupiter.api.io.TempDir;
 class BuildCacheTest {
 
     @Test
-    void storesAndLoadsAnAgentBuildRoundTrippingDependenciesAndGroundTruth(@TempDir Path dir) {
+    void storesAndLoadsAnAgentBuildRoundTrippingAllDependencyEvidenceAndGroundTruth(@TempDir Path dir) {
         BuildCache cache = new BuildCache(dir.resolve("cache"));
         TestIdentity fooTest = new TestIdentity("com.example.FooTest", "passes");
         DependencyRecordSet deps = new DependencyRecordSet(
                 Map.of(fooTest, Map.of("com.example.Foo", "abc123")),
+                Map.of(fooTest, Map.of("com.example.Foo", Set.of("com.example.Bar"))),
                 Set.of("com.example.Ambient"));
         CommitBuild original = CommitBuild.succeeded(
                 deps, List.of(new GroundTruthResult(fooTest, Outcome.PASSED)));
@@ -37,6 +38,7 @@ class BuildCacheTest {
         CommitBuild loaded = cache.load(key).orElseThrow();
         assertFalse(loaded.failed());
         assertEquals(deps.tests(), loaded.dependencyRecordSet().tests());
+        assertEquals(deps.directInvocations(), loaded.dependencyRecordSet().directInvocations());
         assertEquals(deps.ambientDependencies(), loaded.dependencyRecordSet().ambientDependencies());
         assertEquals(1, loaded.groundTruth().size());
         assertEquals(fooTest, loaded.groundTruth().get(0).test());
@@ -79,6 +81,18 @@ class BuildCacheTest {
     }
 
     @Test
+    void ignoresEntriesFromThePreviousCacheFormat(@TempDir Path dir) throws Exception {
+        Path cacheDir = dir.resolve("cache");
+        Files.createDirectories(cacheDir);
+        Files.writeString(cacheDir.resolve("legacy-agent.json"), "{\"old\":true}");
+
+        BuildCache cache = new BuildCache(cacheDir);
+
+        assertFalse(cache.contains(new BuildKey("legacy", true)));
+        assertEquals(Optional.empty(), cache.load(new BuildKey("legacy", true)));
+    }
+
+    @Test
     void aCorruptCacheFileIsTreatedAsAMissSoTheRunCanRebuild(@TempDir Path dir) throws Exception {
         Path cacheDir = dir.resolve("cache");
         BuildCache cache = new BuildCache(cacheDir);
@@ -86,7 +100,7 @@ class BuildCacheTest {
         cache.store(key, CommitBuild.succeeded(new DependencyRecordSet(Map.of(), Set.of()), List.of()));
 
         // Simulate a crash mid-write despite the atomic move: overwrite with garbage.
-        Files.writeString(cacheDir.resolve("truncated-agent.json"), "{ this is not valid json");
+        Files.writeString(cacheDir.resolve("truncated-agent-v2.json"), "{ this is not valid json");
 
         // A corrupt entry must not crash the run — it reads as a miss so the caller rebuilds.
         assertEquals(Optional.empty(), cache.load(key));


### PR DESCRIPTION
## Summary
- persist direct-invocation records in the validator build cache
- version build and mutation cache entries so pre-fix selection evidence is never reused
- cover direct-invocation cache round-trip and legacy-cache invalidation

## Verification
- `mvn -pl blastradius-validator -am verify`

Fixes #227