### PR TITLE
build: upgrade cache-warmer to 0.3.10

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,6 +5,6 @@
     <extension>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-cache-warmer-maven-extension</artifactId>
-        <version>0.3.9</version>
+        <version>0.3.10</version>
     </extension>
 </extensions>


### PR DESCRIPTION
## Summary
- upgrade the Maven Core Extension to cache-warmer `0.3.10`
- includes the fix that restores cached `.class` files after Maven resources creates `target/classes`

## Verification
- `mvn -B --no-transfer-progress -DskipTests -Dinvoker.skip=true package`

The self-hosted profile requires its CI bootstrap step, so it is exercised by the repository workflow.