### PR TITLE
build: benchmark cache-warmer 0.3.9

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extensions>
-    <!-- Loaded before Maven reads the reactor. The extension safely no-ops unless
-         blastradius-maven-plugin is declared for the build. -->
+    <!-- Loaded before Maven reads the reactor. Cache-warmer uses the Git diff and Maven reactor
+         directly, so this pilot needs no Blastradius-specific cache integration. -->
     <extension>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-cache-warmer-maven-extension</artifactId>
-        <version>0.3.7</version>
+        <version>0.3.9</version>
     </extension>
 </extensions>


### PR DESCRIPTION
Closes #245

## Summary
- upgrade the pilot Maven Core Extension to cache-warmer 0.3.9
- remove the obsolete plugin-presence-gate description

## Measurement protocol
- merge this one-coordinate pilot upgrade to establish the cold cache population run on main
- rerun that identical main SHA to measure the warm cache path
- compare GitHub Actions bootstrap and Verify-with-Blastradius step durations, and inspect compiler-skip logs

## Validation
- xmllint --noout .mvn/extensions.xml
- git diff --check