### PR TITLE
Expose Actions cache runtime to Maven

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,10 @@ jobs:
           key: blastradius-index-v2-${{ runner.os }}-jdk${{ matrix.java }}-${{ github.sha }}
           restore-keys: |
             blastradius-index-v2-${{ runner.os }}-jdk${{ matrix.java }}-
+      - name: Expose GitHub Actions cache runtime
+        # The core extension runs in Maven shell steps. Export the runner's short-lived cache
+        # endpoint and token so it can use the GitHub Actions cache backend.
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
       - name: Bootstrap Blastradius plugin
         run: |
           RELEASE_VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"


### PR DESCRIPTION
## Problem
The installed cache-warmer runs inside Maven shell steps, but GitHub’s runner scopes `ACTIONS_RESULTS_URL` and `ACTIONS_RUNTIME_TOKEN` to action steps. That made the default cache backend fall back to a cold build even in CI.

## Fix
Expose the runner-provided, short-lived Actions runtime variables before every Maven command in the build job. The action is pinned to v4.0.0; no new secret or permission is required.

## Validation
- Parsed workflow YAML locally.
- PR matrix CI will verify the endpoint reaches Maven on JDK 21 and 25.