### PR TITLE
ci: move main index tracking after verification

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,14 +64,13 @@ jobs:
             -Dpackaging=maven-plugin \
             -DgeneratePom=true
       - name: Verify with Blastradius
-        env:
-          # A restore-key hit contains an older baseline. It is safe for a PR to select
-          # from that baseline, but main must rebuild before saving this commit's cache key.
-          BLASTRADIUS_REFRESH_MAIN_INDEX: ${{ github.ref == 'refs/heads/main' && steps.blastradius-index.outputs.cache-hit != 'true' }}
         run: |
+          # The required main build stays cache-aware and runs the full suite. Its expensive,
+          # statistics-preserving TRACK replay is delegated to refresh-index.yml after this job
+          # succeeds, so it does not hold up the developer-facing build.
           blastradius_mode=()
-          if [[ "$BLASTRADIUS_REFRESH_MAIN_INDEX" == "true" ]]; then
-            blastradius_mode+=("-Dblastradius.mode=track")
+          if [[ "$GITHUB_REF" == "refs/heads/main" ]]; then
+            blastradius_mode+=("-Dblastradius.skipSelection=true")
           fi
           mvn -B --no-transfer-progress "${blastradius_mode[@]}" -Pself-host-blastradius clean verify
       - name: Generate JaCoCo badge
@@ -85,46 +84,6 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: coverage/target/site/jacoco-aggregate
-      - name: Check Blastradius index refresh actually succeeded
-        id: blastradius-track-check
-        if: ${{ github.ref == 'refs/heads/main' && success() && steps.blastradius-index.outputs.cache-hit != 'true' }}
-        run: |
-          # A TRACK attempt that fails internally (e.g. an instrumentation bug) falls back
-          # to running the full suite without ever refreshing the index, but the outer Maven
-          # build still exits 0 — so success() alone can't tell a real refresh from a silent
-          # fallback. Without this check, "Save Blastradius index from main" below would keep
-          # re-saving an unrefreshed, increasingly stale index under each new commit's cache
-          # key, and every later PR would silently inherit that staleness.
-          report_paths=(
-            blastradius-core/.blastradius/last-build-report.json
-            blastradius-s3-index-store/.blastradius/last-build-report.json
-            blastradius-validator/.blastradius/last-build-report.json
-            blastradius-maven-plugin/.blastradius/last-build-report.json
-          )
-          track_ok=true
-          for report_path in "${report_paths[@]}"; do
-            if [[ ! -f "$report_path" ]]; then
-              echo "::warning::Blastradius index refresh check: $report_path is missing, cannot confirm TRACK succeeded"
-              track_ok=false
-              continue
-            fi
-            mode="$(jq -r '.mode' "$report_path")"
-            if [[ "$mode" != "TRACK" ]]; then
-              applicability="$(jq -r '.indexApplicability' "$report_path")"
-              echo "::warning::Blastradius index refresh check: $report_path reports mode=$mode (indexApplicability=$applicability), expected TRACK"
-              track_ok=false
-            fi
-          done
-          echo "track-ok=$track_ok" >> "$GITHUB_OUTPUT"
-      - name: Save Blastradius index from main
-        if: ${{ github.ref == 'refs/heads/main' && success() && steps.blastradius-index.outputs.cache-hit != 'true' && steps.blastradius-track-check.outputs.track-ok == 'true' }}
-        uses: actions/cache/save@v6
-        with:
-          path: |
-            .blastradius
-            **/.blastradius
-            !**/target/**/.blastradius
-          key: blastradius-index-v2-${{ runner.os }}-jdk${{ matrix.java }}-${{ github.sha }}
       - name: Publish Blastradius selection feedback
         if: ${{ always() }}
         uses: ./.github/actions/blastradius-selection-summary

--- a/.github/workflows/refresh-index.yml
+++ b/.github/workflows/refresh-index.yml
@@ -1,0 +1,104 @@
+name: Refresh Blastradius index
+
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    name: Rebuild main dependency index / JDK ${{ matrix.java }}
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ['21', '25']
+    concurrency:
+      group: blastradius-index-main-jdk${{ matrix.java }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+      - uses: actions/setup-java@v5.6.0
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: maven
+      - uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.6
+      - name: Restore Blastradius index
+        id: blastradius-index
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            .blastradius
+            **/.blastradius
+            !**/target/**/.blastradius
+          key: blastradius-index-v2-${{ runner.os }}-jdk${{ matrix.java }}-${{ github.event.workflow_run.head_sha }}
+          restore-keys: |
+            blastradius-index-v2-${{ runner.os }}-jdk${{ matrix.java }}-
+      - name: Expose GitHub Actions cache runtime
+        uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487 # v4.0.0
+      - name: Bootstrap Blastradius plugin
+        run: |
+          RELEASE_VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
+          SELF_HOST_VERSION="${RELEASE_VERSION}-selfhost"
+          export SELF_HOST_VERSION
+          mvn -B --no-transfer-progress -DskipTests -Dinvoker.skip=true -pl blastradius-maven-plugin -am package
+          mkdir -p target/self-host/META-INF/maven
+          cp "blastradius-maven-plugin/target/blastradius-maven-plugin-${RELEASE_VERSION}.jar" "target/blastradius-maven-plugin-${SELF_HOST_VERSION}.jar"
+          unzip -p "blastradius-maven-plugin/target/blastradius-maven-plugin-${RELEASE_VERSION}.jar" META-INF/maven/plugin.xml \
+            | perl -0pe 's{(<artifactId>blastradius-maven-plugin</artifactId>\s*<version>)[^<]+(</version>)}{$1 . $ENV{SELF_HOST_VERSION} . $2}e' \
+            > target/self-host/META-INF/maven/plugin.xml
+          (cd target/self-host && jar uf "../blastradius-maven-plugin-${SELF_HOST_VERSION}.jar" META-INF/maven/plugin.xml)
+          mvn -B --no-transfer-progress org.apache.maven.plugins:maven-install-plugin:3.1.2:install-file \
+            -Dfile="target/blastradius-maven-plugin-${SELF_HOST_VERSION}.jar" \
+            -DgroupId=io.github.baokhang83.blastradius \
+            -DartifactId=blastradius-maven-plugin \
+            -Dversion="${SELF_HOST_VERSION}" \
+            -Dpackaging=maven-plugin \
+            -DgeneratePom=true
+      - name: Rebuild the Blastradius index
+        run: mvn -B --no-transfer-progress -Dblastradius.mode=track -Pself-host-blastradius clean verify
+      - name: Check index refresh actually succeeded
+        id: blastradius-track-check
+        run: |
+          report_paths=(
+            blastradius-core/.blastradius/last-build-report.json
+            blastradius-s3-index-store/.blastradius/last-build-report.json
+            blastradius-validator/.blastradius/last-build-report.json
+            blastradius-maven-plugin/.blastradius/last-build-report.json
+          )
+          track_ok=true
+          for report_path in "${report_paths[@]}"; do
+            if [[ ! -f "$report_path" ]]; then
+              echo "::warning::Blastradius index refresh check: $report_path is missing, cannot confirm TRACK succeeded"
+              track_ok=false
+              continue
+            fi
+            mode="$(jq -r '.mode' "$report_path")"
+            if [[ "$mode" != "TRACK" ]]; then
+              applicability="$(jq -r '.indexApplicability' "$report_path")"
+              echo "::warning::Blastradius index refresh check: $report_path reports mode=$mode (indexApplicability=$applicability), expected TRACK"
+              track_ok=false
+            fi
+          done
+          echo "track-ok=$track_ok" >> "$GITHUB_OUTPUT"
+      - name: Save Blastradius index
+        if: steps.blastradius-track-check.outputs.track-ok == 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            .blastradius
+            **/.blastradius
+            !**/target/**/.blastradius
+          key: blastradius-index-v2-${{ runner.os }}-jdk${{ matrix.java }}-${{ github.event.workflow_run.head_sha }}

--- a/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
+++ b/blastradius-maven-plugin/src/main/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojo.java
@@ -101,6 +101,14 @@ public final class SelectMojo extends AbstractMojo {
     @Parameter(property = "blastradius.trackChild", defaultValue = "false")
     private boolean trackChild;
 
+    /**
+     * Lets an orchestration build run the complete Maven lifecycle without making a selection
+     * decision. CI uses this for its required main build, while a separate post-build workflow
+     * performs the unchanged TRACK replay and persists its index.
+     */
+    @Parameter(property = "blastradius.skipSelection", defaultValue = "false")
+    private boolean skipSelection;
+
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
 
@@ -123,9 +131,13 @@ public final class SelectMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        if (trackChild) {
-            getLog().info("[blastradius] skipping select goal (this build is a TRACK-mode subprocess "
-                    + "collecting dependency data; the ambient gated build's own Surefire execution is untouched)");
+        if (shouldSkipSelection(trackChild, skipSelection)) {
+            if (trackChild) {
+                getLog().info("[blastradius] skipping select goal (this build is a TRACK-mode subprocess "
+                        + "collecting dependency data; the ambient gated build's own Surefire execution is untouched)");
+            } else {
+                getLog().info("[blastradius] skipping select goal (selection is delegated to the post-build TRACK workflow)");
+            }
             return;
         }
         if (isAggregatorOnlyProject(project.getPackaging())) {
@@ -231,6 +243,10 @@ public final class SelectMojo extends AbstractMojo {
 
     static boolean isAggregatorOnlyProject(String packaging) {
         return "pom".equals(packaging);
+    }
+
+    static boolean shouldSkipSelection(boolean trackChild, boolean skipSelection) {
+        return trackChild || skipSelection;
     }
 
     /**

--- a/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojoModeRoutingTest.java
+++ b/blastradius-maven-plugin/src/test/java/io/github/baokhang83/blastradius/plugin/mojo/SelectMojoModeRoutingTest.java
@@ -20,6 +20,13 @@ class SelectMojoModeRoutingTest {
         assertFalse(SelectMojo.isAggregatorOnlyProject("jar"));
     }
 
+    @Test
+    void skipsSelectionForTheDedicatedMainBuildWithoutMarkingItAsATrackChild() {
+        assertTrue(SelectMojo.shouldSkipSelection(false, true));
+        assertTrue(SelectMojo.shouldSkipSelection(true, false));
+        assertFalse(SelectMojo.shouldSkipSelection(false, false));
+    }
+
     private static final CurrentChanges BASE_REF_BUILD =
             new CurrentChanges("main", "abc123", Optional.of("abc123"), "abc123", true, List.of());
     private static final CurrentChanges PR_BUILD =


### PR DESCRIPTION
## Summary
- Keep the required main build cache-aware and full-suite, but skip its inline selection/TRACK replay.
- Rebuild the same JDK-specific TRACK indexes in a separate workflow after a successful main Build.
- Preserve existing pull-request selection behavior.

## Verification
- mvn -B --no-transfer-progress -pl blastradius-maven-plugin -am test
- Parsed build.yml and refresh-index.yml as YAML
- git diff --check