### PR TITLE
release: 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.3.3] - 2026-08-08
+
+### Added
+
+- Added conservative direct-invocation fallback data for cached dependency indexes.
+- Attribute classes loaded by `@BeforeAll` and cleanup lifecycle methods to their owning tests.
+
+### Fixed
+
+- Preserve direct invocations in the validator cache and correctly follow two-hop invocation
+  paths during selection.
+- Stage the plugin artifact for Maven Invoker tracking tests.
+
+### Documentation
+
+- Corrected the Maven plugin version in the installation examples.
+
 ## [0.3.2] - 2026-08-01
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ analysis behind these numbers.
 <plugin>
   <groupId>io.github.baokhang83.blastradius</groupId>
   <artifactId>blastradius-maven-plugin</artifactId>
-  <version>0.3.6</version>
+  <version>0.3.3</version>
   <executions>
     <execution>
       <phase>process-test-classes</phase>

--- a/blastradius-core/pom.xml
+++ b/blastradius-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.2</version>
+        <version>0.3.3</version>
     </parent>
 
     <artifactId>blastradius-core</artifactId>

--- a/blastradius-maven-plugin/README.md
+++ b/blastradius-maven-plugin/README.md
@@ -63,7 +63,7 @@ Requires a Maven/JUnit 5 project and a resolvable repository for the plugin arti
 <plugin>
   <groupId>io.github.baokhang83.blastradius</groupId>
   <artifactId>blastradius-maven-plugin</artifactId>
-  <version>0.3.0</version>
+  <version>0.3.3</version>
   <executions>
     <execution>
       <phase>process-test-classes</phase>
@@ -262,7 +262,7 @@ jobs. Never place those values in the POM, Gradle build file, repository, or cac
 **`TRACK`** — a base-branch build, building/refreshing the index:
 
 ```
-[INFO] --- blastradius:0.3.0:select (default) @ your-project ---
+[INFO] --- blastradius:0.3.3:select (default) @ your-project ---
 [INFO] [blastradius] TRACK — building a fresh index
 [INFO] [blastradius] 2 / 2 tests selected (0.0% skipped)
 ```
@@ -273,7 +273,7 @@ computes a selection at all, it just reports how big the suite it ran full was.
 **`SELECT`** — a PR build, narrowed by a real index:
 
 ```
-[INFO] --- blastradius:0.3.0:select (default) @ your-project ---
+[INFO] --- blastradius:0.3.3:select (default) @ your-project ---
 [INFO] [blastradius] SELECT — index built from 4e02156 (2026-07-10T03:03:04Z)
 [INFO] [blastradius] 1 / 2 tests selected (50.0% skipped)
 [INFO] [blastradius]   dependency-matched: 1, new-or-modified: 0, fallback: 0
@@ -290,7 +290,7 @@ Add `-Dblastradius.explain=true` for the per-test breakdown that line is pointin
 **`FALLBACK`** — no usable index, running safe:
 
 ```
-[INFO] --- blastradius:0.3.0:select (default) @ your-project ---
+[INFO] --- blastradius:0.3.3:select (default) @ your-project ---
 [INFO] [blastradius] FALLBACK — no persisted index found (MISSING)
 [INFO] [blastradius] 2 / 2 tests selected (0.0% skipped)
 ```

--- a/blastradius-maven-plugin/pom.xml
+++ b/blastradius-maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.2</version>
+        <version>0.3.3</version>
     </parent>
 
     <artifactId>blastradius-maven-plugin</artifactId>
@@ -22,7 +22,7 @@
         <connection>scm:git:https://github.com/baokhang83/blastradius.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/baokhang83/blastradius.git</developerConnection>
         <url>https://github.com/baokhang83/blastradius</url>
-        <tag>v0.3.0</tag>
+        <tag>v0.3.3</tag>
     </scm>
 
     <properties>

--- a/blastradius-s3-index-store/pom.xml
+++ b/blastradius-s3-index-store/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.2</version>
+        <version>0.3.3</version>
     </parent>
     <artifactId>blastradius-s3-index-store</artifactId>
     <name>blastradius S3 index store</name>

--- a/blastradius-validator/pom.xml
+++ b/blastradius-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.2</version>
+        <version>0.3.3</version>
     </parent>
 
     <artifactId>blastradius-validator</artifactId>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.baokhang83.blastradius</groupId>
         <artifactId>blastradius-parent</artifactId>
-        <version>0.3.2</version>
+        <version>0.3.3</version>
     </parent>
 
     <artifactId>coverage</artifactId>

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -3,7 +3,7 @@
 This repository publishes only:
 
 ```text
-io.github.baokhang83.blastradius:blastradius-maven-plugin:0.3.0
+io.github.baokhang83.blastradius:blastradius-maven-plugin:0.3.3
 ```
 
 `blastradius-core` and `blastradius-validator` are internal reactor modules. The plugin
@@ -61,16 +61,16 @@ unset MAVEN_GPG_PASSPHRASE
    mvn -B --no-transfer-progress -Prelease -Dgpg.skip=true clean verify
    ```
 
-2. Ensure the release commit is on `main`, its version is `0.3.0`, and the changelog is
+2. Ensure the release commit is on `main`, its version is `0.3.3`, and the changelog is
    final.
-3. Create and push the annotated `v0.3.0` tag. The tag workflow verifies that its commit
+3. Create and push the annotated `v0.3.3` tag. The tag workflow verifies that its commit
    is reachable from `main`, then runs `mvn -Prelease clean deploy`.
 4. Wait for Central Portal to report the deployment as published, then verify from a clean
    directory:
 
    ```bash
    mvn -B --no-transfer-progress \
-     io.github.baokhang83.blastradius:blastradius-maven-plugin:0.3.0:help
+     io.github.baokhang83.blastradius:blastradius-maven-plugin:0.3.3:help
    ```
 
 5. Copy the plugin configuration in the root [README](../README.md) into a small Git

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.baokhang83.blastradius</groupId>
     <artifactId>blastradius-parent</artifactId>
-    <version>0.3.2</version>
+    <version>0.3.3</version>
     <packaging>pom</packaging>
 
     <name>Blastradius parent</name>
@@ -38,7 +38,7 @@
         <connection>scm:git:https://github.com/baokhang83/blastradius.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/baokhang83/blastradius.git</developerConnection>
         <url>https://github.com/baokhang83/blastradius</url>
-        <tag>v0.3.2</tag>
+        <tag>v0.3.3</tag>
     </scm>
 
     <issueManagement>


### PR DESCRIPTION
## Release 0.3.3

- Bump Maven release coordinates and SCM tags to `0.3.3`.
- Correct the root README Maven example from the accidental `0.3.6` to `0.3.3`.
- Update release documentation and changelog.

Verified locally with `mvn -B --no-transfer-progress -Prelease -Dgpg.skip=true clean verify`.