### PR TITLE
Upgrade cache warmer to 0.3.5

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,6 +5,6 @@
     <extension>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-cache-warmer-maven-extension</artifactId>
-        <version>0.3.4</version>
+        <version>0.3.5</version>
     </extension>
 </extensions>


### PR DESCRIPTION
## Summary
- Install the released cache-warmer 0.3.5 Maven core extension.
- This activates safe Tier A/C runtime caching for Blastradius builds, with GitHub Actions cache as the default backend.

## Validation
- Resolved 0.3.5 from Maven Central.
- Maven reactor verification completed locally.