### PR TITLE
fix: select two-hop direct invocation paths

### DIFF
--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/DirectInvocationReferenceSelector.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/DirectInvocationReferenceSelector.java
@@ -4,19 +4,37 @@ import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import java.util.Map;
 import java.util.Set;
 
-/** Selects a test when one of its dynamically-executed classes directly references a changed class. */
+/**
+ * Selects a test when one of its dynamically-executed classes reaches a changed class in one or
+ * two recorded static invocation edges.
+ */
 final class DirectInvocationReferenceSelector {
 
     SelectionDecision select(TestIdentity test, Map<String, Set<String>> directInvocationOwners,
-            Set<String> changedClassNames) {
+            Map<String, Set<String>> invocationGraph, Set<String> changedClassNames) {
         for (Map.Entry<String, Set<String>> source : directInvocationOwners.entrySet()) {
             for (String changedClassName : changedClassNames) {
-                if (source.getValue().contains(changedClassName)
-                        || source.getValue().stream().anyMatch(owner -> owner.startsWith(changedClassName + "$"))) {
+                if (referencesChangedClass(source.getValue(), changedClassName)) {
                     return SelectionDecision.directInvocationReference(test, source.getKey(), changedClassName);
                 }
             }
         }
+        for (Map.Entry<String, Set<String>> source : directInvocationOwners.entrySet()) {
+            for (String intermediateClass : source.getValue()) {
+                Set<String> targets = invocationGraph.getOrDefault(intermediateClass, Set.of());
+                for (String changedClassName : changedClassNames) {
+                    if (referencesChangedClass(targets, changedClassName)) {
+                        return SelectionDecision.transitiveDirectInvocationReference(
+                                test, source.getKey(), intermediateClass, changedClassName);
+                    }
+                }
+            }
+        }
         return SelectionDecision.noMatch(test);
+    }
+
+    private static boolean referencesChangedClass(Set<String> targets, String changedClassName) {
+        return targets.contains(changedClassName)
+                || targets.stream().anyMatch(target -> target.startsWith(changedClassName + "$"));
     }
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionDecision.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionDecision.java
@@ -11,28 +11,50 @@ import java.util.Objects;
  * @param selected             whether it was selected
  * @param reason               the reason (see {@link SelectionReason})
  * @param matchedChangedClass  the specific changed class responsible, only present when
- *                             {@code reason == DEPENDENCY_MATCH || reason == DIRECT_INVOCATION_REFERENCE}
+ *                             {@code reason == DEPENDENCY_MATCH || reason == DIRECT_INVOCATION_REFERENCE ||
+ *                             reason == TRANSITIVE_DIRECT_INVOCATION_REFERENCE}
  * @param directInvocationSourceClass the executed class that declared the direct invocation,
- *                                    only present for {@code DIRECT_INVOCATION_REFERENCE}
+ *                                    only present for a direct-invocation reason
+ * @param directInvocationIntermediateClass the intermediate invocation target, only present for
+ *                                          {@code TRANSITIVE_DIRECT_INVOCATION_REFERENCE}
  */
 public record SelectionDecision(
         TestIdentity test, boolean selected, SelectionReason reason, String matchedChangedClass,
-        String directInvocationSourceClass) {
+        String directInvocationSourceClass, String directInvocationIntermediateClass) {
 
     /** Preserves callers that do not carry a direct-invocation source. */
     public SelectionDecision(TestIdentity test, boolean selected, SelectionReason reason, String matchedChangedClass) {
-        this(test, selected, reason, matchedChangedClass, null);
+        this(test, selected, reason, matchedChangedClass, null, null);
+    }
+
+    /** Preserves callers that carry a one-hop direct-invocation source. */
+    public SelectionDecision(
+            TestIdentity test, boolean selected, SelectionReason reason, String matchedChangedClass,
+            String directInvocationSourceClass) {
+        this(test, selected, reason, matchedChangedClass, directInvocationSourceClass, null);
     }
 
     public SelectionDecision {
         Objects.requireNonNull(test, "test");
         Objects.requireNonNull(reason, "reason");
-        if (reason == SelectionReason.DEPENDENCY_MATCH || reason == SelectionReason.DIRECT_INVOCATION_REFERENCE) {
+        if (reason == SelectionReason.DEPENDENCY_MATCH
+                || reason == SelectionReason.DIRECT_INVOCATION_REFERENCE
+                || reason == SelectionReason.TRANSITIVE_DIRECT_INVOCATION_REFERENCE) {
             Objects.requireNonNull(matchedChangedClass, "matchedChangedClass required for DEPENDENCY_MATCH");
         }
-        if (reason == SelectionReason.DIRECT_INVOCATION_REFERENCE) {
+        if (reason == SelectionReason.DIRECT_INVOCATION_REFERENCE
+                || reason == SelectionReason.TRANSITIVE_DIRECT_INVOCATION_REFERENCE) {
             Objects.requireNonNull(directInvocationSourceClass,
-                    "directInvocationSourceClass required for DIRECT_INVOCATION_REFERENCE");
+                    "directInvocationSourceClass required for a direct-invocation reason");
+        }
+        if (reason == SelectionReason.DIRECT_INVOCATION_REFERENCE
+                && directInvocationIntermediateClass != null) {
+            throw new IllegalArgumentException(
+                    "directInvocationIntermediateClass is only valid for a transitive direct-invocation reason");
+        }
+        if (reason == SelectionReason.TRANSITIVE_DIRECT_INVOCATION_REFERENCE) {
+            Objects.requireNonNull(directInvocationIntermediateClass,
+                    "directInvocationIntermediateClass required for TRANSITIVE_DIRECT_INVOCATION_REFERENCE");
         }
         boolean expectedSelected = reason != SelectionReason.NO_MATCH;
         if (selected != expectedSelected) {
@@ -41,31 +63,38 @@ public record SelectionDecision(
     }
 
     public static SelectionDecision dependencyMatch(TestIdentity test, String matchedChangedClass) {
-        return new SelectionDecision(test, true, SelectionReason.DEPENDENCY_MATCH, matchedChangedClass, null);
+        return new SelectionDecision(test, true, SelectionReason.DEPENDENCY_MATCH, matchedChangedClass, null, null);
     }
 
     public static SelectionDecision directInvocationReference(
             TestIdentity test, String sourceClass, String matchedChangedClass) {
-        return new SelectionDecision(test, true, SelectionReason.DIRECT_INVOCATION_REFERENCE, matchedChangedClass, sourceClass);
+        return new SelectionDecision(
+                test, true, SelectionReason.DIRECT_INVOCATION_REFERENCE, matchedChangedClass, sourceClass, null);
+    }
+
+    public static SelectionDecision transitiveDirectInvocationReference(
+            TestIdentity test, String sourceClass, String intermediateClass, String matchedChangedClass) {
+        return new SelectionDecision(test, true, SelectionReason.TRANSITIVE_DIRECT_INVOCATION_REFERENCE,
+                matchedChangedClass, sourceClass, intermediateClass);
     }
 
     public static SelectionDecision fallback(TestIdentity test) {
-        return new SelectionDecision(test, true, SelectionReason.FALLBACK_NON_SOURCE_CHANGE, null, null);
+        return new SelectionDecision(test, true, SelectionReason.FALLBACK_NON_SOURCE_CHANGE, null, null, null);
     }
 
     public static SelectionDecision fallbackAmbientDependency(TestIdentity test) {
-        return new SelectionDecision(test, true, SelectionReason.FALLBACK_AMBIENT_DEPENDENCY, null, null);
+        return new SelectionDecision(test, true, SelectionReason.FALLBACK_AMBIENT_DEPENDENCY, null, null, null);
     }
 
     public static SelectionDecision fallbackNonSourceDependentModule(TestIdentity test) {
-        return new SelectionDecision(test, true, SelectionReason.FALLBACK_NON_SOURCE_DEPENDENT_MODULE, null, null);
+        return new SelectionDecision(test, true, SelectionReason.FALLBACK_NON_SOURCE_DEPENDENT_MODULE, null, null, null);
     }
 
     public static SelectionDecision newOrModifiedTest(TestIdentity test) {
-        return new SelectionDecision(test, true, SelectionReason.NEW_OR_MODIFIED_TEST, null, null);
+        return new SelectionDecision(test, true, SelectionReason.NEW_OR_MODIFIED_TEST, null, null, null);
     }
 
     public static SelectionDecision noMatch(TestIdentity test) {
-        return new SelectionDecision(test, false, SelectionReason.NO_MATCH, null, null);
+        return new SelectionDecision(test, false, SelectionReason.NO_MATCH, null, null, null);
     }
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionEngine.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionEngine.java
@@ -4,6 +4,8 @@ import io.github.baokhang83.blastradius.core.git.ChangedFile;
 import io.github.baokhang83.blastradius.core.reactor.ReactorScope;
 import io.github.baokhang83.blastradius.core.tracking.TestIdentity;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,7 +45,7 @@ public final class SelectionEngine {
         return selectAll(allTests, testDependencies, Map.of(), newOrModifiedTests, changedFiles, ambientDependencies, null);
     }
 
-    /** As {@link #selectAll(Set, Map, Set, List, Set)}, with optional one-hop direct references. */
+    /** As {@link #selectAll(Set, Map, Set, List, Set)}, with optional bounded direct references. */
     public List<SelectionDecision> selectAll(
             Set<TestIdentity> allTests,
             Map<TestIdentity, Set<String>> testDependencies,
@@ -72,7 +74,7 @@ public final class SelectionEngine {
                 ambientDependencies, reactorScope);
     }
 
-    /** As the reactor-aware overload, with optional one-hop direct references. */
+    /** As the reactor-aware overload, with optional bounded direct references. */
     public List<SelectionDecision> selectAll(
             Set<TestIdentity> allTests,
             Map<TestIdentity, Set<String>> testDependencies,
@@ -103,6 +105,7 @@ public final class SelectionEngine {
         }
 
         ReactorScope affectedScope = scopedFallback ? reactorScope.forChanges(changedFiles) : null;
+        Map<String, Set<String>> invocationGraph = invocationGraph(directInvocationOwnersByTest);
 
         List<SelectionDecision> decisions = new ArrayList<>();
         for (TestIdentity test : allTests) {
@@ -121,8 +124,21 @@ public final class SelectionEngine {
                 continue;
             }
             decisions.add(directInvocationReferenceSelector.select(
-                    test, directInvocationOwnersByTest.getOrDefault(test.baselineKey(), Map.of()), changedClassNames));
+                    test, directInvocationOwnersByTest.getOrDefault(test.baselineKey(), Map.of()),
+                    invocationGraph, changedClassNames));
         }
         return decisions;
+    }
+
+    /**
+     * Builds a suite-wide static invocation graph from the per-test records. The first edge of a
+     * transitive match remains test-specific; only the intermediate-to-changed edge is shared.
+     */
+    private static Map<String, Set<String>> invocationGraph(
+            Map<TestIdentity, Map<String, Set<String>>> directInvocationOwnersByTest) {
+        Map<String, Set<String>> graph = new HashMap<>();
+        directInvocationOwnersByTest.values().forEach(sources -> sources.forEach((source, targets) ->
+                graph.computeIfAbsent(source, ignored -> new HashSet<>()).addAll(targets)));
+        return graph;
     }
 }

--- a/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionReason.java
+++ b/blastradius-core/src/main/java/io/github/baokhang83/blastradius/core/selection/SelectionReason.java
@@ -10,6 +10,13 @@ public enum SelectionReason {
      * but always names both the executed source and changed target (issue #225).
      */
     DIRECT_INVOCATION_REFERENCE,
+    /**
+     * A class the test demonstrably executed invokes an intermediate class which, according to
+     * recorded static invocation data, directly invokes a changed class. This deliberately stops
+     * after those two edges: it closes the observed {@code source -> intermediate -> changed}
+     * gap without turning the fallback into an unbounded call-graph traversal (issue #227).
+     */
+    TRANSITIVE_DIRECT_INVOCATION_REFERENCE,
     /** A non-Java-source change forced selection of every test (FR-006). */
     FALLBACK_NON_SOURCE_CHANGE,
     /**

--- a/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/SelectionEngineTest.java
+++ b/blastradius-core/src/test/java/io/github/baokhang83/blastradius/core/selection/SelectionEngineTest.java
@@ -95,6 +95,79 @@ class SelectionEngineTest {
     }
 
     @Test
+    void transitiveDirectInvocationReferenceSelectsARecordedTwoHopPath() {
+        TestIdentity graphProvider = new TestIdentity("com.example.GraphProviderTest", "loadsSelector");
+        List<ChangedFile> changed = List.of(new ChangedFile(
+                "src/main/java/com/example/QueryParser.java", FileKind.JAVA_SOURCE, "com.example.QueryParser"));
+
+        List<SelectionDecision> decisions = engine.selectAll(
+                Set.of(MATCHED_TEST, graphProvider),
+                Map.of(MATCHED_TEST, Set.of("com.example.DataUtil"), graphProvider, Set.of("com.example.Selector")),
+                Map.of(
+                        MATCHED_TEST, Map.of("com.example.DataUtil", Set.of("com.example.Selector")),
+                        graphProvider, Map.of("com.example.Selector", Set.of("com.example.QueryParser"))),
+                Set.of(),
+                changed,
+                Set.of());
+
+        SelectionDecision matched = decisions.stream().filter(d -> d.test().equals(MATCHED_TEST)).findFirst().orElseThrow();
+
+        assertTrue(matched.selected());
+        assertEquals(SelectionReason.TRANSITIVE_DIRECT_INVOCATION_REFERENCE, matched.reason());
+        assertEquals("com.example.QueryParser", matched.matchedChangedClass());
+        assertEquals("com.example.DataUtil", matched.directInvocationSourceClass());
+        assertEquals("com.example.Selector", matched.directInvocationIntermediateClass());
+    }
+
+    @Test
+    void transitiveDirectInvocationReferenceDoesNotTraverseBeyondTwoHops() {
+        TestIdentity firstProvider = new TestIdentity("com.example.FirstProviderTest", "loadsHelper");
+        TestIdentity secondProvider = new TestIdentity("com.example.SecondProviderTest", "loadsQueryParser");
+        List<ChangedFile> changed = List.of(new ChangedFile(
+                "src/main/java/com/example/QueryParser.java", FileKind.JAVA_SOURCE, "com.example.QueryParser"));
+
+        List<SelectionDecision> decisions = engine.selectAll(
+                Set.of(MATCHED_TEST, firstProvider, secondProvider),
+                Map.of(),
+                Map.of(
+                        MATCHED_TEST, Map.of("com.example.DataUtil", Set.of("com.example.Selector")),
+                        firstProvider, Map.of("com.example.Selector", Set.of("com.example.Helper")),
+                        secondProvider, Map.of("com.example.Helper", Set.of("com.example.QueryParser"))),
+                Set.of(),
+                changed,
+                Set.of());
+
+        SelectionDecision matched = decisions.stream().filter(d -> d.test().equals(MATCHED_TEST)).findFirst().orElseThrow();
+
+        assertEquals(SelectionReason.NO_MATCH, matched.reason());
+    }
+
+    @Test
+    void directInvocationReferenceTakesPrecedenceOverATwoHopReference() {
+        TestIdentity graphProvider = new TestIdentity("com.example.GraphProviderTest", "loadsSelector");
+        List<ChangedFile> changed = List.of(new ChangedFile(
+                "src/main/java/com/example/QueryParser.java", FileKind.JAVA_SOURCE, "com.example.QueryParser"));
+
+        SelectionDecision decision = engine.selectAll(
+                        Set.of(MATCHED_TEST, graphProvider),
+                        Map.of(),
+                        Map.of(
+                                MATCHED_TEST, Map.of("com.example.DataUtil", Set.of(
+                                        "com.example.Selector", "com.example.QueryParser")),
+                                graphProvider, Map.of("com.example.Selector", Set.of("com.example.QueryParser"))),
+                        Set.of(),
+                        changed,
+                        Set.of())
+                .stream()
+                .filter(candidate -> candidate.test().equals(MATCHED_TEST))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(SelectionReason.DIRECT_INVOCATION_REFERENCE, decision.reason());
+        assertEquals(null, decision.directInvocationIntermediateClass());
+    }
+
+    @Test
     void ordinaryDependencyMatchTakesPrecedenceOverDirectInvocationReference() {
         List<ChangedFile> changed = List.of(new ChangedFile(
                 "src/main/java/com/example/QueryParser.java", FileKind.JAVA_SOURCE, "com.example.QueryParser"));
@@ -110,6 +183,7 @@ class SelectionEngineTest {
 
         assertEquals(SelectionReason.DEPENDENCY_MATCH, decision.reason());
         assertEquals(null, decision.directInvocationSourceClass());
+        assertEquals(null, decision.directInvocationIntermediateClass());
     }
 
     @Test

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/ExplainListingRenderer.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/report/ExplainListingRenderer.java
@@ -28,7 +28,11 @@ public final class ExplainListingRenderer {
         String source = decision.directInvocationSourceClass() == null
                 ? ""
                 : " directInvocationSourceClass=" + decision.directInvocationSourceClass();
-        return "[blastradius]   " + testLabel(decision) + " — " + status + " reason=" + decision.reason() + matched + source;
+        String intermediate = decision.directInvocationIntermediateClass() == null
+                ? ""
+                : " directInvocationIntermediateClass=" + decision.directInvocationIntermediateClass();
+        return "[blastradius]   " + testLabel(decision) + " — " + status + " reason=" + decision.reason()
+                + matched + source + intermediate;
     }
 
     private static String testLabel(SelectionDecision decision) {

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/ExplainListingRendererTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/report/ExplainListingRendererTest.java
@@ -61,4 +61,20 @@ class ExplainListingRendererTest {
         assertTrue(line.contains("matchedChangedClass=com.example.QueryParser"));
         assertTrue(line.contains("directInvocationSourceClass=com.example.Selector"));
     }
+
+    @Test
+    void listsTheIntermediateClassForATransitiveDirectInvocationReference() {
+        TestIdentity matched = new TestIdentity("com.example.DataUtilTest", "loadsSelector");
+        BuildReport report = BuildReport.forSelect(
+                IndexApplicability.applicable(new DependencyIndex("abc123", "2026-07-09T10:00:00Z", List.of())),
+                List.of(SelectionDecision.transitiveDirectInvocationReference(
+                        matched, "com.example.DataUtil", "com.example.Selector", "com.example.QueryParser")));
+
+        String line = renderer.render(report).getFirst();
+
+        assertTrue(line.contains("TRANSITIVE_DIRECT_INVOCATION_REFERENCE"));
+        assertTrue(line.contains("matchedChangedClass=com.example.QueryParser"));
+        assertTrue(line.contains("directInvocationSourceClass=com.example.DataUtil"));
+        assertTrue(line.contains("directInvocationIntermediateClass=com.example.Selector"));
+    }
 }

--- a/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCache.java
+++ b/blastradius-validator/src/main/java/io/github/baokhang83/blastradius/validator/mutation/MutationCache.java
@@ -60,7 +60,7 @@ import java.util.Optional;
 public final class MutationCache {
 
     /** Bump whenever a change to selection can alter an experiment's selected/skipped verdict. */
-    private static final String SELECTION_CACHE_VERSION = "selection-v2-direct-invocations";
+    private static final String SELECTION_CACHE_VERSION = "selection-v3-two-hop-direct-invocations";
 
     private final Path directory;
     private final SkippedTests skippedTests;

--- a/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/selection/PairSelectionAnalyzerTest.java
+++ b/blastradius-validator/src/test/java/io/github/baokhang83/blastradius/validator/selection/PairSelectionAnalyzerTest.java
@@ -58,4 +58,26 @@ class PairSelectionAnalyzerTest {
         assertEquals(SelectionReason.DIRECT_INVOCATION_REFERENCE, result.decisions().getFirst().reason());
         assertTrue(result.failureComparison().wouldMissCases().isEmpty());
     }
+
+    @Test
+    void selectsAChangedTwoHopDirectInvocationTargetByDefault() {
+        TestIdentity test = new TestIdentity("com.example.DataUtilTest", "loadsSelector");
+        TestIdentity graphProvider = new TestIdentity("com.example.SelectorTest", "loadsQueryParser");
+        List<ChangedFile> changedFiles = List.of(new ChangedFile(
+                "src/main/java/com/example/QueryParser.java", FileKind.JAVA_SOURCE, "com.example.QueryParser"));
+        DependencyRecordSet baseline = new DependencyRecordSet(
+                Map.of(test, Map.of("com.example.DataUtil", "checksum"),
+                        graphProvider, Map.of("com.example.Selector", "checksum")),
+                Map.of(test, Map.of("com.example.DataUtil", Set.of("com.example.Selector")),
+                        graphProvider, Map.of("com.example.Selector", Set.of("com.example.QueryParser"))), Set.of());
+        CommitPair edge = CommitPair.analyzed("base", "head", changedFiles);
+
+        PairSelectionResult result = analyzer.analyze(
+                edge, baseline,
+                List.of(new GroundTruthResult(test, Outcome.PASSED)),
+                List.of(new GroundTruthResult(test, Outcome.CONFIRMED_FAILED)), null);
+
+        assertEquals(SelectionReason.TRANSITIVE_DIRECT_INVOCATION_REFERENCE, result.decisions().getFirst().reason());
+        assertTrue(result.failureComparison().wouldMissCases().isEmpty());
+    }
 }


### PR DESCRIPTION
## Summary
- select tests through a bounded two-hop static invocation path
- explain the executed source, intermediate class, and changed target
- invalidate mutation selection cache entries from the one-hop rule

## Validation
- `mvn -B --no-transfer-progress -pl blastradius-validator,blastradius-maven-plugin -am verify`
- `./gradlew :blastradius-gradle-plugin:test`

Closes #227