### PR TITLE
build: upgrade cache warmer to 0.3.7

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,6 +5,6 @@
     <extension>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-cache-warmer-maven-extension</artifactId>
-        <version>0.3.6</version>
+        <version>0.3.7</version>
     </extension>
 </extensions>


### PR DESCRIPTION
## Summary
- Upgrade the Maven core extension to cache-warmer 0.3.7.
- Nested Blastradius TRACK replays now skip redundant cache-runtime work, while the outer CI build keeps cache restore and publication.

## Verification
- Cache-warmer 0.3.7: 80 tests passed.
- Maven Central release workflow passed.