### PR TITLE
build: install cache warmer extension

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+    <!-- Loaded before Maven reads the reactor. The extension safely no-ops unless
+         blastradius-maven-plugin is declared for the build. -->
+    <extension>
+        <groupId>io.github.baokhang83.blastradius</groupId>
+        <artifactId>blastradius-cache-warmer-maven-extension</artifactId>
+        <version>0.3.4</version>
+    </extension>
+</extensions>


### PR DESCRIPTION
Installs io.github.baokhang83.blastradius:blastradius-cache-warmer-maven-extension:0.3.4 through the project-local Maven core-extension configuration.

The extension is loaded before Maven reads the reactor and safely no-ops unless the Blastradius Maven plugin is configured. Verified with mvn -B --no-transfer-progress validate.