### PR TITLE
Upgrade cache warmer to 0.3.6

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,6 +5,6 @@
     <extension>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-cache-warmer-maven-extension</artifactId>
-        <version>0.3.5</version>
+        <version>0.3.6</version>
     </extension>
 </extensions>


### PR DESCRIPTION
## Summary
Upgrade the installed Maven core extension to cache-warmer 0.3.6.

0.3.6 fixes GitHub Actions cache v2 entry publication by using the required 64-character archive-format version. The runtime endpoint export merged in #239 enables the extension to use that backend in CI.

## Validation
- 0.3.6 signed build and Maven Central publication succeeded.
- This PR’s matrix CI will verify the extension against Blastradius on JDK 21 and 25.